### PR TITLE
fix(flex-grid): re-implement FlexGridItem to avoid nth-child selectors

### DIFF
--- a/src/flex-grid/__tests__/__snapshots__/flex-grid-item.test.js.snap
+++ b/src/flex-grid/__tests__/__snapshots__/flex-grid-item.test.js.snap
@@ -1,245 +1,100 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FlexGridItem flexGridItemMediaQueryStyle: {"flexGridColumnCount":1,"flexGridColumnGap":"1px","flexGridRowGap":"2px"} 1`] = `
+exports[`FlexGridItem flexGridItemMediaQueryStyle: 2 columns no gaps 1`] = `
 Object {
-  ":nth-child(n):last-child": Object {
-    "marginRight": "calc(0 * (1px + (100% - 0px) / 1))",
-  },
-  ":nth-child(n):nth-child(n)": Object {
-    "marginBottom": "2px",
-    "marginRight": 0,
-  },
-  ":nth-child(n):nth-last-child(1)": Object {
-    "marginBottom": 0,
-  },
-  "width": "calc((100% - 0px) / 1 - .5px)",
+  "marginBottom": 0,
+  "marginRight": 0,
+  "width": "calc((100% - 0px) / 2 - .5px)",
 }
 `;
 
-exports[`FlexGridItem flexGridItemMediaQueryStyle: {"flexGridColumnCount":1,"flexGridColumnGap":0,"flexGridRowGap":0} 1`] = `
+exports[`FlexGridItem flexGridItemMediaQueryStyle: 2 columns with gaps 1`] = `
 Object {
-  ":nth-child(n):last-child": Object {
-    "marginRight": "calc(0 * (0px + (100% - 0px) / 1))",
-  },
-  ":nth-child(n):nth-child(n)": Object {
-    "marginBottom": 0,
-    "marginRight": 0,
-  },
-  ":nth-child(n):nth-last-child(1)": Object {
-    "marginBottom": 0,
-  },
-  "width": "calc((100% - 0px) / 1 - .5px)",
-}
-`;
-
-exports[`FlexGridItem flexGridItemMediaQueryStyle: {"flexGridColumnCount":2,"flexGridColumnGap":"1px","flexGridRowGap":"2px"} 1`] = `
-Object {
-  ":nth-child(2n):last-child": Object {
-    "marginRight": "calc(0 * (1px + (100% - 1px) / 2))",
-  },
-  ":nth-child(2n):nth-child(2n)": Object {
-    "marginBottom": "2px",
-    "marginRight": 0,
-  },
-  ":nth-child(2n):nth-last-child(1)": Object {
-    "marginBottom": 0,
-  },
-  ":nth-child(2n-1):last-child": Object {
-    "marginRight": "calc(1 * (1px + (100% - 1px) / 2))",
-  },
-  ":nth-child(2n-1):nth-child(2n-1)": Object {
-    "marginBottom": "2px",
-    "marginRight": "1px",
-  },
-  ":nth-child(2n-1):nth-last-child(1)": Object {
-    "marginBottom": 0,
-  },
-  ":nth-child(2n-1):nth-last-child(2)": Object {
-    "marginBottom": 0,
-  },
+  "marginBottom": "2px",
+  "marginRight": "1px",
   "width": "calc((100% - 1px) / 2 - .5px)",
 }
 `;
 
-exports[`FlexGridItem flexGridItemMediaQueryStyle: {"flexGridColumnCount":3,"flexGridColumnGap":"1px","flexGridRowGap":"2px"} 1`] = `
+exports[`FlexGridItem flexGridItemMediaQueryStyle: 2 columns with gaps end of column 1`] = `
 Object {
-  ":nth-child(3n):last-child": Object {
-    "marginRight": "calc(0 * (1px + (100% - 2px) / 3))",
-  },
-  ":nth-child(3n):nth-child(3n)": Object {
-    "marginBottom": "2px",
-    "marginRight": 0,
-  },
-  ":nth-child(3n):nth-last-child(1)": Object {
-    "marginBottom": 0,
-  },
-  ":nth-child(3n-1):last-child": Object {
-    "marginRight": "calc(1 * (1px + (100% - 2px) / 3))",
-  },
-  ":nth-child(3n-1):nth-child(3n-1)": Object {
-    "marginBottom": "2px",
-    "marginRight": "1px",
-  },
-  ":nth-child(3n-1):nth-last-child(1)": Object {
-    "marginBottom": 0,
-  },
-  ":nth-child(3n-1):nth-last-child(2)": Object {
-    "marginBottom": 0,
-  },
-  ":nth-child(3n-2):last-child": Object {
-    "marginRight": "calc(2 * (1px + (100% - 2px) / 3))",
-  },
-  ":nth-child(3n-2):nth-child(3n-2)": Object {
-    "marginBottom": "2px",
-    "marginRight": "1px",
-  },
-  ":nth-child(3n-2):nth-last-child(1)": Object {
-    "marginBottom": 0,
-  },
-  ":nth-child(3n-2):nth-last-child(2)": Object {
-    "marginBottom": 0,
-  },
-  ":nth-child(3n-2):nth-last-child(3)": Object {
-    "marginBottom": 0,
-  },
-  "width": "calc((100% - 2px) / 3 - .5px)",
+  "marginBottom": 0,
+  "marginRight": "1px",
+  "width": "calc((100% - 1px) / 2 - .5px)",
 }
 `;
 
-exports[`FlexGridItem flexGridItemStyle: {"$flexGridColumnCount":[1,2],"$flexGridColumnGap":"1px","$flexGridRowGap":"2px"} 1`] = `
+exports[`FlexGridItem flexGridItemMediaQueryStyle: 2 columns with gaps end of row 1`] = `
+Object {
+  "marginBottom": "2px",
+  "marginRight": 0,
+  "width": "calc((100% - 1px) / 2 - .5px)",
+}
+`;
+
+exports[`FlexGridItem flexGridItemMediaQueryStyle: 2 columns with gaps end of row and column 1`] = `
+Object {
+  "marginBottom": 0,
+  "marginRight": 0,
+  "width": "calc((100% - 1px) / 2 - .5px)",
+}
+`;
+
+exports[`FlexGridItem flexGridItemMediaQueryStyle: 2 columns with gaps row ends early 1`] = `
+Object {
+  "marginBottom": 0,
+  "marginRight": "calc(1 * (1px + (100% - 1px) / 2))",
+  "width": "calc((100% - 1px) / 2 - .5px)",
+}
+`;
+
+exports[`FlexGridItem flexGridItemStyle: no props 1`] = `
+Object {
+  "flexGrow": 1,
+  "marginBottom": 0,
+  "marginRight": 0,
+  "width": "calc((100% - 0px) / 1 - .5px)",
+}
+`;
+
+exports[`FlexGridItem flexGridItemStyle: non-responsive 1`] = `
+Object {
+  "flexGrow": 1,
+  "marginBottom": "2px",
+  "marginRight": "1px",
+  "width": "calc((100% - 1px) / 2 - .5px)",
+}
+`;
+
+exports[`FlexGridItem flexGridItemStyle: responsive columns 1`] = `
 Object {
   "@media screen and (min-width: 0px)": Object {
-    ":nth-child(n):last-child": Object {
-      "marginRight": "calc(0 * (1px + (100% - 0px) / 1))",
-    },
-    ":nth-child(n):nth-child(n)": Object {
-      "marginBottom": "2px",
-      "marginRight": 0,
-    },
-    ":nth-child(n):nth-last-child(1)": Object {
-      "marginBottom": 0,
-    },
-    "width": "calc((100% - 0px) / 1 - .5px)",
-  },
-  "@media screen and (min-width: 320px)": Object {
-    ":nth-child(2n):last-child": Object {
-      "marginRight": "calc(0 * (1px + (100% - 1px) / 2))",
-    },
-    ":nth-child(2n):nth-child(2n)": Object {
-      "marginBottom": "2px",
-      "marginRight": 0,
-    },
-    ":nth-child(2n):nth-last-child(1)": Object {
-      "marginBottom": 0,
-    },
-    ":nth-child(2n-1):last-child": Object {
-      "marginRight": "calc(1 * (1px + (100% - 1px) / 2))",
-    },
-    ":nth-child(2n-1):nth-child(2n-1)": Object {
-      "marginBottom": "2px",
-      "marginRight": "1px",
-    },
-    ":nth-child(2n-1):nth-last-child(1)": Object {
-      "marginBottom": 0,
-    },
-    ":nth-child(2n-1):nth-last-child(2)": Object {
-      "marginBottom": 0,
-    },
+    "marginBottom": "2px",
+    "marginRight": "1px",
     "width": "calc((100% - 1px) / 2 - .5px)",
   },
-  "flexGrow": 1,
-}
-`;
-
-exports[`FlexGridItem flexGridItemStyle: {"$flexGridColumnCount":[1,2],"$flexGridColumnGap":["1px","2px"],"$flexGridRowGap":["2px","4px"]} 1`] = `
-Object {
-  "@media screen and (min-width: 0px)": Object {
-    ":nth-child(n):last-child": Object {
-      "marginRight": "calc(0 * (1px + (100% - 0px) / 1))",
-    },
-    ":nth-child(n):nth-child(n)": Object {
-      "marginBottom": "2px",
-      "marginRight": 0,
-    },
-    ":nth-child(n):nth-last-child(1)": Object {
-      "marginBottom": 0,
-    },
-    "width": "calc((100% - 0px) / 1 - .5px)",
-  },
   "@media screen and (min-width: 320px)": Object {
-    ":nth-child(2n):last-child": Object {
-      "marginRight": "calc(0 * (2px + (100% - 2px) / 2))",
-    },
-    ":nth-child(2n):nth-child(2n)": Object {
-      "marginBottom": "4px",
-      "marginRight": 0,
-    },
-    ":nth-child(2n):nth-last-child(1)": Object {
-      "marginBottom": 0,
-    },
-    ":nth-child(2n-1):last-child": Object {
-      "marginRight": "calc(1 * (2px + (100% - 2px) / 2))",
-    },
-    ":nth-child(2n-1):nth-child(2n-1)": Object {
-      "marginBottom": "4px",
-      "marginRight": "2px",
-    },
-    ":nth-child(2n-1):nth-last-child(1)": Object {
-      "marginBottom": 0,
-    },
-    ":nth-child(2n-1):nth-last-child(2)": Object {
-      "marginBottom": 0,
-    },
-    "width": "calc((100% - 2px) / 2 - .5px)",
-  },
-  "flexGrow": 1,
-}
-`;
-
-exports[`FlexGridItem flexGridItemStyle: {"$flexGridColumnCount":2,"$flexGridColumnGap":"1px","$flexGridRowGap":"2px"} 1`] = `
-Object {
-  ":nth-child(2n):last-child": Object {
-    "marginRight": "calc(0 * (1px + (100% - 1px) / 2))",
-  },
-  ":nth-child(2n):nth-child(2n)": Object {
-    "marginBottom": "2px",
-    "marginRight": 0,
-  },
-  ":nth-child(2n):nth-last-child(1)": Object {
-    "marginBottom": 0,
-  },
-  ":nth-child(2n-1):last-child": Object {
-    "marginRight": "calc(1 * (1px + (100% - 1px) / 2))",
-  },
-  ":nth-child(2n-1):nth-child(2n-1)": Object {
     "marginBottom": "2px",
     "marginRight": "1px",
-  },
-  ":nth-child(2n-1):nth-last-child(1)": Object {
-    "marginBottom": 0,
-  },
-  ":nth-child(2n-1):nth-last-child(2)": Object {
-    "marginBottom": 0,
+    "width": "calc((100% - 2px) / 3 - .5px)",
   },
   "flexGrow": 1,
-  "width": "calc((100% - 1px) / 2 - .5px)",
 }
 `;
 
-exports[`FlexGridItem flexGridItemStyle: {} 1`] = `
+exports[`FlexGridItem flexGridItemStyle: responsive columns and gaps 1`] = `
 Object {
-  ":nth-child(n):last-child": Object {
-    "marginRight": "calc(0 * (0px + (100% - 0px) / 1))",
+  "@media screen and (min-width: 0px)": Object {
+    "marginBottom": "2px",
+    "marginRight": "1px",
+    "width": "calc((100% - 1px) / 2 - .5px)",
   },
-  ":nth-child(n):nth-child(n)": Object {
-    "marginBottom": 0,
-    "marginRight": 0,
-  },
-  ":nth-child(n):nth-last-child(1)": Object {
-    "marginBottom": 0,
+  "@media screen and (min-width: 320px)": Object {
+    "marginBottom": "4px",
+    "marginRight": "2px",
+    "width": "calc((100% - 4px) / 3 - .5px)",
   },
   "flexGrow": 1,
-  "width": "calc((100% - 0px) / 1 - .5px)",
 }
 `;
 
@@ -282,17 +137,9 @@ exports[`FlexGridItem renders: with default styles 1`] = `
             styled-component="true"
             test-style={
               Object {
-                ":nth-child(n):last-child": Object {
-                  "marginRight": "calc(0 * (0px + (100% - 0px) / 1))",
-                },
-                ":nth-child(n):nth-child(n)": Object {
-                  "marginBottom": 0,
-                  "marginRight": 0,
-                },
-                ":nth-child(n):nth-last-child(1)": Object {
-                  "marginBottom": 0,
-                },
                 "flexGrow": 1,
+                "marginBottom": 0,
+                "marginRight": 0,
                 "width": "calc((100% - 0px) / 1 - .5px)",
               }
             }
@@ -353,18 +200,10 @@ exports[`FlexGridItem renders: with overridden styles 1`] = `
             styled-component="true"
             test-style={
               Object {
-                ":nth-child(n):last-child": Object {
-                  "marginRight": "calc(0 * (0px + (100% - 0px) / 1))",
-                },
-                ":nth-child(n):nth-child(n)": Object {
-                  "marginBottom": 0,
-                  "marginRight": 0,
-                },
-                ":nth-child(n):nth-last-child(1)": Object {
-                  "marginBottom": 0,
-                },
                 "color": "red",
                 "flexGrow": 1,
+                "marginBottom": 0,
+                "marginRight": 0,
                 "width": "calc((100% - 0px) / 1 - .5px)",
               }
             }

--- a/src/flex-grid/__tests__/__snapshots__/flex-grid.test.js.snap
+++ b/src/flex-grid/__tests__/__snapshots__/flex-grid.test.js.snap
@@ -168,20 +168,28 @@ exports[`FlexGrid passes FlexGrid props to children: FlexGridItem with flexGridC
             >
               <MockFlexGridItem
                 flexGridColumnCount={4}
+                flexGridItemCount={2}
+                flexGridItemIndex={0}
                 key=".0"
               >
                 <div
                   flex-grid-column-count={4}
+                  flex-grid-item-count={2}
+                  flex-grid-item-index={0}
                 >
                   Item 1
                 </div>
               </MockFlexGridItem>
               <MockFlexGridItem
                 flexGridColumnCount={4}
+                flexGridItemCount={2}
+                flexGridItemIndex={1}
                 key=".1"
               >
                 <div
                   flex-grid-column-count={4}
+                  flex-grid-item-count={2}
+                  flex-grid-item-index={1}
                 >
                   Item 2
                 </div>

--- a/src/flex-grid/__tests__/flex-grid-item.test.js
+++ b/src/flex-grid/__tests__/flex-grid-item.test.js
@@ -19,16 +19,76 @@ import {LightTheme} from '../../themes/index.js';
 describe('FlexGridItem', () => {
   test('flexGridItemMediaQueryStyle', () => {
     const testProps = [
-      {flexGridColumnCount: 1, flexGridColumnGap: 0, flexGridRowGap: 0},
-      {flexGridColumnCount: 1, flexGridColumnGap: '1px', flexGridRowGap: '2px'},
-      {flexGridColumnCount: 2, flexGridColumnGap: '1px', flexGridRowGap: '2px'},
-      {flexGridColumnCount: 3, flexGridColumnGap: '1px', flexGridRowGap: '2px'},
+      {
+        flexGridColumnCount: 2,
+        flexGridColumnGap: 0,
+        flexGridRowGap: 0,
+        flexGridItemIndex: 0,
+        flexGridItemCount: 4,
+        snapshotName: '2 columns no gaps',
+      },
+      {
+        flexGridColumnCount: 2,
+        flexGridColumnGap: '1px',
+        flexGridRowGap: '2px',
+        flexGridItemIndex: 0,
+        flexGridItemCount: 4,
+        snapshotName: '2 columns with gaps',
+      },
+      {
+        flexGridColumnCount: 2,
+        flexGridColumnGap: '1px',
+        flexGridRowGap: '2px',
+        flexGridItemIndex: 1,
+        flexGridItemCount: 4,
+        snapshotName: '2 columns with gaps end of row',
+      },
+      {
+        flexGridColumnCount: 2,
+        flexGridColumnGap: '1px',
+        flexGridRowGap: '2px',
+        flexGridItemIndex: 2,
+        flexGridItemCount: 4,
+        snapshotName: '2 columns with gaps end of column',
+      },
+      {
+        flexGridColumnCount: 2,
+        flexGridColumnGap: '1px',
+        flexGridRowGap: '2px',
+        flexGridItemIndex: 3,
+        flexGridItemCount: 4,
+        snapshotName: '2 columns with gaps end of row and column',
+      },
+      {
+        flexGridColumnCount: 2,
+        flexGridColumnGap: '1px',
+        flexGridRowGap: '2px',
+        flexGridItemIndex: 2,
+        flexGridItemCount: 3,
+        snapshotName: '2 columns with gaps row ends early',
+      },
     ];
-    testProps.forEach(props => {
-      expect(
-        flexGridItemMediaQueryStyle({...props, $theme: LightTheme}),
-      ).toMatchSnapshot(JSON.stringify(props));
-    });
+    testProps.forEach(
+      ({
+        flexGridColumnCount,
+        flexGridColumnGap,
+        flexGridRowGap,
+        flexGridItemIndex,
+        flexGridItemCount,
+        snapshotName,
+      }) => {
+        expect(
+          flexGridItemMediaQueryStyle({
+            flexGridColumnCount,
+            flexGridColumnGap,
+            flexGridRowGap,
+            flexGridItemIndex,
+            flexGridItemCount,
+            $theme: LightTheme,
+          }),
+        ).toMatchSnapshot(snapshotName);
+      },
+    );
   });
 
   test('getResponsiveValue', () => {
@@ -48,28 +108,56 @@ describe('FlexGridItem', () => {
 
   test('flexGridItemStyle', () => {
     const snapshotProps = [
-      {},
+      // $FlowFixMe - intentionally missing props
+      {
+        snapshotName: 'no props',
+      },
       {
         $flexGridColumnCount: 2,
         $flexGridColumnGap: '1px',
         $flexGridRowGap: '2px',
+        $flexGridItemIndex: 0,
+        $flexGridItemCount: 6,
+        snapshotName: 'non-responsive',
       },
       {
-        $flexGridColumnCount: [1, 2],
+        $flexGridColumnCount: [2, 3],
         $flexGridColumnGap: '1px',
         $flexGridRowGap: '2px',
+        $flexGridItemIndex: 0,
+        $flexGridItemCount: 6,
+        snapshotName: 'responsive columns',
       },
       {
-        $flexGridColumnCount: [1, 2],
+        $flexGridColumnCount: [2, 3],
         $flexGridColumnGap: ['1px', '2px'],
         $flexGridRowGap: ['2px', '4px'],
+        $flexGridItemIndex: 0,
+        $flexGridItemCount: 6,
+        snapshotName: 'responsive columns and gaps',
       },
     ];
-    snapshotProps.forEach(props => {
-      expect(flexGridItemStyle({...props, $theme: LightTheme})).toMatchSnapshot(
-        JSON.stringify(props),
-      );
-    });
+    snapshotProps.forEach(
+      ({
+        $flexGridColumnCount,
+        $flexGridColumnGap,
+        $flexGridRowGap,
+        $flexGridItemIndex,
+        $flexGridItemCount,
+        snapshotName,
+      }) => {
+        expect(
+          flexGridItemStyle({
+            $flexGridColumnCount,
+            $flexGridColumnGap,
+            $flexGridRowGap,
+            $flexGridItemIndex,
+            $flexGridItemCount,
+            $theme: LightTheme,
+          }),
+        ).toMatchSnapshot(snapshotName);
+      },
+    );
   });
 
   it('renders', () => {

--- a/src/flex-grid/flex-grid.js
+++ b/src/flex-grid/flex-grid.js
@@ -43,13 +43,21 @@ const FlexGrid = ({
   return (
     <FlexGrid as={as} {...restProps} {...flexGridProps}>
       {// flatten fragments so FlexGrid correctly iterates over fragments’ children
-      flattenFragments(children).map((child: React.Node) =>
-        // $FlowFixMe https://github.com/facebook/flow/issues/4864
-        React.cloneElement(child, {
-          flexGridColumnCount,
-          flexGridColumnGap,
-          flexGridRowGap,
-        }),
+      flattenFragments(children).map(
+        (
+          child: React.Node,
+          flexGridItemIndex: number,
+          {length: flexGridItemCount}: React.Node[],
+        ) => {
+          // $FlowFixMe https://github.com/facebook/flow/issues/4864
+          return React.cloneElement(child, {
+            flexGridColumnCount,
+            flexGridColumnGap,
+            flexGridRowGap,
+            flexGridItemIndex,
+            flexGridItemCount,
+          });
+        },
       )}
     </FlexGrid>
   );

--- a/src/flex-grid/index.d.ts
+++ b/src/flex-grid/index.d.ts
@@ -9,6 +9,9 @@ export interface FlexGridProps extends BlockProps {
 
 export const FlexGrid: React.FC<FlexGridProps>;
 
-export type FlexGridItemProps = FlexGridProps;
+export interface FlexGridItemProps extends FlexGridProps {
+  flexGridItemIndex?: number;
+  flexGridItemCount?: number;
+}
 
-export const FlexGridItem: React.FC<FlexGridProps>;
+export const FlexGridItem: React.FC<FlexGridItemProps>;

--- a/src/flex-grid/types.js
+++ b/src/flex-grid/types.js
@@ -17,4 +17,9 @@ export type FlexGridPropsT = {
   flexGridRowGap?: ResponsiveT<ScaleT>,
 } & BlockPropsT;
 
-export type FlexGridItemPropsT = FlexGridPropsT;
+export type FlexGridItemPropsT = {
+  /** Index of item in FlexGrid, used to determine gaps **/
+  flexGridItemIndex?: number,
+  /** Total count of items in FlexGrid, used to determine gaps **/
+  flexGridItemCount?: number,
+} & FlexGridPropsT;


### PR DESCRIPTION
#### Description

Re-implement FlexGridItem to avoid nth-child selectors. Original implementation relied on the order of rules in the stylesheet, which is not guaranteed with Styletron, sometimes causing layout bugs if rules are out of order.

By passing the index and count props to each FlexGridItem, we can explicitly set margin-right and margin-bottom without relying on nth-child selectors. This also cleans up the DOM and reduces the number of classes:

FlexGridItem classes before: 
![flex-grid-item-classes-before](https://user-images.githubusercontent.com/1285326/71444987-ca72ec80-26ca-11ea-9f59-991fdb0d8f4c.png)
FlexGridItem classes after: 
![flex-grid-item-classes-after](https://user-images.githubusercontent.com/1285326/71444990-d1016400-26ca-11ea-8bfe-abae9be62462.png)

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
