### PR TITLE
fix(vrt): guard against recursive builds

### DIFF
--- a/vrt/ci.js
+++ b/vrt/ci.js
@@ -229,7 +229,7 @@ async function addLabelsToNewPullRequest(newPullRequestNumber) {
       owner: `uber`,
       repo: `baseweb`,
       issue_number: newPullRequestNumber,
-      labels: [`bugfix`, `ci`, `visual snapshot updates`],
+      labels: [`greenkeeping`, `visual snapshot updates`],
     });
     log(`Added labels to new snapshot PR.`);
   } catch (er) {

--- a/vrt/ci.js
+++ b/vrt/ci.js
@@ -30,16 +30,15 @@ const octokit = Octokit({
   auth: GITHUB_BOT_AUTH_TOKEN,
 });
 
-//
-main();
-
 process.on('unhandledRejection', function(err) {
-  console.log(err);
+  log(`The job has failed, but it is not a failure.`);
   throw err;
 });
-//
+
+main();
 
 async function main() {
+  if (!buildIsValid()) return;
   installChromium();
   if (buildWasTriggeredByPR()) {
     configureGit();
@@ -47,6 +46,16 @@ async function main() {
     await updateGitHub();
   } else {
     runTestsWithNoUpdates();
+  }
+}
+
+function buildIsValid() {
+  if (BUILDKITE_BRANCH.endsWith(`--vrt`)) {
+    log(`This build was somehow triggered from a snapshot update branch!`);
+    log(`This should not happen! Check the logs! Exiting early.`);
+    return false;
+  } else {
+    return true;
   }
 }
 


### PR DESCRIPTION
Just a little protection against recursive builds. The PR and commit messages for snapshot updates should prevent builds via `[skip ci]` but just in case this check will prevent anything running.