### PR TITLE
fix(modal): removes children type from shared style props

### DIFF
--- a/src/modal/types.js
+++ b/src/modal/types.js
@@ -72,7 +72,6 @@ export type ModalStateT = {
 };
 
 export type SharedStylePropsArgT = {
-  children?: React.Node,
   $animate: boolean,
   $isVisible: boolean,
   $isOpen: boolean,


### PR DESCRIPTION
### Description

The property definition collided with `children` implicitly defined on [override component types](https://github.com/uber/baseweb/blob/master/src/helpers/overrides.js#L29).

#### Scope

- [x] Patch: Bug Fix
