### PR TITLE
fix(tether): ensures no flow errors from tether

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "just-extend": "^4.0.2",
     "memoize-one": "^5.0.0",
     "polished": "^3.2.0",
-    "popper.js": "^1.14.3",
+    "popper.js": "^1.16.0",
     "react-dropzone": "^9.0.0",
     "react-focus-lock": "^1.9.1",
     "react-input-mask": "^2.0.4",

--- a/src/layer/__tests__/tether.test.js
+++ b/src/layer/__tests__/tether.test.js
@@ -48,6 +48,7 @@ describe('TetherBehavior', () => {
     // Popper library should have been initialized
     expect(Popper).toHaveBeenCalled();
     const tethered = wrapper.childAt(1);
+    // $FlowFixMe
     const calls = Popper.mock.calls;
 
     expect(tethered).toHaveText('This is popper');

--- a/src/layer/tether.js
+++ b/src/layer/tether.js
@@ -7,6 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 import * as React from 'react';
 import Popper from 'popper.js';
+import type {Instance as PopperInstance} from 'popper.js';
 import {toPopperPlacement, parsePopperOffset} from './utils.js';
 import {TETHER_PLACEMENT} from './constants.js';
 import type {TetherPropsT, TetherStateT, PopperDataObjectT} from './types.js';
@@ -20,7 +21,7 @@ class Tether extends React.Component<TetherPropsT, TetherStateT> {
     popperOptions: {},
   };
 
-  popper: ?Popper;
+  popper: ?PopperInstance;
   popperHeight = 0;
 
   state = {
@@ -66,6 +67,9 @@ class Tether extends React.Component<TetherPropsT, TetherStateT> {
   initializePopper() {
     const {placement, popperOptions} = this.props;
     const {modifiers, ...restOptions} = popperOptions;
+
+    if (!this.props.anchorRef || !this.props.popperRef) return;
+
     this.popper = new Popper(this.props.anchorRef, this.props.popperRef, {
       // Recommended placement (popper may ignore if it causes a viewport overflow, etc)
       placement: toPopperPlacement(placement),

--- a/yarn.lock
+++ b/yarn.lock
@@ -15398,9 +15398,9 @@ polished@^3.2.0:
     "@babel/runtime" "^7.4.2"
 
 popper.js@^1.14.3:
-  version "1.14.4"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.4.tgz#8eec1d8ff02a5a3a152dd43414a15c7b79fd69b6"
-  integrity sha1-juwdj/AqWjoVLdQ0FKFce3n9abY=
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.0.tgz#2e1816bcbbaa518ea6c2e15a466f4cb9c6e2fbb3"
+  integrity sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
#### Description

Applications using `baseui` reported errors coming from the `node_modules/baseui/.../tether` directory. The reason why this was not caught in this repo was that the `yarn.lock` file pinned `popper.js` version to `1.14.3` where applications were installing `1.16.0` which contained new flow type definitions.

#### Scope

- [x] Patch: Bug Fix
