### PR TITLE
feat(icon): allow icons to use colors from theme

### DIFF
--- a/src/icon/styled-components.js
+++ b/src/icon/styled-components.js
@@ -24,6 +24,9 @@ export function getSvgStyles({
   } else {
     $size = $theme.sizing.scale600;
   }
+  if ($color && $theme.colors[$color]) {
+    $color = $theme.colors[$color];
+  }
   return {
     display: 'inline-block',
     fill: $color || 'currentColor',


### PR DESCRIPTION
#### Description

Allow icons to use colors from theme. Seems fair since we do the same with size.

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
