### PR TITLE
fix(select): use quotation marks for creatable options

### DIFF
--- a/src/select/__tests__/select.e2e.js
+++ b/src/select/__tests__/select.e2e.js
@@ -127,7 +127,7 @@ describe('select', () => {
       optionAtPosition(1),
       select => select.innerText,
     );
-    expect(option1Text).toBe('Create "Paris"');
+    expect(option1Text).toBe('Create “Paris”');
     await page.click(optionAtPosition(1));
     const inputValue = await page.$eval(
       selectors.selectedList,

--- a/src/select/select-component.js
+++ b/src/select/select-component.js
@@ -427,14 +427,10 @@ class Select extends React.Component<
         $isHighlighted: boolean,
       },
     },
-  ): React.Node => {
-    if (option.isCreatable) {
-      return (
-        locale.select.create + ' ' + '"' + option[this.props.labelKey] + '"'
-      );
-    }
-    return option[this.props.labelKey];
-  };
+  ): React.Node =>
+    option.isCreatable
+      ? `${locale.select.create} “${option[this.props.labelKey]}”`
+      : option[this.props.labelKey];
 
   getValueLabel = ({option}: {option: OptionT}): React.Node => {
     return option[this.props.labelKey];


### PR DESCRIPTION
#### Description

Use quotation marks instead of straight quotes for creatable options.
See https://practicaltypography.com/straight-and-curly-quotes.html

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
