### PR TITLE
Change StyledTable overflowX to 'auto'

### DIFF
--- a/src/table/styled-components.js
+++ b/src/table/styled-components.js
@@ -21,7 +21,7 @@ const StyledTableElement = styled<{}>('div', ({$theme}) => {
     display: 'flex',
     flexDirection: 'column',
     height: '100%',
-    overflowX: 'scroll',
+    overflowX: 'auto',
   };
 });
 


### PR DESCRIPTION
#### Description

This hides the horizontal scrollbar when content doesn't require it by default.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
