### PR TITLE
docs(checkbox): remove default value for placement

### DIFF
--- a/documentation-site/components/yard/config/checkbox.ts
+++ b/documentation-site/components/yard/config/checkbox.ts
@@ -89,7 +89,6 @@ const CheckboxConfig: TConfig = {
     },
     labelPlacement: {
       value: 'LABEL_PLACEMENT.right',
-      defaultValue: 'LABEL_PLACEMENT.right',
       options: LABEL_PLACEMENT,
       type: PropTypes.Enum,
       enumName: 'LABEL_PLACEMENT',


### PR DESCRIPTION
As it turns out, the component worked fine - it's just the default value that works differently for different types of checkboxes. Note the difference between the following images:

<img width="569" alt="Screen Shot 2019-11-12 at 5 22 59 PM" src="https://user-images.githubusercontent.com/2174968/68724752-38c37b80-0571-11ea-8eb7-def6d3b237f6.png">

and

<img width="568" alt="Screen Shot 2019-11-12 at 5 23 06 PM" src="https://user-images.githubusercontent.com/2174968/68724760-3cef9900-0571-11ea-9fbe-008aaa79be7a.png">

The issue was, that the default is different for the different checkbox types, so we always have to add it to the source code to make the examples work.
