### PR TITLE
docs(sidebar): fix sidebar links

### DIFF
--- a/documentation-site/components/sidebar.js
+++ b/documentation-site/components/sidebar.js
@@ -7,70 +7,50 @@ LICENSE file in the root directory of this source tree.
 
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-import React from 'react';
+import * as React from 'react';
 import {withStyle} from 'baseui';
-import {Navigation, StyledNavItem as NavItem} from 'baseui/side-navigation';
-import {Label2, Label3} from 'baseui/typography';
-import Link from 'next/link';
+import {Navigation, StyledNavItem} from 'baseui/side-navigation';
 
 import Routes from '../routes';
 
-const StyledNavItem = withStyle(NavItem, ({$theme, $active}) => {
-  const styleOverride = {};
-
-  if ($theme.name.startsWith('dark')) {
-    if ($active) {
-      styleOverride.background = $theme.colors.backgroundSecondary;
-    }
-  }
-  return {
+const CustomStyledNavItem = withStyle(
+  StyledNavItem,
+  ({$theme, $active, $hasItemId, $level}) => ({
     paddingTop: $theme.sizing.scale200,
     paddingBottom: $theme.sizing.scale200,
-    ...styleOverride,
-  };
-});
+    ...($theme.name.startsWith('dark') && $active
+      ? {
+          backgroundColor: $theme.colors.backgroundSecondary,
+        }
+      : {}),
+    ...(!$hasItemId || $level === 1
+      ? {
+          textTransform: 'uppercase',
+          ...($level === 1
+            ? $theme.typography.font350
+            : $theme.typography.font250),
+        }
+      : {}),
+  }),
+);
 
-const removeSlash = path => {
-  if (path) {
-    return path.replace(/\/$/, '');
-  }
-  return path;
-};
+const removeSlash = path => path && path.replace(/\/$/, '');
 
-function CustomNavItem(props) {
-  const {item, onSelect, onClick, onKeyDown, ...sharedProps} = props;
-  const Label = props.$level === 1 ? Label2 : Label3;
+const CustomNavItem = ({
+  item,
+  onSelect,
+  onClick,
+  onKeyDown,
+  ...sharedProps
+}) => (
+  <CustomStyledNavItem $hasItemId={!!item.itemId} {...sharedProps}>
+    {item.title}
+  </CustomStyledNavItem>
+);
 
-  const NavLink = ({item}) => (
-    <Link passHref={true} href={item.itemId}>
-      <StyledNavItem {...sharedProps}>{item.title}</StyledNavItem>
-    </Link>
-  );
-
-  if (item.itemId && props.$level === 1)
-    return (
-      <Label overrides={{Block: {style: {textTransform: 'uppercase'}}}}>
-        <NavLink item={item} />
-      </Label>
-    );
-
-  if (item.itemId) {
-    return <NavLink item={item} />;
-  }
-
-  return (
-    <Label overrides={{Block: {style: {textTransform: 'uppercase'}}}}>
-      <StyledNavItem {...sharedProps}>{item.title}</StyledNavItem>
-    </Label>
-  );
-}
-
-function activePredicate(item, location) {
-  return (
-    (location && removeSlash(location) === removeSlash(item.itemId)) ||
-    (!location && item.itemId === '/')
-  );
-}
+const activePredicate = (item, location) =>
+  (location && removeSlash(location) === removeSlash(item.itemId)) ||
+  (!location && item.itemId === '/');
 
 export default ({path}) => {
   return (
@@ -79,9 +59,7 @@ export default ({path}) => {
       activePredicate={activePredicate}
       items={Routes}
       overrides={{
-        NavItem: {
-          component: CustomNavItem,
-        },
+        NavItem: CustomNavItem,
       }}
     />
   );


### PR DESCRIPTION
Fix sidebar links, which were unnecessarily nested inside Labels and had href attributes on divs. Now, cmd+click will properly open link in a new tab.

Before: 
![sidebar-before](https://user-images.githubusercontent.com/1285326/70847419-0aa7b480-1e19-11ea-864e-21c2b11538a8.png)
After: 
![sidebar-after](https://user-images.githubusercontent.com/1285326/70847424-12ffef80-1e19-11ea-96f3-6c873f6dbcb6.png)
