### PR TITLE
fix(select): don't perform setState on unmounted component

### DIFF
--- a/src/select/select-component.js
+++ b/src/select/select-component.js
@@ -119,10 +119,13 @@ class Select extends React.Component<PropsT, SelectStateT> {
     isPseudoFocused: false,
   };
 
+  isMounted: boolean = false;
+
   componentDidMount() {
     if (this.props.autoFocus) {
       this.focus();
     }
+    this.isMounted = true;
   }
 
   componentDidUpdate(prevProps: PropsT, prevState: SelectStateT) {
@@ -147,6 +150,7 @@ class Select extends React.Component<PropsT, SelectStateT> {
     if (__BROWSER__) {
       document.removeEventListener('touchstart', this.handleTouchOutside);
     }
+    this.isMounted = false;
   }
 
   focus() {
@@ -296,7 +300,9 @@ class Select extends React.Component<PropsT, SelectStateT> {
       onBlurredState.inputValue = '';
     }
 
-    this.setState(onBlurredState);
+    if (this.isMounted) {
+      this.setState(onBlurredState);
+    }
 
     if (__BROWSER__) {
       document.removeEventListener('click', this.handleClickOutside);


### PR DESCRIPTION
#### Description

1. Place select in overlay
2. Open menu
3. Close overlay by clicking outside of overlay
4. Select will try to update its state which causes the warning and memory leak

Fix contains changes in onBlur handler. Now there is a condition check whether component is still mounted in a dom before performing setState.

#2623 

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
