### PR TITLE
docs(setup): fix styletron section

### DIFF
--- a/documentation-site/pages/getting-started/setup.mdx
+++ b/documentation-site/pages/getting-started/setup.mdx
@@ -24,8 +24,8 @@ yarn add baseui styletron-engine-atomic styletron-react
 npm install baseui styletron-engine-atomic styletron-react
 ```
 
-Base Web comes with both Flow and TypeScript. Styletron only with Flow. If you use
-TypeScript there are an external declarations:
+Base Web comes with both Flow and TypeScript. Styletron comes only with Flow. However, if you use
+TypeScript there are external TypeScript declarations:
 
 ```bash
 yarn add @types/styletron-standard @types/styletron-react @types/styletron-engine-atomic


### PR DESCRIPTION
#### Description

I noticed that the text read:

> **an** example declaration**s**

So I thought I'll just fix it (can't use `an` and plural)

#### Scope

- [x] Docs: Fix typo 😇 
- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
