### PR TITLE
feat(theme): add default grid values

### DIFF
--- a/documentation-site/pages/components/layout-grid.mdx
+++ b/documentation-site/pages/components/layout-grid.mdx
@@ -44,6 +44,8 @@ Here are the default responsive values for the grid, based on the default Base W
   ]}
 />
 
+All of these values are [customizable via your theme](https://baseweb.design/guides/theming). The grid will default to whatever values are in your theme but you can additionally override any of them with props on `Grid` and `Cell`.
+
 ## Examples
 
 Some examples may require you to open them in CodeSandbox to achieve a wide enough viewport for certain behaviors.
@@ -78,7 +80,9 @@ Sometimes this wrapping behavior is desireable, but sometimes you want to adapt 
 
 `span` is a "responsive" prop. It accepts both a single value or an array of values. Each value in the array corresponds to each [breakpoint in our theme](https://baseweb.design/guides/theming/#the-shape-of-the-theme-file).
 
-In the above example, we specify that on the first breakpoint each cell should span 1 column. On the second breakpoint, each cell should span 2 columns, and on the third breakpoint, each cell should span 3 columns: `[1, 2, 3]`. Effectively, this keeps each cell to 1/4 of the width of the grid on all breakpoints.
+When you specify the first value in the array, you are specifying the value for any viewport larger than or equal to the first (`small`) breakpoint in your theme. The second value applies to viewports greater than or equal to the `medium` breakpoint, and the third value applies to viewports greater than or equal to the `large` breakpoint.
+
+In the example above, we specify that on the first breakpoint and up each cell should span 1 column. On the second breakpoint and up, each cell should span 2 columns, and on the third breakpoint and up, each cell should span 3 columns: `[1, 2, 3]`. Effectively, this keeps each cell to 1/4 of the width of the grid on all breakpoints.
 
 This terse way of describing responsive values was originally used in our [Block](/components/block) component- it allows you to very quickly specify even the most complicated responsive layouts.
 
@@ -86,7 +90,7 @@ Note, you can omit larger breakpoint values if they do not change. For example, 
 
 Also note that every `Cell` prop is "responsive". Almost all of the props for `Grid` are also "responsive" props, with the exception of `behavior` and `gridMaxWidth`, which only accept one value across all breakpoints.
 
-One last thing to note: Cells will take up the full width of the grid on viewports smaller than the smallest breakpoint (`<319px` by default). The "responsive" props essentially ignore this range.
+Last thing to note: The grid has only one column on viewports smaller than the first breakpoint (`<320px`). Cells will effectively take up the full width of the grid. Most props have no reasonable effect with one column so "responsive" props essentially ignore this range.
 
 <Example title="Hide" path="layout-grid/hide.js">
   <HideExample />
@@ -150,7 +154,23 @@ You can customize pretty much any part of the grid while maintaining the core re
 - `gridMargins`
 - `gridMaxWidth` (Not responsive)
 
-If you want to customize the breakpoints of the grid you need to [customize your theme object](https://baseweb.design/guides/theming/#creating-a-custom-theme). The grid will always pull breakpoints from the theme and correlate responsive props with those breakpoints.
+The grid will use whatever values are on your theme `grid` property as the default values for these props. This way you do not have to create a "wrapper" grid if yours differs from the default Base grid. [Click here for the full theme shape](https://baseweb.design/guides/theming/#the-shape-of-the-theme-file)or see below for the grid relevant section of the theme:
+
+```js
+const theme = {
+  grid: {
+    columns: [4, 8, 12],
+    gutters: [16, 36, 36],
+    margins: [16, 36, 64],
+    gaps: 0,
+    maxWidth: 1280,
+  },
+};
+```
+
+Note how these are defined in a similar fashion to responsive props. Each value in the array corresponds to a theme breakpoint.
+
+If you want to customize the breakpoints of the grid, you can do so via the `breakpoints` and `mediaQuery` properties. The grid will always pull breakpoints from the theme and correlate responsive props with those breakpoints.
 
 ## API
 

--- a/src/layout-grid/styled-components.js
+++ b/src/layout-grid/styled-components.js
@@ -11,43 +11,41 @@ import {getMediaQueries} from '../helpers/responsive-helpers.js';
 import {BEHAVIOR} from './constants.js';
 import type {ResponsiveT, StyledGridPropsT, StyledCellPropsT} from './types.js';
 
-const DEFAULT_GRID_COLUMNS = [4, 8, 12];
-const DEFAULT_GRID_GUTTERS = [16, 36, 36];
-const DEFAULT_GRID_MARGINS = [16, 36, 64];
-const DEFAULT_GRID_MAX_WIDTH = 1280;
-
 export const StyledGrid = styled<StyledGridPropsT>(
   'div',
   ({
     $align = null,
     $behavior = BEHAVIOR.fixed,
-    $gridGutters = DEFAULT_GRID_GUTTERS,
-    $gridMargins = DEFAULT_GRID_MARGINS,
-    $gridMaxWidth = DEFAULT_GRID_MAX_WIDTH,
+    $gridGutters = null,
+    $gridMargins = null,
+    $gridMaxWidth = null,
     $theme,
   }) => {
     const mediaQueries = getMediaQueries($theme.breakpoints);
+    const gridGutters = $gridGutters || $theme.grid.gutters;
+    const gridMargins = $gridMargins || $theme.grid.margins;
+    const gridMaxWidth = $gridMaxWidth || $theme.grid.maxWidth;
     const gridStyles = mediaQueries.reduce(
       (acc, cur, idx) => {
         return {
           ...acc,
           [cur]: {
-            paddingLeft: `${getResponsiveNumber($gridMargins, idx) -
-              getResponsiveNumber($gridGutters, idx) / 2 -
+            paddingLeft: `${getResponsiveNumber(gridMargins, idx) -
+              getResponsiveNumber(gridGutters, idx) / 2 -
               0.5}px`,
-            paddingRight: `${getResponsiveNumber($gridMargins, idx) -
-              getResponsiveNumber($gridGutters, idx) / 2 -
+            paddingRight: `${getResponsiveNumber(gridMargins, idx) -
+              getResponsiveNumber(gridGutters, idx) / 2 -
               0.5}px`,
             alignItems: getResponsiveValue($align, idx),
           },
         };
       },
       {
-        paddingLeft: `${getResponsiveNumber($gridMargins, 0) -
-          getResponsiveNumber($gridGutters, 0) / 2 -
+        paddingLeft: `${getResponsiveNumber(gridMargins, 0) -
+          getResponsiveNumber(gridGutters, 0) / 2 -
           0.5}px`,
-        paddingRight: `${getResponsiveNumber($gridMargins, 0) -
-          getResponsiveNumber($gridGutters, 0) / 2 -
+        paddingRight: `${getResponsiveNumber(gridMargins, 0) -
+          getResponsiveNumber(gridGutters, 0) / 2 -
           0.5}px`,
         alignItems: getResponsiveValue($align, 0),
       },
@@ -60,8 +58,8 @@ export const StyledGrid = styled<StyledGridPropsT>(
       marginRight: 'auto',
       maxWidth:
         $behavior === BEHAVIOR.fixed
-          ? `${$gridMaxWidth +
-              2 * getResponsiveNumber($gridMargins, Infinity) -
+          ? `${gridMaxWidth +
+              2 * getResponsiveNumber(gridMargins, Infinity) -
               1}px`
           : null,
       ...gridStyles,
@@ -73,15 +71,18 @@ export const StyledCell = styled<StyledCellPropsT>(
   'div',
   ({
     $align = null,
-    $gridColumns = DEFAULT_GRID_COLUMNS,
+    $gridColumns = null,
     $gridGaps = 0,
-    $gridGutters = DEFAULT_GRID_GUTTERS,
+    $gridGutters = null,
     $order = null,
     $skip = [0, 0, 0],
     $span = [1, 1, 1],
     $theme,
   }) => {
     const mediaQueries = getMediaQueries($theme.breakpoints);
+    const gridColumns = $gridColumns || $theme.grid.columns;
+    const gridGaps = $gridGaps || $theme.grid.gaps;
+    const gridGutters = $gridGutters || $theme.grid.gutters;
     const cellStyles = mediaQueries.reduce(
       (acc, cur, idx) => {
         if (getResponsiveNumber($span, idx) === 0) {
@@ -101,19 +102,19 @@ export const StyledCell = styled<StyledCellPropsT>(
           ...acc,
           [cur]: {
             display: 'block',
-            width: `${(100 / getResponsiveNumber($gridColumns, idx)) *
+            width: `${(100 / getResponsiveNumber(gridColumns, idx)) *
               Math.min(
                 getResponsiveNumber($span, idx),
-                getResponsiveNumber($gridColumns, idx),
+                getResponsiveNumber(gridColumns, idx),
               )}%`,
-            marginLeft: `${(100 / getResponsiveNumber($gridColumns, idx)) *
+            marginLeft: `${(100 / getResponsiveNumber(gridColumns, idx)) *
               Math.min(
                 getResponsiveNumber($skip, idx),
-                getResponsiveNumber($gridColumns, idx) - 1,
+                getResponsiveNumber(gridColumns, idx) - 1,
               )}%`,
-            paddingLeft: getResponsiveNumber($gridGutters, idx) / 2 + 'px',
-            paddingRight: getResponsiveNumber($gridGutters, idx) / 2 + 'px',
-            marginBottom: getResponsiveNumber($gridGaps, idx) + 'px',
+            paddingLeft: getResponsiveNumber(gridGutters, idx) / 2 + 'px',
+            paddingRight: getResponsiveNumber(gridGutters, idx) / 2 + 'px',
+            marginBottom: getResponsiveNumber(gridGaps, idx) + 'px',
             alignSelf: getResponsiveValue($align, idx),
             order: getResponsiveNumber($order, idx),
           },
@@ -121,9 +122,9 @@ export const StyledCell = styled<StyledCellPropsT>(
       },
       {
         width: '100%',
-        paddingLeft: getResponsiveNumber($gridGutters, 0) / 2 + 'px',
-        paddingRight: getResponsiveNumber($gridGutters, 0) / 2 + 'px',
-        marginBottom: getResponsiveNumber($gridGaps, 0) + 'px',
+        paddingLeft: getResponsiveNumber(gridGutters, 0) / 2 + 'px',
+        paddingRight: getResponsiveNumber(gridGutters, 0) / 2 + 'px',
+        marginBottom: getResponsiveNumber(gridGaps, 0) + 'px',
         alignSelf: getResponsiveValue($align, 0),
         order: getResponsiveNumber($order, 0),
       },

--- a/src/styles/types.js
+++ b/src/styles/types.js
@@ -7,6 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 import type {ComponentType} from 'react';
 import type {IconPropsT} from '../icon/types.js';
+import type {ResponsiveT} from '../layout-grid/types.js';
 
 export type BreakpointsT = {
   small: number,
@@ -18,6 +19,14 @@ export type MediaQueryT = {
   small: string,
   medium: string,
   large: string,
+};
+
+export type GridT = {
+  columns: ResponsiveT<number>,
+  gutters: ResponsiveT<number>,
+  margins: ResponsiveT<number>,
+  gaps: ResponsiveT<number>,
+  maxWidth: number,
 };
 
 export type ColorsT = {
@@ -591,6 +600,7 @@ export type ThemeT = {|
   direction: 'auto' | 'rtl' | 'ltr',
   breakpoints: BreakpointsT,
   mediaQuery: MediaQueryT,
+  grid: GridT,
   colors: ColorsT,
   typography: TypographyT,
   sizing: SizingT,

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -12,10 +12,10 @@ interface MediaQuery {
 
 type Responsive<T> = T | T[];
 interface Grid {
-  columns: ResponsiveT<number>;
-  gutters: ResponsiveT<number>;
-  margins: ResponsiveT<number>;
-  gaps: ResponsiveT<number>;
+  columns: Responsive<number>;
+  gutters: Responsive<number>;
+  margins: Responsive<number>;
+  gaps: Responsive<number>;
   maxWidth: number;
 }
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -10,6 +10,15 @@ interface MediaQuery {
   large: string;
 }
 
+type Responsive<T> = T | T[];
+interface Grid {
+  columns: ResponsiveT<number>;
+  gutters: ResponsiveT<number>;
+  margins: ResponsiveT<number>;
+  gaps: ResponsiveT<number>;
+  maxWidth: number;
+}
+
 interface Colors {
   // Primary Palette
   primary50: string;
@@ -578,6 +587,7 @@ export interface Theme {
   direction: 'auto' | 'rtl' | 'ltr';
   breakpoints: Breakpoints;
   mediaQuery: MediaQuery;
+  grid: Grid;
   colors: Colors;
   typography: Typography;
   sizing: Sizing;

--- a/src/themes/creator.js
+++ b/src/themes/creator.js
@@ -31,6 +31,14 @@ export default function createTheme(
       large: getMediaQuery(1136),
     },
 
+    grid: {
+      columns: [4, 8, 12],
+      gutters: [16, 36, 36],
+      margins: [16, 36, 64],
+      gaps: 0,
+      maxWidth: 1280,
+    },
+
     colors: {
       // Primary Palette
       primary: primitives.primary,


### PR DESCRIPTION
This updates the layout-grid module to use theme values for default grid values. This requires some new properties on the theme object.

Also added a bit of clarity in docs around "responsive" props.