### PR TITLE
chore(border): update Card Root to follow BorderT pattern

### DIFF
--- a/src/card/styled-components.js
+++ b/src/card/styled-components.js
@@ -34,18 +34,9 @@ export const HeaderImage = styled<{}>('img', ({$theme}) => ({
 }));
 
 export const Root = styled<{}>('div', ({$theme}) => ({
-  borderTopWidth: '2px',
-  borderRightWidth: '2px',
-  borderBottomWidth: '2px',
-  borderLeftWidth: '2px',
-  borderTopStyle: 'solid',
-  borderRightStyle: 'solid',
-  borderBottomStyle: 'solid',
-  borderLeftStyle: 'solid',
-  borderTopColor: $theme.colors.borderOpaque,
-  borderRightColor: $theme.colors.borderOpaque,
-  borderBottomColor: $theme.colors.borderOpaque,
-  borderLeftColor: $theme.colors.borderOpaque,
+  borderWidth: '2px',
+  borderStyle: 'solid',
+  borderColor: $theme.colors.borderOpaque,
   borderTopLeftRadius: $theme.borders.surfaceBorderRadius,
   borderTopRightRadius: $theme.borders.surfaceBorderRadius,
   borderBottomLeftRadius: $theme.borders.surfaceBorderRadius,

--- a/src/table-semantic/styled-components.js
+++ b/src/table-semantic/styled-components.js
@@ -72,7 +72,10 @@ export const StyledTableHeadCell = styled<{}>('th', ({$theme}) => {
       top: '0',
       right: '100%',
       bottom: '0',
-      borderLeft: Object.values($theme.borders.border300).join(' '),
+      borderLeftColor: $theme.borders.border300.borderColor,
+      // $FlowFixMe
+      borderLeftStyle: $theme.borders.border300.borderStyle,
+      borderLeftWidth: $theme.borders.border300.borderWidth,
     },
 
     // We have to use pseudo elements to add the shadow to prevent


### PR DESCRIPTION
Update Card Root to follow BorderT pattern so it can be overridden with theme values without Styletron warnings. Also fix Table Semantic StyledTableHeadCell, which could potentially break since JS Object order is not guaranteed.