### PR TITLE
fix(tabs): space key a11y on Tabs and Accordion component.

### DIFF
--- a/src/accordion/panel.js
+++ b/src/accordion/panel.js
@@ -47,6 +47,7 @@ class Panel extends React.Component<PanelPropsT> {
     // toggle on Enter or Space button pressed
     if (e.key === 'Enter' || e.which === 32) {
       typeof onChange === 'function' && onChange({expanded: !expanded});
+      e.which === 32 && e.preventDefault(); // prevent jumping scroll when using Space
     }
     typeof onKeyDown === 'function' && onKeyDown(e);
     return;

--- a/src/tabs/tab.js
+++ b/src/tabs/tab.js
@@ -40,6 +40,7 @@ class TabComponent extends React.Component<TabPropsT> {
     // toggle on Enter or Space button pressed
     if (e.key === 'Enter' || e.which === 32) {
       typeof onSelect === 'function' && onSelect();
+      e.which === 32 && e.preventDefault(); // prevent jumping scroll when using Space
     }
     return;
   };


### PR DESCRIPTION
#### Description

[Tabs](https://baseweb.design/components/tabs/) and [Accordion](https://baseweb.design/components/accordion/) components makes the scroll jump when navigating using Space key. This is really annoying for accessibility.

The fix is really easy, just need to `e.preventDefault()` the event when it's triggered via space key.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
