### PR TITLE
docs(survey): fix cookie path

### DIFF
--- a/documentation-site/components/survey.js
+++ b/documentation-site/components/survey.js
@@ -126,6 +126,7 @@ function shouldShowSurvey() {
       // by default, cookies are session cookies, so without an expiration they are removed
       // when the browser window is closed.
       expires: new Date(now.getFullYear() + 10, now.getMonth()),
+      path: '/',
     });
     return {showSurvey: false, delay};
   }
@@ -142,6 +143,7 @@ function shouldShowSurvey() {
 
   Cookies.set(cookies.LAST_SURVEYED, now.getTime(), {
     expires: new Date(now.getFullYear() + 10, now.getMonth()),
+    path: '/',
   });
   return {showSurvey: true, delay: SURVEY_DELAY};
 }


### PR DESCRIPTION
Currently, the survey can show up on each pages, because the cookie is placed on the context on the path of the currently viewed component