### PR TITLE
Update learn.mdx

### DIFF
--- a/documentation-site/pages/getting-started/learn.mdx
+++ b/documentation-site/pages/getting-started/learn.mdx
@@ -36,7 +36,7 @@ export default () => {
       href="/my-link"
       className={useCss({
         fontSize: '20px',
-        color: $theme.colors.primary,
+        color: theme.colors.primary,
       })}
     >
       Custom Link


### PR DESCRIPTION
Fixes the `theme` variable usage in the `useStyletron` example, because it comes from `const [useCss, theme] = useStyletron();`

#### Description

Fix documentation for `useStyletron`

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
