### PR TITLE
docs(popover): fix typo in ref-handling description

### DIFF
--- a/documentation-site/examples/popover/ref-handling.js
+++ b/documentation-site/examples/popover/ref-handling.js
@@ -54,7 +54,7 @@ export default () => {
       >
         <CheckboxWithRef>
           Created a wrapper component that renders Checkbox and
-          passes popover's anchor props to the Chackbox's Root
+          passes popover's anchor props to the Checkbox's Root
           element.
         </CheckboxWithRef>
       </StatefulPopover>


### PR DESCRIPTION

#### Description

Single word typo in popover/ref-handling.js:  'Chackbox' -> 'Checkbox'
<!-- Describe your changes below in as much detail as possible -->

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
