### PR TITLE
fix(select): merge StatefulMenu overrides

### DIFF
--- a/src/select/__tests__/dropdown.test.js
+++ b/src/select/__tests__/dropdown.test.js
@@ -89,4 +89,30 @@ describe('SelectDropdown', function() {
       'OptionContent gets correct props when an option is selected',
     );
   });
+
+  test('StatefulMenu overrides merge with default overrides', function() {
+    const prevOverrides = {...wrapper.find(StatefulMenu).props().overrides};
+    const emptyStateOverrides = {
+      EmptyState: {
+        style: {
+          backgroundColor: 'red',
+        },
+      },
+    };
+    wrapper.setProps({
+      overrides: {
+        StatefulMenu: {
+          props: {
+            overrides: emptyStateOverrides,
+          },
+        },
+      },
+    });
+    expect(wrapper.find(StatefulMenu).props().overrides.EmptyState).toEqual(
+      emptyStateOverrides.EmptyState,
+    );
+    expect(wrapper.find(StatefulMenu).props().overrides.Option).toEqual(
+      prevOverrides.Option,
+    );
+  });
 });

--- a/src/select/dropdown.js
+++ b/src/select/dropdown.js
@@ -119,10 +119,11 @@ export default class SelectDropdown extends React.Component<DropdownPropsT> {
       overrides.DropdownListItem,
       StyledDropdownListItem,
     );
-    const [OverriddenStatefulMenu, statefulMenuProps] = getOverrides(
-      overrides.StatefulMenu,
-      StatefulMenu,
-    );
+    const [
+      OverriddenStatefulMenu,
+      // $FlowFixMe
+      {overrides: statefulMenuOverrides = {}, ...restStatefulMenuProps},
+    ] = getOverrides(overrides.StatefulMenu, StatefulMenu);
     const highlightedIndex = this.getHighlightedIndex();
     return (
       <DropdownContainer
@@ -174,9 +175,10 @@ export default class SelectDropdown extends React.Component<DropdownPropsT> {
             {
               List: overrides.Dropdown || {},
               Option: overrides.DropdownOption || {},
+              ...statefulMenuOverrides,
             },
           )}
-          {...statefulMenuProps}
+          {...restStatefulMenuProps}
         />
       </DropdownContainer>
     );


### PR DESCRIPTION
#### Description

Merge StatefulMenu overrides instead of replacing. This fixes the issue of getOptionLabel not working when you try overriding the StatefulMenu’s EmptyState.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
