### PR TITLE
feat(data-table): expandable rows prototype

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "static-server": "^2.2.1",
     "storybook-addon-rtl": "^0.2.2",
     "styletron-engine-atomic": "^1.4.0",
-    "styletron-react": "^5.2.0",
+    "styletron-react": "^5.2.2",
     "styletron-standard": "^3.0.0",
     "tar": "^5.0.0",
     "terser": "^4.1.4",

--- a/src/data-table/__tests__/data-table-expandable-row.scenario.js
+++ b/src/data-table/__tests__/data-table-expandable-row.scenario.js
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+
+import Alert from '../../icon/alert.js';
+import Check from '../../icon/check.js';
+
+import BooleanColumn from '../column-boolean.js';
+import NumericalColumn from '../column-numerical.js';
+import {Unstable_DataTable} from '../data-table.js';
+
+export const name = 'data-table-expandable-row';
+
+const columns = [
+  NumericalColumn({title: 'row-id'}),
+  BooleanColumn({title: 'is-it-flagged'}),
+];
+
+function buildRow(index) {
+  return {
+    id: index,
+    data: [index, false],
+    children: [
+      {id: `${index}-1`, data: [6, false]},
+      {id: `${index}-2`, data: [7, false]},
+      {id: `${index}-3`, data: [8, false]},
+      {id: `${index}-4`, data: [9, false]},
+    ],
+  };
+}
+
+const rows = [];
+for (let i = 0; i < 200; i++) {
+  rows.push(buildRow(i));
+}
+
+export const component = () => {
+  return (
+    <div style={{height: '800px', width: '900px'}}>
+      <Unstable_DataTable columns={columns} rows={rows} />
+    </div>
+  );
+};

--- a/src/data-table/cell-shell.js
+++ b/src/data-table/cell-shell.js
@@ -9,12 +9,16 @@ LICENSE file in the root directory of this source tree.
 import * as React from 'react';
 
 import {Checkbox} from '../checkbox/index.js';
+import ChevronDown from '../icon/chevron-down.js';
+import ChevronRight from '../icon/chevron-right.js';
 import {useStyletron} from '../styles/index.js';
 
 type PropsT = {|
   children: React.Node,
+  isExpanded?: boolean,
   isMeasured?: boolean,
   isSelected?: boolean,
+  onExpand?: () => void,
   onSelect?: () => void,
 |};
 
@@ -35,6 +39,11 @@ const CellShell = React.forwardRef<PropsT, HTMLDivElement>((props, ref) => {
       <div className={useCss({display: 'flex', alignItems: 'center'})}>
         {Boolean(props.onSelect) && (
           <Checkbox onChange={props.onSelect} checked={props.isSelected} />
+        )}
+        {Boolean(props.onExpand) && (
+          <div onClick={props.onExpand}>
+            {props.isExpanded ? <ChevronDown /> : <ChevronRight />}
+          </div>
         )}
         {props.children}
       </div>

--- a/src/data-table/column-boolean.js
+++ b/src/data-table/column-boolean.js
@@ -53,8 +53,10 @@ const BooleanCell = React.forwardRef<_, HTMLDivElement>((props, ref) => {
   return (
     <CellShell
       ref={ref}
+      isExpanded={props.isExpanded}
       isMeasured={props.isMeasured}
       isSelected={props.isSelected}
+      onExpand={props.onExpand}
       onSelect={props.onSelect}
     >
       <div

--- a/src/data-table/column-categorical.js
+++ b/src/data-table/column-categorical.js
@@ -228,8 +228,10 @@ const CategoricalCell = React.forwardRef<_, HTMLDivElement>((props, ref) => {
   return (
     <CellShell
       ref={ref}
+      isExpanded={props.isExpanded}
       isMeasured={props.isMeasured}
       isSelected={props.isSelected}
+      onExpand={props.onExpand}
       onSelect={props.onSelect}
     >
       {props.value}

--- a/src/data-table/column-custom.js
+++ b/src/data-table/column-custom.js
@@ -44,8 +44,10 @@ function CustomColumn<ValueT, FilterParamsT>(
       return (
         <CellShell
           ref={ref}
+          isExpanded={props.isExpanded}
           isMeasured={props.isMeasured}
           isSelected={props.isSelected}
+          onExpand={props.onExpand}
           onSelect={props.onSelect}
         >
           <ProvidedCell value={props.value} />

--- a/src/data-table/column-numerical.js
+++ b/src/data-table/column-numerical.js
@@ -225,8 +225,10 @@ const NumericalCell = React.forwardRef<_, HTMLDivElement>((props, ref) => {
   return (
     <CellShell
       ref={ref}
+      isExpanded={props.isExpanded}
       isMeasured={props.isMeasured}
       isSelected={props.isSelected}
+      onExpand={props.onExpand}
       onSelect={props.onSelect}
     >
       <div
@@ -286,8 +288,10 @@ function NumericalColumn(options: OptionsT): NumericalColumnT {
       return (
         <NumericalCell
           ref={ref}
+          isExpanded={props.isExpanded}
           isMeasured={props.isMeasured}
           isSelected={props.isSelected}
+          onExpand={props.onExpand}
           onSelect={props.onSelect}
           value={props.value}
           format={normalizedOptions.format}

--- a/src/data-table/column-string.js
+++ b/src/data-table/column-string.js
@@ -31,8 +31,10 @@ const StringCell = React.forwardRef<_, HTMLDivElement>((props, ref) => {
   return (
     <CellShell
       ref={ref}
+      isExpanded={props.isExpanded}
       isMeasured={props.isMeasured}
       isSelected={props.isSelected}
+      onExpand={props.onExpand}
       onSelect={props.onSelect}
     >
       {props.value}

--- a/src/data-table/types.js
+++ b/src/data-table/types.js
@@ -41,11 +41,11 @@ export type ColumnT<ValueT = any, FilterParamsT = any> = {|
   sortFn: (ValueT, ValueT) => number,
 |};
 
-export type RowT = {
+export type RowT = {|
   id: number | string,
-  // eslint-disable-next-line flowtype/no-weak-types
-  data: any[],
-};
+  data: any[], // eslint-disable-line flowtype/no-weak-types
+  children?: RowT[],
+|};
 
 export type BatchActionT = {|
   label: string,

--- a/src/data-table/types.js
+++ b/src/data-table/types.js
@@ -28,8 +28,10 @@ export type ColumnT<ValueT = any, FilterParamsT = any> = {|
   filterable: boolean,
   renderCell: React.ComponentType<{
     value: ValueT,
+    isExpanded?: boolean,
     isMeasured?: boolean,
     isSelected?: boolean,
+    onExpand?: () => void,
     onSelect?: () => void,
   }>,
   renderFilter: React.ComponentType<{|

--- a/yarn.lock
+++ b/yarn.lock
@@ -18548,18 +18548,26 @@ styletron-engine-atomic@^1.4.0:
     inline-style-prefixer "^5.1.0"
     styletron-standard "^3.0.0"
 
-styletron-react@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/styletron-react/-/styletron-react-5.2.0.tgz#670f276782fc65a64d9af3ae8f50da2935869ee4"
-  integrity sha512-UX7Yvz7pUe9s0VRoShMAoFi9KJLfJMbbNFrwiK6rmjtjjA69yfrA75gGrb/BjUO003t3K/MDHInUg/uJb90PQQ==
+styletron-react@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/styletron-react/-/styletron-react-5.2.2.tgz#8c07252f15410ddee8f1c613ff3d27411829a5cc"
+  integrity sha512-y37qOyaLT/WKaPinuJXHZ6rvxKdhW0l4W+p/WiE95wAjpOXqKi02uoQWoX+ufXsZx91WeBN8yXnwS5a54l0mXw==
   dependencies:
     prop-types "^15.6.0"
-    styletron-standard "^3.0.0"
+    styletron-standard "^3.0.1"
 
 styletron-standard@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/styletron-standard/-/styletron-standard-3.0.0.tgz#a6d75b4e1390331186ab6b01c69df391f1c7c277"
   integrity sha512-Rmx7os4JiowVaQz/51xJdyPNZ3pEdbyU00i8vFFbUPxPbmR1pcO70ZmiazOzFZz0W43tF2IcUlfE/GncNi1WqQ==
+  dependencies:
+    csstype "2.6.5"
+    inline-style-prefixer "^5.1.0"
+
+styletron-standard@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/styletron-standard/-/styletron-standard-3.0.1.tgz#c0b412231582fd2c4ce4d8f7f96b2a10a7523420"
+  integrity sha512-d35UYM4aCf4GDNv7o4ZC8YGkCyGS4Yp4SmbyKOxLxI7JcMJ2hLs+PTwcL41HW65WzZXy6XLDR/H5Fr3919ReoQ==
   dependencies:
     csstype "2.6.5"
     inline-style-prefixer "^5.1.0"


### PR DESCRIPTION
#### Description

Prototype implementation of row-expand functionality. I'm unsure of the specific needs from design and ultimately end-users, but this is built against the figma specs. Are 'child' rows useful if they must contain the same columns as the parents? I personally cannot think of real world use-cases. Maybe something more along the lines of airtable's [grouping](https://airtable.com/shrboYH2xp41kojwQ) feature is more appropriate? 

<img width="343" alt="Screen Shot 2019-10-11 at 2 46 49 PM" src="https://user-images.githubusercontent.com/5317799/66687182-af99eb80-ec36-11e9-85c7-714a36459bfd.png">


#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
