### PR TITLE
docs(theming): update anchor links that point to theming guide

### DIFF
--- a/documentation-site/components/yard/theme-editor.tsx
+++ b/documentation-site/components/yard/theme-editor.tsx
@@ -128,8 +128,8 @@ const ThemeEditor: React.FC<ThemeEditorProps> = ({
       >
         Do you want to change {componentName} colors globally? You can customize
         the theme through ThemeProvider and set your own colors.{' '}
-        <Link href="/guides/theming#creating-a-custom-theme">
-          <StyledLink href="/guides/theming#creating-a-custom-theme">
+        <Link href="/guides/theming/#a-custom-theme">
+          <StyledLink href="/guides/theming/#a-custom-theme">
             Learn more
           </StyledLink>
         </Link>

--- a/documentation-site/pages/blog/base-web-v7/index.mdx
+++ b/documentation-site/pages/blog/base-web-v7/index.mdx
@@ -204,7 +204,7 @@ const InitialComponent = styled('div', props => {
 We are removing deprecated properties from the theme object. It only affects you if you've used your own theme
 with the `Tag`, `Tooltip` or `Input` components.
 
-To update your theme, please take a look at the update shape of the theme object [here](https://baseweb.design/guides/theming#the-shape-of-the-theme-file).
+To update your theme, please take a look at the update shape of the theme object [here](https://baseweb.design/guides/theming/#theme-properties).
 
 ## Pagination
 

--- a/documentation-site/pages/blog/getting-started-with-base-web/index.mdx
+++ b/documentation-site/pages/blog/getting-started-with-base-web/index.mdx
@@ -99,7 +99,7 @@ Base Web tackles this with an "Overrides" pattern. It provides a consistent API 
 
 _To learn more, check out the [Overrides guide](/guides/understanding-overrides/)._
 
-Don't throw everything into overrides though. Adjusting your theme values is better if you override the same properties over and over (_Read about themes [here](/guides/theming#the-shape-of-the-theme-file)_).
+Don't throw everything into overrides though. Adjusting your theme values is better if you override the same properties over and over (_Read about themes [here](/guides/theming/#theme-properties)_).
 
 To customize the `Card` component to work better for our use-case, we can do something like this:
 

--- a/documentation-site/pages/blog/responsive-web/index.mdx
+++ b/documentation-site/pages/blog/responsive-web/index.mdx
@@ -103,7 +103,7 @@ This sets the following values inside `MyTheme`:
 }
 ```
 
-Then you can use `MyTheme` throughout your app using Base Web’s [`ThemeProvider`](/guides/theming#the-themeprovider).
+Then you can use `MyTheme` throughout your app using Base Web’s [`ThemeProvider`](/guides/theming/#setup).
 
 ## Mobile-first styling of components
 

--- a/documentation-site/pages/components/base-provider.mdx
+++ b/documentation-site/pages/components/base-provider.mdx
@@ -15,7 +15,7 @@ export default Layout;
 
 `BaseProvider` provides a single wrapper to configure your application.
 It adds a [`LayersManager`](/components/layer/)
-and a [`ThemeProvider`](/guides/theming#the-themeprovider)
+and a [`ThemeProvider`](/guides/theming/#setup)
 to handle styling and stacking context in the application.
 
 Wrap your application with the `BaseProvider` at its root:

--- a/documentation-site/pages/components/input.mdx
+++ b/documentation-site/pages/components/input.mdx
@@ -105,7 +105,7 @@ You can also use `overrides` to customize the icons used in the toggle:
 />
 ```
 
-Note, if all you want to do is change the icons, you could [update your theme](/guides/theming/#overriding-icons) instead.
+Note, if all you want to do is change the icons, you could [update your theme](/guides/theming/#customizing-icons) instead.
 
 <Example title="Overrides usage" path="input/overrides.js">
   <Customization />

--- a/documentation-site/pages/components/layout-grid.mdx
+++ b/documentation-site/pages/components/layout-grid.mdx
@@ -81,7 +81,7 @@ Sometimes this wrapping behavior is desireable, but sometimes you want to adapt 
   <ResponsiveExample />
 </Example>
 
-`span` is a "responsive" prop. It accepts both a single value or an array of values. Each value in the array corresponds to each [breakpoint in our theme](https://baseweb.design/guides/theming/#the-shape-of-the-theme-file).
+`span` is a "responsive" prop. It accepts both a single value or an array of values. Each value in the array corresponds to each [breakpoint in our theme](https://baseweb.design/guides/theming/#theme-properties).
 
 When you specify the first value in the array, you are specifying the value for any viewport larger than or equal to the first (`small`) breakpoint in your theme. The second value applies to viewports greater than or equal to the `medium` breakpoint, and the third value applies to viewports greater than or equal to the `large` breakpoint.
 
@@ -157,7 +157,7 @@ You can customize pretty much any part of the grid while maintaining the core re
 - `gridMargins`
 - `gridMaxWidth` (Not responsive)
 
-The grid will use whatever values are on your theme `grid` property as the default values for these props. This way you do not have to create a "wrapper" grid if yours differs from the default Base grid. [Click here for the full theme shape](https://baseweb.design/guides/theming/#the-shape-of-the-theme-file)or see below for the grid relevant section of the theme:
+The grid will use whatever values are on your theme `grid` property as the default values for these props. This way you do not have to create a "wrapper" grid if yours differs from the default Base grid. [Click here for the full theme shape](https://baseweb.design/guides/theming/#theme-properties)or see below for the grid relevant section of the theme:
 
 ```js
 const theme = {

--- a/documentation-site/pages/components/styled.mdx
+++ b/documentation-site/pages/components/styled.mdx
@@ -24,7 +24,7 @@ export default Layout;
 </Notification>
 
 Base Web exports a modified version of [Styletron's](https://www.styletron.org/api/#styled) `styled` function.
-This modified version has access to [theme variables](/guides/theming/#theming-values):
+This modified version has access to [theme variables](/guides/theming/#theme-properties):
 
 ## Examples
 

--- a/documentation-site/pages/components/typography.mdx
+++ b/documentation-site/pages/components/typography.mdx
@@ -21,7 +21,7 @@ export default Layout;
 
 A set of text block components for an out-of-the-box path to the BaseUI font standard.
 
-You can find the font definitions in the [Theming values](/guides/theming/#theming-values) page.
+You can find the font definitions in the [Theming values](/guides/theming/#typography) page.
 
 ## When to use
 

--- a/documentation-site/pages/components/use-styletron.mdx
+++ b/documentation-site/pages/components/use-styletron.mdx
@@ -25,7 +25,7 @@ information about how this is used.
 
 ## Examples
 
-This modified version has access to [theme variables](/guides/theming/#theming-values):
+This modified version has access to [theme variables](/guides/theming/#theme-properties):
 
 <Example title="Using theme values" path="use-styletron/basic.js">
   <UseStyletronBasic />
@@ -60,7 +60,7 @@ To understand overrides better, go [here](/guides/understanding-overrides/).
 ## Custom themes and Flow type
 
 The `styled` and `withStyle` functions imported from `baseui` provide flow type support for the
-default [theme shape](/guides/theming/#theming-values). However, if you create a custom theme with additional fields,
+default [theme shape](/guides/theming/#theme-properties). However, if you create a custom theme with additional fields,
 flow will show an error. To help, baseui exports two utility functions `createThemedStyled` and
 `createThemedWithStyle`. These will return their respective functions with a provided theme type.
 Doing so saves from needing to import the custom theme type around. See below for an example.

--- a/documentation-site/pages/guides/understanding-overrides.mdx
+++ b/documentation-site/pages/guides/understanding-overrides.mdx
@@ -101,7 +101,7 @@ The `overrides.Label.style` property accepts a [style object](https://www.stylet
 
 ## `$theme`
 
-If you opt-in for the [style function](https://www.styletron.org/concepts/#style-function), `overrides` provides a special prop called **`$theme`** that you can use. The `$theme` prop includes all Base Web [design constants](/guides/theming/#theming-values). So instead of the hard-coded value `#892C21`, you can use the theme:
+If you opt-in for the [style function](https://www.styletron.org/concepts/#style-function), `overrides` provides a special prop called **`$theme`** that you can use. The `$theme` prop includes all Base Web [design constants](/guides/theming/#theme-properties). So instead of the hard-coded value `#892C21`, you can use the theme:
 
 ```jsx
 <StatefulList


### PR DESCRIPTION
Noticed some links on site point to older sections on theming guide. Did a sweep to update the anchor tags to the current page sections.