### PR TITLE
chore(bundle): add better support for checking each component size

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,8 @@
     "babel-plugin-transform-styletron-display-name": "^1.1.3",
     "babel-plugin-webpack-loaders": "^0.9.0",
     "broken-link-checker": "^0.7.8",
+    "commander": "^4.0.1",
+    "compression-webpack-plugin": "^3.0.0",
     "copy-to-clipboard": "^3.2.0",
     "core-js": "^2.5.7",
     "cross-env": "^6.0.0",

--- a/scripts/bundle-size/.gitignore
+++ b/scripts/bundle-size/.gitignore
@@ -1,0 +1,4 @@
+entry.js
+stats.json
+bundle.js
+bundle.js.gz

--- a/scripts/bundle-size/bundle-size.js
+++ b/scripts/bundle-size/bundle-size.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+/* eslint-env node */
+/* eslint-disable flowtype/require-valid-file-annotation */
+
+const childProcess = require('child_process');
+const fs = require('fs');
+const {resolve} = require('path');
+const commander = require('commander');
+
+const program = new commander.Command();
+
+program
+  .requiredOption('-c, --component <component>', 'Component name')
+  .requiredOption('-e, --export-name <exportName>', 'Export name')
+  .option('-a, --analyzer', 'Start analyzer');
+
+program.parse(process.argv);
+
+const numberOfLines = data => {
+  return data.split('\n').length;
+};
+const removeLines = (data, lines = []) => {
+  return data
+    .split('\n')
+    .filter((val, idx) => lines.indexOf(idx) === -1)
+    .join('\n');
+};
+
+const {component, exportName} = program;
+
+const js = `
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ${exportName} from "../../src/${component}";
+
+function App () {
+  return <${exportName} />
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));
+`;
+
+fs.writeFileSync(resolve(__dirname, 'entry.js'), js, {flag: 'w'});
+const configPath = resolve(__dirname, 'webpack.config.js');
+const statsPath = resolve(__dirname, 'stats.json');
+
+childProcess.execSync(
+  `yarn webpack --config ${configPath} --json > ${statsPath}`,
+  {
+    env: {
+      ...process.env,
+      ANALYZER: program.analyzer,
+    },
+  },
+);
+
+const statsString = fs.readFileSync(statsPath).toString();
+// for some reason, the output is polluted with a few lines.
+// we have to clean them up before processing
+const statsCleaned = removeLines(statsString, [
+  0,
+  1,
+  numberOfLines(statsString) - 2,
+]);
+
+const stats = JSON.parse(statsCleaned);
+const assets = new Map(stats.assets.map(asset => [asset.name, asset]));
+
+const webpackSize = Object.entries(stats.assetsByChunkName).map(
+  ([chunkName, assetName]) => {
+    const parsedSize = assets.get(assetName).size;
+    const gzipSize = assets.get(`${assetName}.gz`).size;
+    return [chunkName, {parsed: parsedSize, gzip: gzipSize}];
+  },
+);
+
+console.log(webpackSize);

--- a/scripts/bundle-size/webpack.config.js
+++ b/scripts/bundle-size/webpack.config.js
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+/* eslint-env node */
+// @flow
+
+const {resolve} = require('path');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
+  .BundleAnalyzerPlugin;
+const CompressionPlugin = require('compression-webpack-plugin');
+
+const plugins = [new CompressionPlugin()];
+
+if (process.env.ANALYZER) {
+  plugins.push(new BundleAnalyzerPlugin());
+}
+
+module.exports = {
+  entry: {
+    main: resolve(__dirname, 'entry.js'),
+  },
+  context: __dirname,
+  plugins,
+  externals: /^(react|react-dom)$/,
+  mode: 'production',
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        query: {
+          cacheDirectory: true,
+        },
+      },
+    ],
+  },
+  output: {
+    filename: 'bundle.js',
+    path: __dirname,
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6349,6 +6349,26 @@ cacache@^10.0.4:
     unique-filename "^1.1.0"
     y18n "^4.0.0"
 
+cacache@^11.2.0:
+  version "11.3.3"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.3.tgz#8bd29df8c6a718a6ebd2d010da4d7972ae3bbadc"
+  integrity sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==
+  dependencies:
+    bluebird "^3.5.5"
+    chownr "^1.1.1"
+    figgy-pudding "^3.5.1"
+    glob "^7.1.4"
+    graceful-fs "^4.1.15"
+    lru-cache "^5.1.1"
+    mississippi "^3.0.0"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    promise-inflight "^1.0.1"
+    rimraf "^2.6.3"
+    ssri "^6.0.1"
+    unique-filename "^1.1.1"
+    y18n "^4.0.0"
+
 cacache@^12.0.2:
   version "12.0.3"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.3.tgz#be99abba4e1bf5df461cd5a2c1071fc432573390"
@@ -7154,6 +7174,11 @@ commander@^2.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
   integrity sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==
 
+commander@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.0.1.tgz#b67622721785993182e807f4883633e6401ba53c"
+  integrity sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA==
+
 commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
@@ -7242,6 +7267,18 @@ compressible@~2.0.16:
   integrity sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==
   dependencies:
     mime-db ">= 1.40.0 < 2"
+
+compression-webpack-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-3.0.0.tgz#097d2e4d95c3a14cb5c8ed20899009ab5b9bbca0"
+  integrity sha512-ls+oKw4eRbvaSv/hj9NmctihhBcR26j76JxV0bLRLcWhrUBdQFgd06z/Kgg7exyQvtWWP484wZxs0gIUX3NO0Q==
+  dependencies:
+    cacache "^11.2.0"
+    find-cache-dir "^3.0.0"
+    neo-async "^2.5.0"
+    schema-utils "^1.0.0"
+    serialize-javascript "^1.4.0"
+    webpack-sources "^1.0.1"
 
 compression@1.7.4:
   version "1.7.4"


### PR DESCRIPTION
This is the first step to improve our understanding of the base web bundle

<img width="1267" alt="Screen Shot 2019-11-13 at 3 29 07 PM" src="https://user-images.githubusercontent.com/2174968/68813347-65879980-062a-11ea-903e-b9302d3d7a11.png">

### usage

```
./scripts/bundle-size/bundle-size.js -c input -e Input
```

#### usage with the webpack bundle analyzer

```
./scripts/bundle-size/bundle-size.js -c input -e Input -a
```


