### PR TITLE
docs(gallery): update to match tables sections

### DIFF
--- a/documentation-site/components/gallery.js
+++ b/documentation-site/components/gallery.js
@@ -148,22 +148,6 @@ const COMPONENTS = {
       Component: thumbnails.SvgList,
     },
     {
-      href: '/components/table',
-      Component: thumbnails.SvgTable,
-    },
-    {
-      href: '/components/table-grid',
-      Component: thumbnails.SvgTableGrid,
-    },
-    {
-      href: '/components/table-semantic',
-      Component: thumbnails.SvgTableSemantic,
-    },
-    {
-      href: '/components/unstable-data-table',
-      Component: thumbnails.SvgDataTable,
-    },
-    {
       href: '/components/tag',
       Component: thumbnails.SvgTag,
     },
@@ -174,6 +158,24 @@ const COMPONENTS = {
     {
       href: '/components/typography',
       Component: thumbnails.SvgTypography,
+    },
+  ],
+  Tables: [
+    {
+      href: '/components/table',
+      Component: thumbnails.SvgTable,
+    },
+    {
+      href: '/components/unstable-data-table',
+      Component: thumbnails.SvgDataTable,
+    },
+    {
+      href: '/components/table-grid',
+      Component: thumbnails.SvgTableGrid,
+    },
+    {
+      href: '/components/table-semantic',
+      Component: thumbnails.SvgTableSemantic,
     },
   ],
   Feedback: [

--- a/documentation-site/components/thumbs/index.js
+++ b/documentation-site/components/thumbs/index.js
@@ -44,13 +44,15 @@ export {default as SvgLayoutGrid} from './components/LayoutGrid.js';
 export {default as SvgHeading} from './components/Heading.js';
 export {default as SvgIcon} from './components/Icon.js';
 export {default as SvgList} from './components/List.js';
-export {default as SvgTable} from './components/Table.js';
-export {default as SvgTableGrid} from './components/TableGrid.js';
-export {default as SvgTableSemantic} from './components/TableSemantic.js';
-export {default as SvgDataTable} from './components/DataTable.js';
 export {default as SvgTag} from './components/Tag.js';
 export {default as SvgTreeView} from './components/TreeView.js';
 export {default as SvgTypography} from './components/Typography.js';
+
+// Tables
+export {default as SvgTable} from './components/Table.js';
+export {default as SvgDataTable} from './components/DataTable.js';
+export {default as SvgTableGrid} from './components/TableGrid.js';
+export {default as SvgTableSemantic} from './components/TableSemantic.js';
 
 // Feedback
 export {default as SvgNotification} from './components/Notification.js';


### PR DESCRIPTION
Just a small update to gallery page to match nav structure. `Tables` is its own thing now.