### PR TITLE
fix(datepicker): clicking scroll in month selection closes datepicker

### DIFF
--- a/src/datepicker/calendar-header.js
+++ b/src/datepicker/calendar-header.js
@@ -340,6 +340,7 @@ export default class CalendarHeader extends React.Component<
     ) : (
       <OverriddenPopover
         placement="bottom"
+        mountNode={this.props.popoverMountNode}
         isOpen={this.state.isMonthYearDropdownOpen}
         onClick={() => {
           this.setState(prev => ({

--- a/src/datepicker/calendar.js
+++ b/src/datepicker/calendar.js
@@ -81,7 +81,6 @@ export default class Calendar extends React.Component<
     trapTabbing: false,
   };
 
-  root: React.ElementRef<*>;
   calendar: React.ElementRef<*>;
 
   constructor(props: CalendarPropsT) {
@@ -94,6 +93,7 @@ export default class Calendar extends React.Component<
       focused: false,
       date: this.getDateInView(),
       quickSelectId: null,
+      rootElement: null,
     };
   }
 
@@ -183,6 +183,7 @@ export default class Calendar extends React.Component<
         order={order}
         onMonthChange={this.changeMonth}
         onYearChange={this.changeYear}
+        popoverMountNode={this.state.rootElement}
       />
     );
   };
@@ -287,8 +288,8 @@ export default class Calendar extends React.Component<
         const activeElm = document.activeElement;
         // need to look for any tabindex >= 0 and ideally for not disabled
         // focusable by default elements like input, button, etc.
-        const focusable = this.root
-          ? this.root.querySelectorAll('[tabindex="0"]')
+        const focusable = this.state.rootElement
+          ? this.state.rootElement.querySelectorAll('[tabindex="0"]')
           : null;
         const length = focusable ? focusable.length : 0;
         if (event.shiftKey) {
@@ -552,7 +553,13 @@ export default class Calendar extends React.Component<
           <Root
             data-baseweb="calendar"
             ref={root => {
-              this.root = root;
+              if (
+                root &&
+                root instanceof HTMLElement &&
+                !this.state.rootElement
+              ) {
+                this.setState({rootElement: (root: HTMLElement)});
+              }
             }}
             aria-label="calendar"
             onKeyDown={this.props.trapTabbing ? this.handleTabbing : null}

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -220,25 +220,7 @@ export default class Datepicker extends React.Component<
               mountNode={this.props.mountNode}
               placement={PLACEMENT.bottom}
               isOpen={this.state.isOpen}
-              onClickOutside={event => {
-                // Required to check that items rendered in a sub-popover does not trigger close.
-                // For example, upon selecting an option from the month dropdown it would cause
-                // this code to run since the two popovers are DOM siblings rather than parent/child.
-                // There's likely a more robust way to check this, but ignores clicks from elements
-                // that are select options for now.
-                function isOption(element) {
-                  if (!element) return false;
-                  return element.getAttribute('role') === 'option';
-                }
-                if (
-                  isOption(event.target) ||
-                  isOption(event.target.parentElement)
-                ) {
-                  return;
-                }
-
-                this.close();
-              }}
+              onClickOutside={this.close}
               onEsc={this.handleEsc}
               content={
                 <Calendar

--- a/src/datepicker/types.js
+++ b/src/datepicker/types.js
@@ -112,6 +112,7 @@ export type CalendarInternalState = {
   focused: boolean,
   date: Date,
   quickSelectId: ?string,
+  rootElement: ?HTMLElement,
 };
 
 export type CalendarPropsT = {
@@ -169,6 +170,7 @@ export type CalendarPropsT = {
 export type HeaderPropsT = CalendarPropsT & {
   date: Date,
   order: number,
+  popoverMountNode: ?HTMLElement,
 };
 
 export type DatepickerPropsT = CalendarPropsT & {


### PR DESCRIPTION
#### Description

When clicking the popover which contains `calendar-header` in the datepicker, `onClickOutside` in the popover that contains the `calendar` is called. This is because the calendar-header is not rendered _in_ the parent popover, but in a separate node. The closing of the parent popover is prevented with a hack, that checks if the `role` of the clicked element is "option". However, if the scroll bar is clicked, the `menu`-element is the target, and the component closes(even though the user wanted to scroll). 

This PR renders calender-header popover as a child of the popover that renders the calendar, so that clicking calendar-header is not considered "outside" of the calendar. 

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
