### PR TITLE
fix(vrt): link to snapshot pr url in bot comments

### DIFF
--- a/vrt/ci.js
+++ b/vrt/ci.js
@@ -128,7 +128,7 @@ async function updatePullRequests(snapshotPullRequest) {
     log(
       `The existing snapshot PR has been updated with the latest snapshot diffs.`,
     );
-    await addCommentToOriginalPullRequest(snapshotPullRequest.number);
+    await addCommentToOriginalPullRequest(snapshotPullRequest.html_url);
   } else {
     const newSnapshotPullRequest = await createSnapshotPullRequest();
     await addLabelsToSnapshotPullRequest(newSnapshotPullRequest.number);


### PR DESCRIPTION
When a new PR is opened with updated snapshots, our bot posts a comment to the original PR, with a link to the snapshot PR.

There was a small regression introduced a week ago where the comment did not properly link to the snapshot PR, instead printing out the issue number of the PR.

This PR fixes the issue by properly passing the snapshot PR url rather than the snapshot PR issue number to the function that handles this logic.