### PR TITLE
fix(radio): radio's onChange prop typescript definition

### DIFF
--- a/documentation-site/examples/radio/basic.tsx
+++ b/documentation-site/examples/radio/basic.tsx
@@ -6,7 +6,7 @@ export default () => {
   return (
     <RadioGroup
       name="radio group"
-      onChange={e => setValue((e.target as HTMLInputElement).value)}
+      onChange={e => setValue(e.target.value)}
       value={value}
     >
       <Radio value="1">First</Radio>

--- a/documentation-site/examples/radio/error.tsx
+++ b/documentation-site/examples/radio/error.tsx
@@ -7,7 +7,7 @@ export default () => {
     <RadioGroup
       isError
       name="radio group"
-      onChange={e => setValue((e.target as HTMLInputElement).value)}
+      onChange={e => setValue(e.target.value)}
       value={value}
     >
       <Radio value="1">First</Radio>

--- a/documentation-site/examples/radio/horizontal-align.tsx
+++ b/documentation-site/examples/radio/horizontal-align.tsx
@@ -7,7 +7,7 @@ export default () => {
     <RadioGroup
       align="horizontal"
       name="radio group"
-      onChange={e => setValue((e.target as HTMLInputElement).value)}
+      onChange={e => setValue(e.target.value)}
       value={value}
     >
       <Radio value="1">First</Radio>

--- a/documentation-site/examples/radio/overrides.tsx
+++ b/documentation-site/examples/radio/overrides.tsx
@@ -7,7 +7,7 @@ export default () => {
   return (
     <RadioGroup
       name="radio group"
-      onChange={e => setValue((e.target as HTMLInputElement).value)}
+      onChange={e => setValue(e.target.value)}
       value={value}
     >
       <Radio

--- a/src/radio/index.d.ts
+++ b/src/radio/index.d.ts
@@ -27,7 +27,7 @@ export interface StatefulContainerProps {
   children?: React.ReactNode;
   initialState?: State;
   stateReducer: StateReducer;
-  onChange?: React.FormEventHandler<HTMLInputElement>;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
   autoFocus?: boolean;
 }
 
@@ -35,7 +35,7 @@ export class StatefulContainer extends React.Component<
   StatefulContainerProps,
   State
 > {
-  onChange(e: React.FormEventHandler<HTMLInputElement>): void;
+  onChange(e: React.ChangeEventHandler<HTMLInputElement>): void;
   stateReducer(type: string, e: React.SyntheticEvent<HTMLInputElement>): void;
 }
 
@@ -45,7 +45,7 @@ export interface StatefulRadioGroupProps {
   initialState?: State;
   autoFocus?: boolean;
   name?: string;
-  onChange?: React.FormEventHandler<HTMLInputElement>;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
   align?: 'horizontal' | 'vertical';
 }
 
@@ -64,7 +64,7 @@ export interface RadioGroupProps {
   align?: 'horizontal' | 'vertical';
   name?: string;
   labelPlacement?: 'top' | 'right' | 'bottom' | 'left';
-  onChange?: React.FormEventHandler<HTMLInputElement>;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
   onMouseEnter?: React.MouseEventHandler<HTMLInputElement>;
   onMouseLeave?: React.MouseEventHandler<HTMLInputElement>;
   onFocus?: React.FocusEventHandler<HTMLInputElement>;
@@ -96,7 +96,7 @@ export interface RadioProps {
   isError?: boolean;
   labelPlacement?: 'top' | 'right' | 'bottom' | 'left';
   name?: string;
-  onChange?: React.FormEventHandler<HTMLInputElement>;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
   onMouseEnter?: React.MouseEventHandler<HTMLInputElement>;
   onMouseLeave?: React.MouseEventHandler<HTMLInputElement>;
   onFocus?: React.FocusEventHandler<HTMLInputElement>;


### PR DESCRIPTION
Fixes #2469 

#### Description

Update the onChange props typescript definition all radio components (Radio, RadioGroup, StatefulRadioGroup & StatefulContainer)

from `onChange?: React.FormEventHandler<HTMLInputElement>;`

to `onChange?: React.ChangeEventHandler<HTMLInputElement>;`

This removes the need to cast the event's target as a "HTMLInputElement"  inside the onChange callback

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
