### PR TITLE
docs(sidebar): clean up sidebar links

### DIFF
--- a/documentation-site/components/sidebar.js
+++ b/documentation-site/components/sidebar.js
@@ -7,70 +7,49 @@ LICENSE file in the root directory of this source tree.
 
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-import React from 'react';
+import * as React from 'react';
 import {withStyle} from 'baseui';
-import {Navigation, StyledNavItem as NavItem} from 'baseui/side-navigation';
-import {Label2, Label3} from 'baseui/typography';
+import {Navigation, StyledNavItem, StyledNavLink} from 'baseui/side-navigation';
 import Link from 'next/link';
 
 import Routes from '../routes';
 
-const StyledNavItem = withStyle(NavItem, ({$theme, $active}) => {
-  const styleOverride = {};
-
-  if ($theme.name.startsWith('dark')) {
-    if ($active) {
-      styleOverride.background = $theme.colors.backgroundSecondary;
-    }
-  }
-  return {
+const CustomStyledNavItem = withStyle(
+  StyledNavItem,
+  ({$theme, $active, $hasItemId, $level}) => ({
     paddingTop: $theme.sizing.scale200,
     paddingBottom: $theme.sizing.scale200,
-    ...styleOverride,
-  };
-});
+    ...($theme.name.startsWith('dark') && $active
+      ? {
+          background: $theme.colors.backgroundSecondary,
+        }
+      : {}),
+    ...(!$hasItemId || $level === 1
+      ? {
+          textTransform: 'uppercase',
+          ...($level === 1
+            ? $theme.typography.font350
+            : $theme.typography.font250),
+        }
+      : {}),
+  }),
+);
 
-const removeSlash = path => {
-  if (path) {
-    return path.replace(/\/$/, '');
-  }
-  return path;
-};
+const removeSlash = path => path && path.replace(/\/$/, '');
 
-function CustomNavItem(props) {
-  const {item, onSelect, onClick, onKeyDown, ...sharedProps} = props;
-  const Label = props.$level === 1 ? Label2 : Label3;
+const CustomNavItem = ({item, onSelect, onClick, onKeyDown, ...restProps}) => (
+  <CustomStyledNavItem $hasItemId={!!item.itemId} {...restProps} />
+);
 
-  const NavLink = ({item}) => (
-    <Link passHref={true} href={item.itemId}>
-      <StyledNavItem {...sharedProps}>{item.title}</StyledNavItem>
-    </Link>
-  );
+const CustomNavLink = props => (
+  <Link href={props.href}>
+    <StyledNavLink {...props} />
+  </Link>
+);
 
-  if (item.itemId && props.$level === 1)
-    return (
-      <Label overrides={{Block: {style: {textTransform: 'uppercase'}}}}>
-        <NavLink item={item} />
-      </Label>
-    );
-
-  if (item.itemId) {
-    return <NavLink item={item} />;
-  }
-
-  return (
-    <Label overrides={{Block: {style: {textTransform: 'uppercase'}}}}>
-      <StyledNavItem {...sharedProps}>{item.title}</StyledNavItem>
-    </Label>
-  );
-}
-
-function activePredicate(item, location) {
-  return (
-    (location && removeSlash(location) === removeSlash(item.itemId)) ||
-    (!location && item.itemId === '/')
-  );
-}
+const activePredicate = (item, location) =>
+  (location && removeSlash(location) === removeSlash(item.itemId)) ||
+  (!location && item.itemId === '/');
 
 export default ({path}) => {
   return (
@@ -79,9 +58,8 @@ export default ({path}) => {
       activePredicate={activePredicate}
       items={Routes}
       overrides={{
-        NavItem: {
-          component: CustomNavItem,
-        },
+        NavItem: CustomNavItem,
+        NavLink: CustomNavLink,
       }}
     />
   );


### PR DESCRIPTION
Second attempt at #2489, this time keeping Link from 'next/link'.

#### Description

Clean up sidebar links, which were unnecessarily nested inside Labels and had href attributes on divs. Now, cmd+click will properly open link in a new tab.

Before: 
![sidebar-before](https://user-images.githubusercontent.com/1285326/71215406-80be7800-226c-11ea-8a22-eb7a90d6dda5.png)

After: 
<img width="1390" alt="sidebar-after3" src="https://user-images.githubusercontent.com/1285326/71221705-79a26480-2282-11ea-9323-6929e1963aa5.png">
