### PR TITLE
docs(tooltip): change default triggerType to hover

### DIFF
--- a/documentation-site/components/yard/config/tooltip.ts
+++ b/documentation-site/components/yard/config/tooltip.ts
@@ -35,6 +35,8 @@ const TooltipConfig: TConfig = {
     },
     triggerType: {
       ...PopoverConfig.props.triggerType,
+      value: 'TRIGGER_TYPE.hover',
+      defaultValue: 'TRIGGER_TYPE.hover',
       imports: {
         'baseui/tooltip': {
           named: ['TRIGGER_TYPE'],


### PR DESCRIPTION
#### Description

Currently the default `triggerType` for Tooltip `click`. Although, it is not possible to interact with the component in a clickable manner. This PR changes the `triggerType` to `hover`, which should be a more suitable default, and fix the issue.

Example:

![image](https://i.gyazo.com/905c5bf380034186628f1069a5c41041.gif)

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
