### PR TITLE
docs(button-group): add relevant theme keys

### DIFF
--- a/documentation-site/components/yard/config/button-group.ts
+++ b/documentation-site/components/yard/config/button-group.ts
@@ -38,6 +38,10 @@ const ButtonGroupConfig: TConfig = {
     'buttonMinimalActive',
     'buttonDisabledFill',
     'buttonDisabledText',
+    'buttonPrimarySelectedFill',
+    'buttonPrimarySelectedText',
+    'buttonSecondarySelectedFill',
+    'buttonSecondarySelectedText',
   ],
   props: {
     children: {


### PR DESCRIPTION
#### Description

There are missing theme color keys for button group component

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
