### PR TITLE
fix(docs): rename Datepicker basic usage example

### DIFF
--- a/documentation-site/pages/components/datepicker.mdx
+++ b/documentation-site/pages/components/datepicker.mdx
@@ -46,7 +46,7 @@ A simple and reusable component to work with or select a date or a range of date
 
 ## Examples
 
-<Example title="Datepicker" path="datepicker/basic.js">
+<Example title="Datepicker basic usage" path="datepicker/basic.js">
   <DatepickerBasic />
 </Example>
 


### PR DESCRIPTION
Rename Datepicker basic usage example to avoid React warning:
```
Warning: Encountered two children with the same key, `Datepicker`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```
