### PR TITLE
feat(typography): rename components to match Base typography style names

### DIFF
--- a/src/typography/index.d.ts
+++ b/src/typography/index.d.ts
@@ -20,6 +20,7 @@ export const ParagraphMedium: React.FC<BlockProps>;
 export const ParagraphSmall: React.FC<BlockProps>;
 export const ParagraphXSmall: React.FC<BlockProps>;
 
+// TODO(v10): remove
 export const Caption1: React.FC<BlockProps>;
 export const Caption2: React.FC<BlockProps>;
 export const Display: React.FC<BlockProps>;

--- a/src/typography/index.d.ts
+++ b/src/typography/index.d.ts
@@ -1,6 +1,25 @@
 import * as React from 'react';
 import {BlockProps} from '../block';
 
+export const DisplayLarge: React.FC<BlockProps>;
+export const DisplayMedium: React.FC<BlockProps>;
+export const DisplaySmall: React.FC<BlockProps>;
+export const DisplayXSmall: React.FC<BlockProps>;
+export const HeadingXXLarge: React.FC<BlockProps>;
+export const HeadingXLarge: React.FC<BlockProps>;
+export const HeadingLarge: React.FC<BlockProps>;
+export const HeadingMedium: React.FC<BlockProps>;
+export const HeadingSmall: React.FC<BlockProps>;
+export const HeadingXSmall: React.FC<BlockProps>;
+export const LabelLarge: React.FC<BlockProps>;
+export const LabelMedium: React.FC<BlockProps>;
+export const LabelSmall: React.FC<BlockProps>;
+export const LabelXSmall: React.FC<BlockProps>;
+export const ParagraphLarge: React.FC<BlockProps>;
+export const ParagraphMedium: React.FC<BlockProps>;
+export const ParagraphSmall: React.FC<BlockProps>;
+export const ParagraphXSmall: React.FC<BlockProps>;
+
 export const Caption1: React.FC<BlockProps>;
 export const Caption2: React.FC<BlockProps>;
 export const Display: React.FC<BlockProps>;

--- a/src/typography/index.js
+++ b/src/typography/index.js
@@ -254,6 +254,7 @@ export const ParagraphXSmall = React.forwardRef<BlockPropsT, HTMLElement>(
 );
 ParagraphXSmall.displayName = 'ParagraphXSmall';
 
+// TODO(v10): remove
 // Aliases for backwards compatability
 export const Display = DisplayLarge;
 export const Display1 = DisplayLarge;

--- a/src/typography/index.js
+++ b/src/typography/index.js
@@ -10,10 +10,10 @@ import * as React from 'react';
 import Block from '../block/block.js';
 import type {BlockPropsT} from '../block/types.js';
 
-export const Display1 = React.forwardRef<BlockPropsT, HTMLElement>(
+export const DisplayLarge = React.forwardRef<BlockPropsT, HTMLElement>(
   (props, ref) => (
     <Block
-      data-baseweb="typo-display1"
+      data-baseweb="typo-displaylarge"
       {...props}
       font={props.font || 'font1450'}
       color={props.color || 'colorPrimary'}
@@ -21,12 +21,12 @@ export const Display1 = React.forwardRef<BlockPropsT, HTMLElement>(
     />
   ),
 );
-Display1.displayName = 'Display1';
+DisplayLarge.displayName = 'DisplayLarge';
 
-export const Display2 = React.forwardRef<BlockPropsT, HTMLElement>(
+export const DisplayMedium = React.forwardRef<BlockPropsT, HTMLElement>(
   (props, ref) => (
     <Block
-      data-baseweb="typo-display2"
+      data-baseweb="typo-displaymedium"
       {...props}
       font={props.font || 'font1350'}
       color={props.color || 'colorPrimary'}
@@ -34,12 +34,12 @@ export const Display2 = React.forwardRef<BlockPropsT, HTMLElement>(
     />
   ),
 );
-Display2.displayName = 'Display2';
+DisplayMedium.displayName = 'DisplayMedium';
 
-export const Display3 = React.forwardRef<BlockPropsT, HTMLElement>(
+export const DisplaySmall = React.forwardRef<BlockPropsT, HTMLElement>(
   (props, ref) => (
     <Block
-      data-baseweb="typo-display3"
+      data-baseweb="typo-displaysmall"
       {...props}
       font={props.font || 'font1250'}
       color={props.color || 'colorPrimary'}
@@ -47,12 +47,12 @@ export const Display3 = React.forwardRef<BlockPropsT, HTMLElement>(
     />
   ),
 );
-Display3.displayName = 'Display3';
+DisplaySmall.displayName = 'DisplaySmall';
 
-export const Display4 = React.forwardRef<BlockPropsT, HTMLElement>(
+export const DisplayXSmall = React.forwardRef<BlockPropsT, HTMLElement>(
   (props, ref) => (
     <Block
-      data-baseweb="typo-display4"
+      data-baseweb="typo-displayxsmall"
       {...props}
       font={props.font || 'font1150'}
       color={props.color || 'colorPrimary'}
@@ -60,84 +60,96 @@ export const Display4 = React.forwardRef<BlockPropsT, HTMLElement>(
     />
   ),
 );
-Display4.displayName = 'Display4';
+DisplayXSmall.displayName = 'DisplayXSmall';
 
-export const H1 = React.forwardRef<BlockPropsT, HTMLElement>((props, ref) => (
-  <Block
-    data-baseweb="typo-h1"
-    as={props.as || 'h1'}
-    {...props}
-    font={props.font || 'font1050'}
-    color={props.color || 'colorPrimary'}
-    ref={ref}
-  />
-));
-H1.displayName = 'H1';
-
-export const H2 = React.forwardRef<BlockPropsT, HTMLElement>((props, ref) => (
-  <Block
-    data-baseweb="typo-h2"
-    as={props.as || 'h2'}
-    {...props}
-    font={props.font || 'font950'}
-    color={props.color || 'colorPrimary'}
-    ref={ref}
-  />
-));
-H2.displayName = 'H2';
-
-export const H3 = React.forwardRef<BlockPropsT, HTMLElement>((props, ref) => (
-  <Block
-    data-baseweb="typo-h3"
-    as={props.as || 'h3'}
-    {...props}
-    font={props.font || 'font850'}
-    color={props.color || 'colorPrimary'}
-    ref={ref}
-  />
-));
-H3.displayName = 'H3';
-
-export const H4 = React.forwardRef<BlockPropsT, HTMLElement>((props, ref) => (
-  <Block
-    data-baseweb="typo-h4"
-    as={props.as || 'h4'}
-    {...props}
-    font={props.font || 'font750'}
-    color={props.color || 'colorPrimary'}
-    ref={ref}
-  />
-));
-H4.displayName = 'H4';
-
-export const H5 = React.forwardRef<BlockPropsT, HTMLElement>((props, ref) => (
-  <Block
-    data-baseweb="typo-h5"
-    as={props.as || 'h5'}
-    {...props}
-    font={props.font || 'font650'}
-    color={props.color || 'colorPrimary'}
-    ref={ref}
-  />
-));
-H5.displayName = 'H5';
-
-export const H6 = React.forwardRef<BlockPropsT, HTMLElement>((props, ref) => (
-  <Block
-    data-baseweb="typo-h6"
-    as={props.as || 'h6'}
-    {...props}
-    font={props.font || 'font550'}
-    color={props.color || 'colorPrimary'}
-    ref={ref}
-  />
-));
-H6.displayName = 'H6';
-
-export const Label1 = React.forwardRef<BlockPropsT, HTMLElement>(
+export const HeadingXXLarge = React.forwardRef<BlockPropsT, HTMLElement>(
   (props, ref) => (
     <Block
-      data-baseweb="typo-label1"
+      data-baseweb="typo-headingxxlarge"
+      as={props.as || 'h1'}
+      {...props}
+      font={props.font || 'font1050'}
+      color={props.color || 'colorPrimary'}
+      ref={ref}
+    />
+  ),
+);
+HeadingXXLarge.displayName = 'HeadingXXLarge';
+
+export const HeadingXLarge = React.forwardRef<BlockPropsT, HTMLElement>(
+  (props, ref) => (
+    <Block
+      data-baseweb="typo-headingxlarge"
+      as={props.as || 'h2'}
+      {...props}
+      font={props.font || 'font950'}
+      color={props.color || 'colorPrimary'}
+      ref={ref}
+    />
+  ),
+);
+HeadingXLarge.displayName = 'HeadingXLarge';
+
+export const HeadingLarge = React.forwardRef<BlockPropsT, HTMLElement>(
+  (props, ref) => (
+    <Block
+      data-baseweb="typo-headinglarge"
+      as={props.as || 'h3'}
+      {...props}
+      font={props.font || 'font850'}
+      color={props.color || 'colorPrimary'}
+      ref={ref}
+    />
+  ),
+);
+HeadingLarge.displayName = 'HeadingLarge';
+
+export const HeadingMedium = React.forwardRef<BlockPropsT, HTMLElement>(
+  (props, ref) => (
+    <Block
+      data-baseweb="typo-headingmedium"
+      as={props.as || 'h4'}
+      {...props}
+      font={props.font || 'font750'}
+      color={props.color || 'colorPrimary'}
+      ref={ref}
+    />
+  ),
+);
+HeadingMedium.displayName = 'HeadingMedium';
+
+export const HeadingSmall = React.forwardRef<BlockPropsT, HTMLElement>(
+  (props, ref) => (
+    <Block
+      data-baseweb="typo-headingsmall"
+      as={props.as || 'h5'}
+      {...props}
+      font={props.font || 'font650'}
+      color={props.color || 'colorPrimary'}
+      ref={ref}
+    />
+  ),
+);
+HeadingSmall.displayName = 'HeadingSmall';
+
+export const HeadingXSmall = React.forwardRef<BlockPropsT, HTMLElement>(
+  (props, ref) => (
+    <Block
+      data-baseweb="typo-headingxsmall"
+      as={props.as || 'h6'}
+      {...props}
+      font={props.font || 'font550'}
+      color={props.color || 'colorPrimary'}
+      ref={ref}
+    />
+  ),
+);
+HeadingXSmall.displayName = 'HeadingXSmall';
+
+export const LabelLarge = React.forwardRef<BlockPropsT, HTMLElement>(
+  (props, ref) => (
+    <Block
+      data-baseweb="typo-labellarge"
       {...props}
       font={props.font || 'font450'}
       color={props.color || 'colorPrimary'}
@@ -145,12 +157,12 @@ export const Label1 = React.forwardRef<BlockPropsT, HTMLElement>(
     />
   ),
 );
-Label1.displayName = 'Label1';
+LabelLarge.displayName = 'LabelLarge';
 
-export const Label2 = React.forwardRef<BlockPropsT, HTMLElement>(
+export const LabelMedium = React.forwardRef<BlockPropsT, HTMLElement>(
   (props, ref) => (
     <Block
-      data-baseweb="typo-label2"
+      data-baseweb="typo-labelmedium"
       {...props}
       font={props.font || 'font350'}
       color={props.color || 'colorPrimary'}
@@ -158,12 +170,12 @@ export const Label2 = React.forwardRef<BlockPropsT, HTMLElement>(
     />
   ),
 );
-Label2.displayName = 'Label2';
+LabelMedium.displayName = 'LabelMedium';
 
-export const Label3 = React.forwardRef<BlockPropsT, HTMLElement>(
+export const LabelSmall = React.forwardRef<BlockPropsT, HTMLElement>(
   (props, ref) => (
     <Block
-      data-baseweb="typo-label3"
+      data-baseweb="typo-labelsmall"
       {...props}
       font={props.font || 'font250'}
       color={props.color || 'colorPrimary'}
@@ -171,12 +183,12 @@ export const Label3 = React.forwardRef<BlockPropsT, HTMLElement>(
     />
   ),
 );
-Label3.displayName = 'Label3';
+LabelSmall.displayName = 'LabelSmall';
 
-export const Label4 = React.forwardRef<BlockPropsT, HTMLElement>(
+export const LabelXSmall = React.forwardRef<BlockPropsT, HTMLElement>(
   (props, ref) => (
     <Block
-      data-baseweb="typo-label4"
+      data-baseweb="typo-labelxsmall"
       {...props}
       font={props.font || 'font150'}
       color={props.color || 'colorPrimary'}
@@ -184,12 +196,12 @@ export const Label4 = React.forwardRef<BlockPropsT, HTMLElement>(
     />
   ),
 );
-Label4.displayName = 'Label4';
+LabelXSmall.displayName = 'LabelXSmall';
 
-export const Paragraph1 = React.forwardRef<BlockPropsT, HTMLElement>(
+export const ParagraphLarge = React.forwardRef<BlockPropsT, HTMLElement>(
   (props, ref) => (
     <Block
-      data-baseweb="typo-p1"
+      data-baseweb="typo-paragraphlarge"
       as={props.as || 'p'}
       {...props}
       font={props.font || 'font400'}
@@ -198,12 +210,12 @@ export const Paragraph1 = React.forwardRef<BlockPropsT, HTMLElement>(
     />
   ),
 );
-Paragraph1.displayName = 'Paragraph1';
+ParagraphLarge.displayName = 'ParagraphLarge';
 
-export const Paragraph2 = React.forwardRef<BlockPropsT, HTMLElement>(
+export const ParagraphMedium = React.forwardRef<BlockPropsT, HTMLElement>(
   (props, ref) => (
     <Block
-      data-baseweb="typo-p2"
+      data-baseweb="typo-paragraphmedium"
       as={props.as || 'p'}
       {...props}
       font={props.font || 'font300'}
@@ -212,12 +224,12 @@ export const Paragraph2 = React.forwardRef<BlockPropsT, HTMLElement>(
     />
   ),
 );
-Paragraph2.displayName = 'Paragraph2';
+ParagraphMedium.displayName = 'ParagraphMedium';
 
-export const Paragraph3 = React.forwardRef<BlockPropsT, HTMLElement>(
+export const ParagraphSmall = React.forwardRef<BlockPropsT, HTMLElement>(
   (props, ref) => (
     <Block
-      data-baseweb="typo-p3"
+      data-baseweb="typo-paragraphsmall"
       as={props.as || 'p'}
       {...props}
       font={props.font || 'font200'}
@@ -226,12 +238,12 @@ export const Paragraph3 = React.forwardRef<BlockPropsT, HTMLElement>(
     />
   ),
 );
-Paragraph3.displayName = 'Paragraph3';
+ParagraphSmall.displayName = 'ParagraphSmall';
 
-export const Paragraph4 = React.forwardRef<BlockPropsT, HTMLElement>(
+export const ParagraphXSmall = React.forwardRef<BlockPropsT, HTMLElement>(
   (props, ref) => (
     <Block
-      data-baseweb="typo-p4"
+      data-baseweb="typo-paragraphxsmall"
       as={props.as || 'p'}
       {...props}
       font={props.font || 'font100'}
@@ -240,10 +252,29 @@ export const Paragraph4 = React.forwardRef<BlockPropsT, HTMLElement>(
     />
   ),
 );
-Paragraph4.displayName = 'Paragraph4';
+ParagraphXSmall.displayName = 'ParagraphXSmall';
 
 // Aliases for backwards compatability
-export const Display = Display1;
+export const Display = DisplayLarge;
+export const Display1 = DisplayLarge;
+export const Display2 = DisplayMedium;
+export const Display3 = DisplaySmall;
+export const Display4 = DisplayXSmall;
+export const H1 = HeadingXXLarge;
+export const H2 = HeadingXLarge;
+export const H3 = HeadingLarge;
+export const H4 = HeadingMedium;
+export const H5 = HeadingSmall;
+export const H6 = HeadingXSmall;
+export const Paragraph1 = ParagraphLarge;
+export const Paragraph2 = ParagraphMedium;
+export const Paragraph3 = ParagraphSmall;
+export const Paragraph4 = ParagraphXSmall;
+export const Label1 = LabelLarge;
+export const Label2 = LabelMedium;
+export const Label3 = LabelSmall;
+export const Label4 = LabelXSmall;
+
 export const Caption1 = React.forwardRef<BlockPropsT, HTMLElement>(
   (props, ref) => (
     <Paragraph4 {...props} color={props.color || 'colorSecondary'} ref={ref} />


### PR DESCRIPTION
#### Description
This PR updates the typography component names to match the Base design system typography names, making it easier for engineers to find the typography component that matches the text styles found in Figma.

The existing names are moved to aliases to keep backward compatibility.

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
