### PR TITLE
docs(select): stress importance of id and label as default properties

### DIFF
--- a/documentation-site/pages/components/select.mdx
+++ b/documentation-site/pages/components/select.mdx
@@ -43,6 +43,8 @@ Select menus in Base hover atop of a selection menu while providing a simple lis
 Proper spacing, color, and a check-mark are clear indicators of a selection. Each menu is
 scrollable, if applicable.
 
+Note: by default, `id` and `label` are default properties that Select components look for in options array objects. To adapt to custom properties, use the `labelKey` and `valueKey` to override the defaults.
+
 ## Examples
 
 <Example title="Select basic usage" path="select/controlled.js">


### PR DESCRIPTION
#### Description

there was no mention of the importance of having id and label properties in options array objects. the document does not explain the utalization of labelKey and valueKey.

Left a not on the documentation to stress it out.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
