### PR TITLE
fix(vrt): get owner logic

### DIFF
--- a/vrt/ci.js
+++ b/vrt/ci.js
@@ -333,7 +333,7 @@ function someSnapshotsWereUpdated() {
 // Extract basweb fork owner from a GitHub repository url
 function getOwnerFromRepoURL(url) {
   const matches = url.match(/https:\/\/github\.com\/(.*)\/baseweb\.git/);
-  return matches[1] ? matches[1] : `uber`;
+  return matches && matches[1] ? matches[1] : `uber`;
 }
 
 function log(message) {


### PR DESCRIPTION
Buildkite passes a `BUILDKITE_PULL_REQUEST_REPO=""` if the repo is owned by `uber`. I assumed it would always return the url so this fails the build without an additional check.