### PR TITLE
docs(yard): add icons for actions

### DIFF
--- a/documentation-site/components/yard/yard.tsx
+++ b/documentation-site/components/yard/yard.tsx
@@ -12,6 +12,12 @@ import copy from 'copy-to-clipboard';
 import {trackEvent} from '../../helpers/ga';
 import debounce from 'lodash/debounce';
 
+import {
+  MdContentCopy,
+  MdFormatIndentIncrease,
+  MdRotateRight,
+} from 'react-icons/md';
+
 // code sandbox stuff
 //@ts-ignore
 import CodeSandboxer from 'react-codesandboxer';
@@ -314,6 +320,9 @@ const Yard: React.FC<
             updateCode(dispatch, formatCode(state.code));
           }}
         >
+          <MdFormatIndentIncrease
+            style={{paddingRight: theme.sizing.scale100}}
+          />{' '}
           Format
         </Button>
         <Button
@@ -323,16 +332,7 @@ const Yard: React.FC<
             copy(state.code);
           }}
         >
-          Copy code
-        </Button>
-        <Button
-          kind={KIND.tertiary}
-          onClick={() => {
-            trackEvent('yard', `${componentName}:copy_url`);
-            copy(window.location.href);
-          }}
-        >
-          Copy URL
+          <MdContentCopy style={{paddingRight: theme.sizing.scale100}} /> Copy
         </Button>
         <Button
           kind={KIND.tertiary}
@@ -352,7 +352,28 @@ const Yard: React.FC<
             updateUrl({pathname});
           }}
         >
-          Reset
+          <MdRotateRight style={{paddingRight: theme.sizing.scale100}} /> Reset
+        </Button>
+      </ButtonGroup>
+      <ButtonGroup
+        size={SIZE.compact}
+        overrides={{
+          Root: {
+            style: ({$theme}) => ({
+              flexWrap: 'wrap',
+              marginTop: $theme.sizing.scale300,
+            }),
+          },
+        }}
+      >
+        <Button
+          kind={KIND.tertiary}
+          onClick={() => {
+            trackEvent('yard', `${componentName}:copy_url`);
+            copy(window.location.href);
+          }}
+        >
+          Copy URL
         </Button>
         <CodeSandboxer
           key="js"

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "react": "^16.9.0",
     "react-codesandboxer": "^3.1.1",
     "react-dom": "^16.9.0",
+    "react-icons": "^3.8.0",
     "react-markdown": "^4.0.3",
     "react-simple-code-editor": "^0.10.0",
     "react-twitter-embed": "^2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16288,6 +16288,13 @@ react-fuzzy@^0.5.2:
     fuse.js "^3.0.1"
     prop-types "^15.5.9"
 
+react-icons@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.8.0.tgz#229de5904809696c9f46932bd9b6126b2522866e"
+  integrity sha512-rA/8GRKjPulft8BSBSMsHkE1AGPqJ7LjNsyk0BE7XjG70Iz62zOled2SJk7LDo8x9z86a3xOstDlKlMZ4pAy7A==
+  dependencies:
+    camelcase "^5.0.0"
+
 react-input-mask@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-input-mask/-/react-input-mask-2.0.4.tgz#9ade5cf8196f4a856dbf010820fe75a795f3eb14"


### PR DESCRIPTION
With the addition of a [new button](https://github.com/uber/baseweb/pull/2263), the space really got limited. This PR changes the 3 edit buttons to icons

<img width="570" alt="Screen Shot 2019-11-07 at 3 22 04 PM" src="https://user-images.githubusercontent.com/2174968/68436315-86f00d80-0172-11ea-92c9-0e9ca59f79f4.png">
