### PR TITLE
test(vrt): run in band

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "e2e:serve": "static-server e2e/dist --port 8080",
     "e2e:test": "jest --runInBand -c jest.e2e.config.js",
     "e2e:test:ci": "PUPPETEER_TARGET_URL=http://e2e-server:8080 jest -c jest.e2e.config.js",
-    "vrt": "jest -c jest.vrt.config.js",
+    "vrt": "jest -c jest.vrt.config.js --runInBand",
     "vrt:docker:run": "docker-compose run e2e-test bash -c 'yarn add puppeteer && PUPPETEER_TARGET_URL=http://e2e-server:8080 yarn vrt'",
     "vrt:docker:update": "docker-compose run e2e-test bash -c 'yarn add puppeteer && PUPPETEER_TARGET_URL=http://e2e-server:8080 yarn vrt -u'",
     "vrt:ci": "PUPPETEER_TARGET_URL=http://e2e-server:8080 node ./vrt/ci.js",


### PR DESCRIPTION
Experimentation as per https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server