### PR TITLE
fix(package): update module field to relative path

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "sideEffects": false,
-  "module": "/esm/index.js",
+  "module": "./esm/index.js",
   "repository": "uber/baseweb",
   "scripts": {
     "lint:code": "eslint ./",


### PR DESCRIPTION
Parcel looks to ignore the absolute path.

#### Description

The `package.json` included in subfolder has a relative path on `module` field. Parcel ignores the absolute path on the main `package.json` for `import { LightTheme, DarkTheme, BaseProvider } from "baseui"`. It leads the bundle to include two different ThemeProvider files breaking theming for example.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
