### PR TITLE
docs(select): fix virtualized example

### DIFF
--- a/documentation-site/examples/select/with-many-options.js
+++ b/documentation-site/examples/select/with-many-options.js
@@ -7,6 +7,10 @@ import {StyledList, StyledEmptyState} from 'baseui/menu';
 import List from 'react-virtualized/dist/commonjs/List';
 import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
 
+const LIST_ITEM_HEIGHT = 36;
+const EMPTY_LIST_HEIGHT = 72;
+const MAX_LIST_HEIGHT = 500;
+
 const ListItem = withStyle(StyledDropdownListItem, {
   paddingTop: 0,
   paddingBottom: 0,
@@ -14,46 +18,50 @@ const ListItem = withStyle(StyledDropdownListItem, {
   alignItems: 'center',
 });
 
-const Container = withStyle(StyledList, ({$height}) => ({
-  height: $height,
-}));
-
-const VirtualList = React.forwardRef((props, ref) => {
+const VirtualDropdown = React.forwardRef((props, ref) => {
   const children = React.Children.toArray(props.children);
 
   if (!children[0] || !children[0].props.item) {
     return (
-      <Container $height="72px" ref={ref}>
+      <StyledList $style={{height: EMPTY_LIST_HEIGHT + 'px'}} ref={ref}>
         <StyledEmptyState {...children[0].props} />
-      </Container>
+      </StyledList>
     );
   }
 
+  const height = Math.min(MAX_LIST_HEIGHT, children.length * LIST_ITEM_HEIGHT);
+
   return (
-    <Container $height="500px" ref={ref}>
+    <StyledList $style={{height: height + 'px'}} ref={ref}>
       <AutoSizer>
         {({width}) => (
           <List
             role={props.role}
-            height={500}
+            height={height}
             width={width}
             rowCount={children.length}
-            rowHeight={36}
+            rowHeight={LIST_ITEM_HEIGHT}
             rowRenderer={({index, key, style}) => {
+              const {item, overrides, ...restChildProps} = children[
+                index
+              ].props;
               return (
                 <ListItem
                   key={key}
-                  style={style}
-                  {...children[index].props}
+                  style={{
+                    boxSizing: 'border-box',
+                    ...style,
+                  }}
+                  {...restChildProps}
                 >
-                  {children[index].props.item.id}
+                  {item.id}
                 </ListItem>
               );
             }}
           />
         )}
       </AutoSizer>
-    </Container>
+    </StyledList>
   );
 });
 
@@ -73,7 +81,7 @@ export default () => {
       options={options}
       labelKey="id"
       valueKey="label"
-      overrides={{Dropdown: VirtualList}}
+      overrides={{Dropdown: VirtualDropdown}}
       onChange={({value}) => setValue(value)}
       value={value}
     />

--- a/documentation-site/examples/select/with-many-options.tsx
+++ b/documentation-site/examples/select/with-many-options.tsx
@@ -5,6 +5,10 @@ import {StyledList, StyledEmptyState} from 'baseui/menu';
 
 import {List, AutoSizer} from 'react-virtualized';
 
+const LIST_ITEM_HEIGHT = 36;
+const EMPTY_LIST_HEIGHT = 72;
+const MAX_LIST_HEIGHT = 500;
+
 const ListItem = withStyle(StyledDropdownListItem, {
   paddingTop: 0,
   paddingBottom: 0,
@@ -12,49 +16,50 @@ const ListItem = withStyle(StyledDropdownListItem, {
   alignItems: 'center',
 });
 
-const Container = withStyle(
-  StyledList,
-  (props: {$height: string}) => ({
-    height: props.$height,
-  }),
-);
-
-const VirtualList = React.forwardRef((props: any, ref) => {
+const VirtualDropdown = React.forwardRef((props: any, ref) => {
   const children = React.Children.toArray(props.children);
 
   if (!children[0] || !children[0].props.item) {
     return (
-      <Container $height="72px" ref={ref}>
+      <StyledList $style={{height: EMPTY_LIST_HEIGHT + 'px'}} ref={ref}>
         <StyledEmptyState {...children[0].props} />
-      </Container>
+      </StyledList>
     );
   }
 
+  const height = Math.min(MAX_LIST_HEIGHT, children.length * LIST_ITEM_HEIGHT);
+
   return (
-    <Container $height="500px" ref={ref}>
+    <StyledList $style={{height: height + 'px'}} ref={ref}>
       <AutoSizer>
         {({width}) => (
           <List
             role={props.role}
-            height={500}
+            height={height}
             width={width}
             rowCount={children.length}
-            rowHeight={36}
+            rowHeight={LIST_ITEM_HEIGHT}
             rowRenderer={({index, key, style}) => {
+              const {item, overrides, ...restChildProps} = children[
+                index
+              ].props;
               return (
                 <ListItem
                   key={key}
-                  style={style}
-                  {...children[index].props}
+                  style={{
+                    boxSizing: 'border-box',
+                    ...style,
+                  }}
+                  {...restChildProps}
                 >
-                  {children[index].props.item.id}
+                  {item.id}
                 </ListItem>
               );
             }}
           />
         )}
       </AutoSizer>
-    </Container>
+    </StyledList>
   );
 });
 
@@ -74,7 +79,7 @@ export default () => {
       options={options}
       labelKey="id"
       valueKey="label"
-      overrides={{Dropdown: {component: VirtualList}}}
+      overrides={{Dropdown: {component: VirtualDropdown}}}
       onChange={({value}) => setValue(value)}
       value={value}
     />


### PR DESCRIPTION
- Use `box-sizing: border-box` so list items fit in list. Also avoid `item="[object Object]" overrides="[object Object]"` from appearing in DOM.
Before:
<img width="1390" alt="Screen Shot 2019-11-11 at 4 43 15 PM" src="https://user-images.githubusercontent.com/1285326/68661539-f9087f80-04ef-11ea-93f9-941c89ff8dc7.png">
After:
<img width="1390" alt="Screen Shot 2019-11-11 at 5 00 48 PM" src="https://user-images.githubusercontent.com/1285326/68661553-fefe6080-04ef-11ea-8c51-debdc72ff896.png">

- Avoid mis-sized lists by resizing the height based on the number of children. E.g. try searching for `1111` and see the list height resize now.
Before:
![baseweb design_components_select_](https://user-images.githubusercontent.com/1285326/68661642-1fc6b600-04f0-11ea-9e32-8566c5b850d2.png)

After:
![localhost_3000_components_select](https://user-images.githubusercontent.com/1285326/68661649-23f2d380-04f0-11ea-9d6d-4da4aa339437.png)
