### PR TITLE
fix(datepicker): mask argument accepts null

### DIFF
--- a/src/datepicker/types.js
+++ b/src/datepicker/types.js
@@ -189,7 +189,7 @@ export type DatepickerPropsT = CalendarPropsT & {
   mountNode?: HTMLElement,
   /** Called when calendar is closed */
   onClose?: () => mixed,
-  mask?: string,
+  mask?: string | null,
 };
 
 export type SharedStylePropsT = {


### PR DESCRIPTION
`Fix`

#### Description
The `mask` property within `Datepicker` should be able to take in the argument of `null`. When doing so flow gives an error, only allowing `mask` to take in strings. 
<!-- Describe your changes below in as much detail as possible -->
Added null type into mask property arguments.
#### Scope

- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
