### PR TITLE
docs(spinner): update example to use withstyle rather than $style

### DIFF
--- a/documentation-site/examples/spinner/next-custom.js
+++ b/documentation-site/examples/spinner/next-custom.js
@@ -1,15 +1,17 @@
 // @flow
 
 import * as React from 'react';
+import {withStyle} from 'baseui';
 import {StyledSpinnerNext} from 'baseui/spinner';
 
-export default () => (
-  <StyledSpinnerNext
-    $style={({$theme}) => ({
-      width: $theme.sizing.scale2400, // 96px
-      height: $theme.sizing.scale2400, // 96px
-      borderWidth: $theme.sizing.scale500, // 12px
-      borderTopColor: $theme.colors.negative,
-    })}
-  />
+const ExtraLargeSpinner = withStyle<typeof StyledSpinnerNext, {}>(
+  StyledSpinnerNext,
+  ({$theme}) => ({
+    width: $theme.sizing.scale2400, // 96px
+    height: $theme.sizing.scale2400, // 96px
+    borderWidth: $theme.sizing.scale500, // 12px
+    borderTopColor: $theme.colors.negative,
+  }),
 );
+
+export default () => <ExtraLargeSpinner />;

--- a/documentation-site/examples/spinner/next-custom.js
+++ b/documentation-site/examples/spinner/next-custom.js
@@ -1,6 +1,5 @@
 // @flow
 
-import * as React from 'react';
 import {withStyle} from 'baseui';
 import {StyledSpinnerNext} from 'baseui/spinner';
 

--- a/documentation-site/examples/spinner/next-custom.js
+++ b/documentation-site/examples/spinner/next-custom.js
@@ -4,14 +4,11 @@ import * as React from 'react';
 import {withStyle} from 'baseui';
 import {StyledSpinnerNext} from 'baseui/spinner';
 
-const ExtraLargeSpinner = withStyle<typeof StyledSpinnerNext, {}>(
-  StyledSpinnerNext,
-  ({$theme}) => ({
-    width: $theme.sizing.scale2400, // 96px
-    height: $theme.sizing.scale2400, // 96px
-    borderWidth: $theme.sizing.scale500, // 12px
-    borderTopColor: $theme.colors.negative,
-  }),
-);
+const ExtraLargeSpinner = withStyle(StyledSpinnerNext, {
+  width: '96px',
+  height: '96px',
+  borderWidth: '12px',
+  borderTopColor: 'pink',
+});
 
-export default () => <ExtraLargeSpinner />;
+export default ExtraLargeSpinner;

--- a/documentation-site/examples/spinner/next-custom.tsx
+++ b/documentation-site/examples/spinner/next-custom.tsx
@@ -2,14 +2,11 @@ import * as React from 'react';
 import {withStyle} from 'baseui';
 import {StyledSpinnerNext} from 'baseui/spinner';
 
-const ExtraLargeSpinner = withStyle(
-  StyledSpinnerNext,
-  ({$theme}) => ({
-    width: $theme.sizing.scale2400, // 96px
-    height: $theme.sizing.scale2400, // 96px
-    borderWidth: $theme.sizing.scale500, // 12px
-    borderTopColor: $theme.colors.negative,
-  }),
-);
+const ExtraLargeSpinner = withStyle(StyledSpinnerNext, {
+  width: '96px',
+  height: '96px',
+  borderWidth: '12px',
+  borderTopColor: 'pink',
+});
 
-export default () => <ExtraLargeSpinner />;
+export default ExtraLargeSpinner;

--- a/documentation-site/examples/spinner/next-custom.tsx
+++ b/documentation-site/examples/spinner/next-custom.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react';
+import {withStyle} from 'baseui';
 import {StyledSpinnerNext} from 'baseui/spinner';
-import {Theme} from 'baseui/theme';
 
-export default () => (
-  <StyledSpinnerNext
-    $style={({$theme}: {$theme: Theme}) => ({
-      width: $theme.sizing.scale2400, // 96px
-      height: $theme.sizing.scale2400, // 96px
-      borderWidth: $theme.sizing.scale500, // 12px
-      borderTopColor: $theme.colors.negative,
-    })}
-  />
+const ExtraLargeSpinner = withStyle(
+  StyledSpinnerNext,
+  ({$theme}) => ({
+    width: $theme.sizing.scale2400, // 96px
+    height: $theme.sizing.scale2400, // 96px
+    borderWidth: $theme.sizing.scale500, // 12px
+    borderTopColor: $theme.colors.negative,
+  }),
 );
+
+export default () => <ExtraLargeSpinner />;

--- a/documentation-site/examples/spinner/next-custom.tsx
+++ b/documentation-site/examples/spinner/next-custom.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {withStyle} from 'baseui';
 import {StyledSpinnerNext} from 'baseui/spinner';
 

--- a/documentation-site/pages/components/spinner.mdx
+++ b/documentation-site/pages/components/spinner.mdx
@@ -97,7 +97,7 @@ Neat! If that isn't enough, the spinner also comes in three sizes...
   <SpinnerNextSize />
 </Example>
 
-If you want to customize the spinner's default styling, you can use the [`$style`](https://www.styletron.org/api/#styled) prop, which has access to all of your `baseui` theme properties.
+If you want to customize the default styling of the spinner you can extend it using [`withStyle`](/blog/base-web-v8/#themed-withstyle-function), which has access to all of your `baseui` theme properties.
 
 <Example title="Customizing" path="spinner/next-custom.js">
   <SpinnerNextCustom />
@@ -105,4 +105,4 @@ If you want to customize the spinner's default styling, you can use the [`$style
 
 In this example we modify the size of the spinner with `width`, `height`, and `borderWidth` as well as the highlight color with `borderTopColor`.
 
-You can also use `$style` to add margins to the spinner or align it within another element.
+You can also use `withStyle` to add margins to the spinner or align it within another element.

--- a/documentation-site/pages/components/spinner.mdx
+++ b/documentation-site/pages/components/spinner.mdx
@@ -97,12 +97,10 @@ Neat! If that isn't enough, the spinner also comes in three sizes...
   <SpinnerNextSize />
 </Example>
 
-If you want to customize the default styling of the spinner you can extend it using [`withStyle`](/blog/base-web-v8/#themed-withstyle-function), which has access to all of your `baseui` theme properties.
+If you want to customize the default styling of the spinner you can extend it using [`withStyle`](/blog/base-web-v8/#themed-withstyle-function).
 
 <Example title="Customizing" path="spinner/next-custom.js">
   <SpinnerNextCustom />
 </Example>
 
-In this example we modify the size of the spinner with `width`, `height`, and `borderWidth` as well as the highlight color with `borderTopColor`.
-
-You can also use `withStyle` to add margins to the spinner or align it within another element.
+In this example we modify the size of the spinner (via `width`, `height`, and `borderWidth`) as well as the highlight color (via `borderTopColor`). You could also use `withStyle` to add margins to the spinner or align it within another element.


### PR DESCRIPTION
update docs for `spinner` to use `withStyle` rather than `$style`