### PR TITLE
docs(yard): preserve defaultValue when value is undefined

### DIFF
--- a/documentation-site/components/yard/utils.ts
+++ b/documentation-site/components/yard/utils.ts
@@ -35,7 +35,7 @@ export const buildPropsObj = (
   });
   Object.keys(updatedPropValues).forEach(name => {
     newProps[name] = {
-      value: updatedPropValues[name],
+      value: updatedPropValues[name] || stateProps[name].defaultValue,
       type: stateProps[name].type,
       options: stateProps[name].options,
       enumName: stateProps[name].enumName,


### PR DESCRIPTION
When you go to the button component and edit the code, radio buttons as KIND and SIZE get empty, since the `defaultValue` is not preserved. This PR fixes it.