### PR TITLE
fix(toast): adds override props InnerContainer to the typescript def

### DIFF
--- a/src/toast/index.d.ts
+++ b/src/toast/index.d.ts
@@ -93,6 +93,7 @@ export interface ToastPrivateState {
 export interface ToastOverrides {
   Body?: Override<SharedStylePropsArg>;
   CloseIcon?: Override<SharedStylePropsArg>;
+  InnerContainer?: Override<SharedStylePropsArg>;
 }
 export interface ToastProps {
   autoHideDuration?: number;


### PR DESCRIPTION
Adds InnerContainer props to overrides for Notification.

#### Description

Fixes type error for notification component in override props for InnerContainer

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
