### PR TITLE
docs(sidebar): fix link missing href

### DIFF
--- a/documentation-site/components/sidebar.js
+++ b/documentation-site/components/sidebar.js
@@ -41,11 +41,15 @@ const CustomNavItem = ({item, onSelect, onClick, onKeyDown, ...restProps}) => (
   <CustomStyledNavItem $hasItemId={!!item.itemId} {...restProps} />
 );
 
-const CustomNavLink = props => (
-  <Link href={props.href}>
+const CustomNavLink = props => {
+  return props.href ? (
+    <Link href={props.href}>
+      <StyledNavLink {...props} />
+    </Link>
+  ) : (
     <StyledNavLink {...props} />
-  </Link>
-);
+  );
+};
 
 const activePredicate = (item, location) =>
   (location && removeSlash(location) === removeSlash(item.itemId)) ||


### PR DESCRIPTION
Fix an error being thrown when `href` is not provided to `Link`.

<img width="805" alt="Screen Shot 2019-12-23 at 3 38 45 PM" src="https://user-images.githubusercontent.com/1939257/71385172-8bde1480-259a-11ea-840b-c2fef07f5a58.png">

Solution: only use `Link` if an `href` is provided, otherwise use `StyledNavLink`.
