### PR TITLE
feat(datepicker): allow for endDate in quickSelectOptions

### DIFF
--- a/documentation-site/components/yard/config/datepicker.ts
+++ b/documentation-site/components/yard/config/datepicker.ts
@@ -1,3 +1,9 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
 import {Datepicker, ORIENTATION} from 'baseui/datepicker';
 import {SIZE} from 'baseui/input';
 import {PropTypes} from 'react-view';
@@ -93,7 +99,7 @@ const DatepickerConfig: TConfig = {
       value: undefined,
       type: PropTypes.Array,
       description:
-        'Array of custom options (Array<{ id: string; beginDate: Date }>) displayed in the quick select. Overrides default options if provided.',
+        'Array of custom options (Array<{ id: string; beginDate: Date; endDate?: Date }>) displayed in the quick select. Overrides default options if provided.',
       hidden: true,
     },
     filterDate: {

--- a/src/datepicker/calendar.js
+++ b/src/datepicker/calendar.js
@@ -493,7 +493,10 @@ export default class Calendar extends React.Component<
                     if (this.props.onChange) {
                       if (this.props.range) {
                         this.props.onChange({
-                          date: [params.option.beginDate, NOW],
+                          date: [
+                            params.option.beginDate,
+                            params.option.endDate || NOW,
+                          ],
                         });
                       } else {
                         this.props.onChange({date: params.option.beginDate});

--- a/src/datepicker/index.d.ts
+++ b/src/datepicker/index.d.ts
@@ -53,7 +53,7 @@ export interface CalendarProps {
   autoFocusCalendar?: boolean;
   excludeDates?: Date[];
   quickSelect?: boolean;
-  quickSelectOptions?: Array<{id: string; beginDate: Date}>;
+  quickSelectOptions?: Array<{id: string; beginDate: Date; endDate?: Date}>;
   filterDate?: (day: Date) => boolean;
   highlightedDate?: Date;
   includeDates?: Date[];

--- a/src/datepicker/types.js
+++ b/src/datepicker/types.js
@@ -123,7 +123,7 @@ export type CalendarPropsT = {
   /** Display select for quickly choosing date ranges. `range` must be true as well. */
   quickSelect?: boolean,
   /** Array of custom options displayed in the quick select. Overrides default options if provided. */
-  quickSelectOptions?: Array<{id: string, beginDate: Date}>,
+  quickSelectOptions?: Array<{id: string, beginDate: Date, endDate?: Date}>,
   /** A filter function that is called to check the disabled state of a day. If `false` is returned the day is considered to be disabled. */
   filterDate?: ?(day: Date) => boolean,
   /** Indicates a highlighted date on hover and keyboard navigation */


### PR DESCRIPTION
#### Description

Allow for endDate in quickSelectOptions, so user can build custom ranges.

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
