### PR TITLE
fix(avatar): reset to error state when src is missing

### DIFF
--- a/src/avatar/__tests__/avatar.test.js
+++ b/src/avatar/__tests__/avatar.test.js
@@ -87,18 +87,15 @@ describe('Avatar', () => {
     expect(wrapper.find(StyledInitials).text()).toBe('U');
   });
 
-  it('resets noImageAvailable flag when src is updated', done => {
-    const wrapper = mount(
-      <Avatar name="user name" src="invalid-img-src.png" />,
-    );
+  it('resets noImageAvailable flag when src is updated', () => {
+    const wrapper = mount(<Avatar name="user name" />);
 
-    triggerLoadError(wrapper);
     expect(wrapper.state().noImageAvailable).toBeTruthy();
-    wrapper.setProps({name: 'user name', src: 'valid-img-src.png'}, () => {
-      setTimeout(() => {
-        expect(wrapper.state().noImageAvailable).toBeFalsy();
-        done();
-      }, 0);
-    });
+
+    wrapper.setProps({name: 'user name', src: 'valid-img-src.png'});
+    expect(wrapper.state().noImageAvailable).toBeFalsy();
+
+    wrapper.setProps({name: 'user name', src: null});
+    expect(wrapper.state().noImageAvailable).toBeTruthy();
   });
 });

--- a/src/avatar/avatar.js
+++ b/src/avatar/avatar.js
@@ -38,7 +38,7 @@ export default class Avatar extends React.Component<PropsT, StateT> {
   }
 
   componentDidUpdate(prevProps: PropsT, prevState: StateT) {
-    if (prevProps.src != this.props.src) {
+    if (prevProps.src !== this.props.src) {
       this.setState({noImageAvailable: !this.props.src});
     }
   }

--- a/src/avatar/avatar.js
+++ b/src/avatar/avatar.js
@@ -38,8 +38,8 @@ export default class Avatar extends React.Component<PropsT, StateT> {
   }
 
   componentDidUpdate(prevProps: PropsT, prevState: StateT) {
-    if (prevProps.src !== this.props.src && prevState.noImageAvailable) {
-      this.setState({noImageAvailable: false});
+    if (prevProps.src != this.props.src) {
+      this.setState({noImageAvailable: !this.props.src});
     }
   }
 


### PR DESCRIPTION
#### Description

When the avatar's `src` is updated from a valid source to a null-ish value (undefined, null), the `onError` callback will not be triggered and the `noImageAvailable` flag will still be false, thus the Avatar will display broken image.

Here is the [sandbox to reproduce the issue](https://codesandbox.io/s/avatar-xeqg4).

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
