### PR TITLE
fix(modal): handle nested modal overflow reset

### DIFF
--- a/src/modal/__tests__/modal.test.js
+++ b/src/modal/__tests__/modal.test.js
@@ -149,6 +149,53 @@ describe('Modal', () => {
     expect(body.style.overflow).toBe('');
   });
 
+  describe('nested modals', () => {
+    const TwoModals = ({isOpen1 = false, isOpen2 = false}) => (
+      <>
+        <Modal isOpen={isOpen1}>Modal 1</Modal>
+        <Modal isOpen={isOpen2}>Modal 2</Modal>,
+      </>
+    );
+
+    test('resets body scroll when top closes first', () => {
+      wrapper = mount(<TwoModals />);
+
+      const body = ((document.body: any): HTMLBodyElement);
+      expect(body.style.overflow).toBe('');
+
+      wrapper.setProps({isOpen1: true, isOpen2: false});
+      expect(body.style.overflow).toBe('hidden');
+
+      wrapper.setProps({isOpen1: true, isOpen2: true});
+      expect(body.style.overflow).toBe('hidden');
+
+      wrapper.setProps({isOpen1: true, isOpen2: false});
+      expect(body.style.overflow).toBe('hidden');
+
+      wrapper.setProps({isOpen1: false, isOpen2: false});
+      expect(body.style.overflow).toBe('');
+    });
+
+    test('resets body scroll when bottom closes first', () => {
+      wrapper = mount(<TwoModals />);
+
+      const body = ((document.body: any): HTMLBodyElement);
+      expect(body.style.overflow).toBe('');
+
+      wrapper.setProps({isOpen1: true, isOpen2: false});
+      expect(body.style.overflow).toBe('hidden');
+
+      wrapper.setProps({isOpen1: true, isOpen2: true});
+      expect(body.style.overflow).toBe('hidden');
+
+      wrapper.setProps({isOpen1: false, isOpen2: true});
+      expect(body.style.overflow).toBe('');
+
+      wrapper.setProps({isOpen1: false, isOpen2: false});
+      expect(body.style.overflow).toBe('');
+    });
+  });
+
   test('override components', () => {
     const Root = styled('div', {});
     const Backdrop = styled('div', {});

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -118,7 +118,11 @@ class Modal extends React.Component<ModalPropsT, ModalStateT> {
     const mountNode = this.getMountNode();
     const lastStyle = this.lastMountNodeOverflowStyle;
     if (mountNode && lastStyle !== null) {
-      mountNode.style.overflow = lastStyle || '';
+      // If overflow is not 'hidden', something else has changed the
+      // overflow style and we shouldn't try to reset it.
+      if (mountNode.style.overflow === 'hidden') {
+        mountNode.style.overflow = lastStyle || '';
+      }
       this.lastMountNodeOverflowStyle = null;
     }
   }


### PR DESCRIPTION
Resolves https://github.com/uber/baseweb/issues/2435

### Problem
When closing nested modals simultaneously (e.g. press ESC), the bottom one can unmount before the top one. This causes the top modal to reset the mountNode's overflow to 'hidden', which locks scrolling.
The flow goes like this:
1. Bottom modal mounts, caches last overflow as '', and sets overflow to 'hidden'
2. Top modal mounts, caches last overflow as 'hidden', and sets overflow to 'hidden'
3. Bottom modal unmounts and resets overflow to ''
4. Top modal unmounts and resets overflow to 'hidden'

### Solution
This change bails out of resetting overflow if it's changed since the modal mounted.
So now the flow would be:
1. Bottom modal mounts, caches last overflow as '', and sets overflow to 'hidden'
2. Top modal mounts, caches last overflow as 'hidden', and sets overflow to 'hidden'
3. Bottom modal unmounts and resets overflow to ''
4. Top modal unmounts and bails out because overflow is no longer
'hidden'

I'm not 100% sure this is the best approach, so let me know if you have a better idea.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
