### PR TITLE
feat(media-query): add mediaQuery object to theme and update docs

### DIFF
--- a/documentation-site/components/header-navigation.js
+++ b/documentation-site/components/header-navigation.js
@@ -35,7 +35,7 @@ const Hamburger = themedStyled<{}>('div', ({$theme}) => ({
   height: '32px',
   paddingLeft: $theme.sizing.scale600,
   cursor: 'pointer',
-  [$theme.media.medium]: {
+  [$theme.mediaQuery.medium]: {
     display: 'none',
   },
 }));
@@ -47,7 +47,7 @@ const LogoSegment = themedStyled<{$searchInputOpen: boolean}>(
     justifySelf: 'flex-start',
     justifyContent: 'flex-start',
     flex: 'none',
-    [$theme.media.small]: {
+    [$theme.mediaQuery.small]: {
       display: 'flex',
     },
   }),
@@ -148,7 +148,7 @@ const Navigation = ({toggleSidebar, toggleTheme, toggleDirection}: PropsT) => {
                     style: ({$theme}) => ({
                       display: 'none',
                       height: $theme.sizing.scale800,
-                      [$theme.media.small]: {
+                      [$theme.mediaQuery.small]: {
                         display: 'block',
                       },
                     }),
@@ -169,7 +169,7 @@ const Navigation = ({toggleSidebar, toggleTheme, toggleDirection}: PropsT) => {
                     style: ({$theme}) => ({
                       display: 'none',
                       height: $theme.sizing.scale800,
-                      [$theme.media.small]: {
+                      [$theme.mediaQuery.small]: {
                         display: 'block',
                       },
                     }),
@@ -194,7 +194,7 @@ const Navigation = ({toggleSidebar, toggleTheme, toggleDirection}: PropsT) => {
                       cursor: 'pointer',
                       display: 'none',
                       height: $theme.sizing.scale800,
-                      [$theme.media.small]: {
+                      [$theme.mediaQuery.small]: {
                         display: 'block',
                       },
                     }),
@@ -213,7 +213,7 @@ const Navigation = ({toggleSidebar, toggleTheme, toggleDirection}: PropsT) => {
                   Block: {
                     style: ({$theme}) => ({
                       height: $theme.sizing.scale800,
-                      [$theme.media.small]: {
+                      [$theme.mediaQuery.small]: {
                         display: 'block',
                       },
                     }),

--- a/documentation-site/components/help.js
+++ b/documentation-site/components/help.js
@@ -21,8 +21,9 @@ const Help = () => {
         boxShadow: theme.lighting.shadow400,
         padding: theme.sizing.scale400,
         backgroundColor: theme.colors.background,
-        [`@media screen and (max-width: ${theme.breakpoints.medium}px`]: {
-          display: 'none',
+        display: 'none',
+        [theme.mediaQuery.medium]: {
+          display: 'block',
         },
       })}
     >

--- a/documentation-site/components/layout.js
+++ b/documentation-site/components/layout.js
@@ -71,7 +71,7 @@ const SidebarWrapper = themedStyled<{
   paddingTop: $theme.sizing.scale700,
   marginLeft: $theme.sizing.scale800,
   marginRight: $theme.sizing.scale800,
-  [$theme.media.medium]: {
+  [$theme.mediaQuery.medium]: {
     display: $hideSideNavigation ? 'none' : 'block',
     maxWidth: '16em',
   },
@@ -88,7 +88,7 @@ const ContentWrapper = themedStyled<{
   paddingRight: $theme.sizing.scale800,
   width: '100%',
   maxWidth: $maxWidth ? $maxWidth : '40em',
-  [$theme.media.medium]: {
+  [$theme.mediaQuery.medium]: {
     display: 'block',
     maxWidth: $maxWidth ? $maxWidth : '40em',
   },

--- a/documentation-site/components/posts.js
+++ b/documentation-site/components/posts.js
@@ -35,7 +35,7 @@ const Index = () => {
         Block: {
           style: ({$theme}) => ({
             justifyContent: 'center',
-            [$theme.media.small]: {
+            [$theme.mediaQuery.small]: {
               justifyContent: 'flex-start',
             },
           }),

--- a/documentation-site/components/search.js
+++ b/documentation-site/components/search.js
@@ -44,7 +44,7 @@ const PlainInput = themedStyled<{$inputVisible: boolean}>(
       ':focus': {
         borderColor: $theme.colors.primary,
       },
-      [$theme.media.small]: {
+      [$theme.mediaQuery.small]: {
         position: 'static',
         display: 'block',
         width: '250px',
@@ -73,7 +73,7 @@ const IconWrapper = themedStyled<{$inputVisible: boolean}>(
     marginTop: $inputVisible ? '4px' : 0,
     height: '32px',
     cursor: 'pointer',
-    [$theme.media.small]: {
+    [$theme.mediaQuery.small]: {
       [$theme.direction === 'rtl' ? 'right' : 'left']: '12px',
       marginTop: '4px',
       cursor: 'inherit',
@@ -122,7 +122,7 @@ class DocSearch extends React.Component<Props, State> {
                     height: searchInputOpen ? '22px' : '32px',
                     width: searchInputOpen ? '22px' : '32px',
                     fill: searchInputOpen ? '#666' : '#333',
-                    [$theme.media.small]: {
+                    [$theme.mediaQuery.small]: {
                       height: '22px',
                       width: '22px',
                       fill: '#666',

--- a/documentation-site/components/survey.js
+++ b/documentation-site/components/survey.js
@@ -45,8 +45,9 @@ const Survey = () => {
         paddingTop: theme.sizing.scale800,
         paddingBottom: theme.sizing.scale800,
         backgroundColor: theme.colors.background,
-        [`@media screen and (max-width: ${theme.breakpoints.medium}px`]: {
-          display: 'none',
+        display: 'none',
+        [theme.mediaQuery.medium]: {
+          display: 'block',
         },
       })}
     >

--- a/documentation-site/components/walkthrough.js
+++ b/documentation-site/components/walkthrough.js
@@ -122,8 +122,9 @@ export default () => {
           textAlign: 'center',
           padding: theme.sizing.scale400,
           backgroundColor: theme.colors.background,
-          [`@media screen and (max-width: ${theme.breakpoints.medium}px`]: {
-            display: 'none',
+          display: 'none',
+          [theme.mediaQuery.medium]: {
+            display: 'block',
           },
         })}
       >

--- a/documentation-site/components/yard/knobs.tsx
+++ b/documentation-site/components/yard/knobs.tsx
@@ -1,3 +1,9 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
 import * as React from 'react';
 import {useStyletron} from 'baseui';
 import {Button, KIND, SIZE} from 'baseui/button';
@@ -57,8 +63,9 @@ const Knobs: React.FC<TKnobsProps> = ({knobProps, set, error}) => {
       <div
         className={useCss({
           display: 'flex',
-          [`@media screen and (max-width: ${theme.breakpoints.medium}px)`]: {
-            flexWrap: 'wrap',
+          flexWrap: 'wrap',
+          [theme.mediaQuery.medium]: {
+            flexWrap: 'nowrap',
           },
           margin: `0 -${theme.sizing.scale600}`,
         })}

--- a/documentation-site/components/yard/override.tsx
+++ b/documentation-site/components/yard/override.tsx
@@ -1,3 +1,9 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
 import * as React from 'react';
 import {useStyletron} from 'baseui';
 import {StatefulTooltip} from 'baseui/tooltip';
@@ -106,8 +112,9 @@ const Override: React.FC<TProps> = ({
           Root: {
             style: ({$theme}) => ({
               marginTop: $theme.sizing.scale300,
-              [`@media screen and (max-width: ${$theme.breakpoints.medium}px)`]: {
-                flexWrap: 'wrap',
+              flexWrap: 'wrap',
+              [theme.mediaQuery.medium]: {
+                flexWrap: 'nowrap',
               },
             }),
           },

--- a/documentation-site/components/yard/theme-editor.tsx
+++ b/documentation-site/components/yard/theme-editor.tsx
@@ -133,8 +133,9 @@ const ThemeEditor: React.FC<ThemeEditorProps> = ({
         className={useCss({
           display: 'flex',
           flexDirection: 'row',
-          [`@media screen and (max-width: ${currentTheme.breakpoints.medium}px)`]: {
-            flexWrap: 'wrap',
+          flexWrap: 'wrap',
+          [currentTheme.mediaQuery.medium]: {
+            flexWrap: 'nowrap',
           },
         })}
       >

--- a/documentation-site/pages/_app.js
+++ b/documentation-site/pages/_app.js
@@ -19,7 +19,6 @@ import {
   LightTheme,
   LightThemeMove,
 } from 'baseui';
-import {getMediaQuery} from 'baseui/helpers/responsive-helpers';
 import type {BreakpointsT, ThemeT} from 'baseui/styles/types';
 
 import App from 'next/app';
@@ -34,50 +33,35 @@ import {styletron, debug} from '../helpers/styletron';
 import {trackPageView} from '../helpers/ga';
 import DirectionContext from '../components/direction-context';
 
-const Breakpoints = {
+const breakpoints: BreakpointsT = {
   small: 670,
   medium: 920,
   large: 1280,
 };
 
-const ResponsiveTheme = Object.keys(Breakpoints).reduce(
+const ResponsiveTheme = Object.keys(breakpoints).reduce(
   (acc, key) => {
-    acc.breakpoints[key] = Breakpoints[key];
-    acc.media[key] = getMediaQuery({
-      'min-width': `${Breakpoints[key]}px`,
-    });
+    acc.mediaQuery[
+      key
+    ] = `@media screen and (min-width: ${breakpoints[key]}px)`;
     return acc;
   },
   {
-    breakpoints: {},
-    media: {},
+    breakpoints,
+    mediaQuery: {},
   },
 );
 
 const themes = {
-  LightTheme: {
-    ...LightTheme,
-    ...ResponsiveTheme,
-  },
-  LightThemeMove: {
-    ...LightThemeMove,
-    ...ResponsiveTheme,
-  },
-  DarkTheme: {
-    ...DarkTheme,
-    ...ResponsiveTheme,
-  },
-  DarkThemeMove: {
-    ...DarkThemeMove,
-    ...ResponsiveTheme,
-  },
+  LightTheme: {...LightTheme, ...ResponsiveTheme},
+  LightThemeMove: {...LightThemeMove, ...ResponsiveTheme},
+  DarkTheme: {...DarkTheme, ...ResponsiveTheme},
+  DarkThemeMove: {...DarkThemeMove, ...ResponsiveTheme},
 };
 
-type AppThemeT = ThemeT & {media: $ObjMap<BreakpointsT, <V>(V) => string>};
-
-export const themedStyled = createThemedStyled<AppThemeT>();
-export const themedWithStyle = createThemedWithStyle<AppThemeT>();
-export const themedUseStyletron = createThemedUseStyletron<AppThemeT>();
+export const themedStyled = createThemedStyled<ThemeT>();
+export const themedWithStyle = createThemedWithStyle<ThemeT>();
+export const themedUseStyletron = createThemedUseStyletron<ThemeT>();
 
 const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
 const LIGHT_MEDIA_QUERY = '(prefers-color-scheme: light)';

--- a/documentation-site/pages/blog/responsive-web/index.mdx
+++ b/documentation-site/pages/blog/responsive-web/index.mdx
@@ -64,28 +64,26 @@ In many cases, you would want to override Base Web’s breakpoints with your own
 To override these, we recommend creating your own mapping, as well as generating the respective `min-width` media query strings so we can target different screen widths for styling:
 
 ```js
-const MyBreakpoints = {
+const breakpoints = {
   small: 769,
   medium: 1024,
   large: 1216,
 };
 
-const ResponsiveTheme = Object.keys(MyBreakpoints).reduce(
+const ResponsiveTheme = Object.keys(breakpoints).reduce(
   (acc, key) => {
-    acc.breakpoints[key] = MyBreakpoints[key];
-    acc.media[key] = `@media screen and (min-width: ${MyBreakpoints[key]}px)`;
+    acc.mediaQuery[
+      key
+    ] = `@media screen and (min-width: ${breakpoints[key]}px)`;
     return acc;
   },
   {
-    breakpoints: {},
-    media: {},
+    breakpoints,
+    mediaQuery: {},
   },
 );
 
-export const MyTheme = {
-  ...LightTheme,
-  ...ResponsiveTheme,
-};
+export const MyTheme = {...LightTheme, ...ResponsiveTheme};
 ```
 
 This sets the following values inside `MyTheme`:
@@ -97,7 +95,7 @@ This sets the following values inside `MyTheme`:
     "medium": 1024,
     "large": 1216,
   },
-  "media": {
+  "mediaQuery": {
     "small": "@media screen and (min-width: 769px)"
     "medium": "@media screen and (min-width: 1024px)",
     "large": "@media screen and (min-width: 1216px)",
@@ -119,7 +117,7 @@ Now that our theme is set up with media queries, we can start using them to crea
 const LoadStatus = themedStyled('span', ({$theme}) => ({
   ...$theme.typography.font250,
   color: $theme.colors.mono800,
-  [$theme.media.small]: {
+  [$theme.mediaQuery.small]: {
     ...$theme.typography.font550,
     color: $theme.colors.mono900,
   },
@@ -156,7 +154,7 @@ const NavBar = themedStyled('div', ({$theme}) => ({
   height: $theme.sizing.scale1400,
   paddingRight: $theme.sizing.scale800,
   paddingLeft: $theme.sizing.scale800,
-  [$theme.media.small]: {
+  [$theme.mediaQuery.small]: {
     height: $theme.sizing.scale1600,
     paddingRight: $theme.sizing.scale1200,
     paddingLeft: $theme.sizing.scale1200,

--- a/documentation-site/pages/components/block.mdx
+++ b/documentation-site/pages/components/block.mdx
@@ -58,9 +58,7 @@ breakpoints: {
 Given a `marginTop` value of `['10px', '20px', '30px', '40px']` `Block` will create the css rules below:
 
 ```css
-@media screen and (min-width: 0px) {
-  margin-top: 10px;
-}
+margin-top: 10px;
 @media screen and (min-width: 320px) {
   margin-top: 20px;
 }

--- a/documentation-site/pages/index.js
+++ b/documentation-site/pages/index.js
@@ -127,7 +127,7 @@ const Index = (props: {
         Block: {
           style: ({$theme}) => ({
             flexWrap: 'wrap',
-            [$theme.media.small]: {
+            [$theme.mediaQuery.small]: {
               flexWrap: 'nowrap',
             },
           }),

--- a/src/styles/types.js
+++ b/src/styles/types.js
@@ -14,6 +14,12 @@ export type BreakpointsT = {
   large: number,
 };
 
+export type MediaQueryT = {
+  small: string,
+  medium: string,
+  large: string,
+};
+
 export type ColorsT = {
   // Primary Palette
   primary50: string,
@@ -584,6 +590,7 @@ export type ThemeT = {|
   name: string,
   direction: 'auto' | 'rtl' | 'ltr',
   breakpoints: BreakpointsT,
+  mediaQuery: MediaQueryT,
   colors: ColorsT,
   typography: TypographyT,
   sizing: SizingT,

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -4,6 +4,12 @@ interface Breakpoints {
   large: number;
 }
 
+interface MediaQuery {
+  small: string;
+  medium: string;
+  large: string;
+}
+
 interface Colors {
   // Primary Palette
   primary50: string;
@@ -571,6 +577,7 @@ export interface Theme {
   name: string;
   direction: 'auto' | 'rtl' | 'ltr';
   breakpoints: Breakpoints;
+  mediaQuery: MediaQuery;
   colors: Colors;
   typography: Typography;
   sizing: Sizing;

--- a/src/themes/creator.js
+++ b/src/themes/creator.js
@@ -9,6 +9,7 @@ LICENSE file in the root directory of this source tree.
 import type {ThemeT} from '../styles/types.js';
 import type {PrimitivesT} from './types.js';
 import deepMerge from '../utils/deep-merge.js';
+import {getMediaQuery} from '../helpers/responsive-helpers.js';
 
 const WHITE = '#FFFFFF';
 const BLACK = '#000000';
@@ -22,6 +23,12 @@ export default function createTheme(
       small: 320,
       medium: 600,
       large: 1136,
+    },
+
+    mediaQuery: {
+      small: getMediaQuery({'min-width': `${320}px`}),
+      medium: getMediaQuery({'min-width': `${600}px`}),
+      large: getMediaQuery({'min-width': `${1136}px`}),
     },
 
     colors: {


### PR DESCRIPTION
#### Description

* Add mediaQuery object to theme based on breakpoints
* Update docs to use mediaQuery instead of media
* Follow mobile-first pattern in docs when possible
* Fix Block documentation which said there was a media query for below the first breakpoint

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
