### PR TITLE
fix(dnd-list): prevent list hover being triggered when dragging

### DIFF
--- a/src/dnd-list/styled-components.js
+++ b/src/dnd-list/styled-components.js
@@ -22,6 +22,7 @@ export const List = styled<SharedStylePropsArgT>('ul', ({$isDragged}) => {
   return ({
     paddingLeft: 0,
     cursor: $isDragged ? 'grabbing' : null,
+    pointerEvents: $isDragged ? 'none' : 'auto',
   }: {});
 });
 List.displayName = 'StyledList';


### PR DESCRIPTION
A subtle bug. When you do dnd and move rapidly, the mouse gets ahead of the ghost item and starts triggering `:hover` effect of other items on the background. It doesn't look pretty. This fixes it.

![ezgif-1-5d0d1a3e8a6f](https://user-images.githubusercontent.com/1387913/66955495-5277ae80-f017-11e9-9aff-771029462fe0.gif)

