### PR TITLE
fix(select): more accurate prop type for Select component

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -9,9 +9,8 @@ import * as React from 'react';
 import SelectComponent from './select-component.js';
 import MultiValue from './multi-value.js';
 import SingleValue from './value.js';
-import type {PropsT} from './types.js';
 
-function Select(props: $Shape<PropsT>) {
+function Select(props: React.ElementConfig<typeof SelectComponent>) {
   return (
     <SelectComponent
       {...props}


### PR DESCRIPTION
#### Description

[`React.ElementConfig<T>`](https://flow.org/en/docs/react/types/#toc-react-elementconfig) gets the type of a component’s props but preserves the optionality of `defaultProps`. It is thus more accurate than simply using `$Shape<TProps>`.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
