### PR TITLE
fix(select): allow clear icon svg overrides

### DIFF
--- a/src/select/select-component.js
+++ b/src/select/select-component.js
@@ -700,8 +700,18 @@ class Select extends React.Component<PropsT, SelectStateT> {
         onTouchEnd={this.handleTouchEndClearValue}
         onTouchMove={this.handleTouchMove}
         onTouchStart={this.handleTouchStart}
-        overrides={{Svg: StyledClearIcon}}
         role="button"
+        overrides={{
+          Svg: {
+            component: StyledClearIcon,
+            ...(overrides.ClearIcon && overrides.ClearIcon.props
+              ? {props: overrides.ClearIcon.props}
+              : {}),
+            ...(overrides.ClearIcon && overrides.ClearIcon.style
+              ? {style: overrides.ClearIcon.style}
+              : {}),
+          },
+        }}
         {...sharedProps}
         {...clearIconProps}
       />


### PR DESCRIPTION

#### Description

We are currently able to modify the `SelectArrow` svg through overrides, however we cannot currently override the `ClearIcon` with the same API

With this we can modify the `SelectArrow` and `ClearIcon` with the same API

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
