### PR TITLE
docs(select): update select placeholders with working examples

### DIFF
--- a/documentation-site/components/yard/config/select.ts
+++ b/documentation-site/components/yard/config/select.ts
@@ -113,13 +113,13 @@ const SelectConfig: TConfig = {
     },
     options: {
       value: `[
-        {label: 'AliceBlue', id: '#F0F8FF'},
-        {label: 'AntiqueWhite', id: '#FAEBD7'},
-        {label: 'Aqua', id: '#00FFFF'},
-        {label: 'Aquamarine', id: '#7FFFD4'},
-        {label: 'Azure', id: '#F0FFFF'},
-        {label: 'Beige', id: '#F5F5DC'},
-      ]`,
+  {label: 'AliceBlue', id: '#F0F8FF'},
+  {label: 'AntiqueWhite', id: '#FAEBD7'},
+  {label: 'Aqua', id: '#00FFFF'},
+  {label: 'Aquamarine', id: '#7FFFD4'},
+  {label: 'Azure', id: '#F0FFFF'},
+  {label: 'Beige', id: '#F5F5DC'},
+]`,
       type: PropTypes.Array,
       description: `Options to be displayed in the dropdown.
         If an option has a disabled prop value set to true it will be rendered as a disabled option in the dropdown.`,
@@ -136,14 +136,14 @@ const SelectConfig: TConfig = {
       type: PropTypes.Function,
       description:
         'A custom method to get a display value for a dropdown option.',
-      placeholder: '({opt, state}) => opt.label',
+      placeholder: '({option}) => option.label',
     },
     getValueLabel: {
       value: undefined,
       type: PropTypes.Function,
       description:
         'A custom method to get a display value for a selected option.',
-      placeholder: '({opt}) => opt.label',
+      placeholder: '({option}) => option.label',
     },
     labelKey: {
       value: undefined,


### PR DESCRIPTION
#### Description

Update select placeholders with working examples and remove unnecessary spaces

Before: 
![baseweb design_components_select_](https://user-images.githubusercontent.com/1285326/70307459-10b8e800-17be-11ea-93e4-7e417369f602.png)

After: 
![localhost_3000_components_select (1)](https://user-images.githubusercontent.com/1285326/70307478-1adae680-17be-11ea-826d-0f4dd9fba6f4.png)
