### PR TITLE
feat: add href support to menu item

### DIFF
--- a/src/menu/option-list.js
+++ b/src/menu/option-list.js
@@ -12,7 +12,7 @@ import {getOverrides} from '../helpers/overrides.js';
 
 import {OPTION_LIST_SIZE} from './constants.js';
 import MaybeChildMenu from './maybe-child-menu.js';
-import {StyledListItem} from './styled-components.js';
+import {StyledListItem, StyledListItemAnchor} from './styled-components.js';
 import type {OptionListPropsT} from './types.js';
 
 function OptionList(props: OptionListPropsT, ref: React.ElementRef<*>) {
@@ -32,6 +32,18 @@ function OptionList(props: OptionListPropsT, ref: React.ElementRef<*>) {
     overrides.ListItem,
     StyledListItem,
   );
+  const getItem = item => {
+    return (
+      <>
+        {!item.href && getItemLabel(item)}
+        {item.href && (
+          <StyledListItemAnchor href={item.href} target="_blank">
+            {getItemLabel(item)}
+          </StyledListItemAnchor>
+        )}
+      </>
+    );
+  };
 
   return (
     <MaybeChildMenu
@@ -49,7 +61,7 @@ function OptionList(props: OptionListPropsT, ref: React.ElementRef<*>) {
         {...restProps}
         {...listItemProps}
       >
-        {getItemLabel({isHighlighted: $isHighlighted, ...item})}
+        {getItem({isHighlighted: $isHighlighted, ...item})}
       </ListItem>
     </MaybeChildMenu>
   );

--- a/src/menu/option-list.js
+++ b/src/menu/option-list.js
@@ -32,17 +32,21 @@ function OptionList(props: OptionListPropsT, ref: React.ElementRef<*>) {
     overrides.ListItem,
     StyledListItem,
   );
+  const [ListItemAnchor, listItemAnchorProps] = getOverrides(
+    overrides.ListItemAnchor,
+    StyledListItemAnchor,
+  );
+
   const getItem = item => {
-    return (
-      <>
-        {!item.href && getItemLabel(item)}
-        {item.href && (
-          <StyledListItemAnchor href={item.href} target="_blank">
-            {getItemLabel(item)}
-          </StyledListItemAnchor>
-        )}
-      </>
-    );
+    if (item.href) {
+      return (
+        <ListItemAnchor href={item.href} {...listItemAnchorProps}>
+          {getItemLabel(item)}
+        </ListItemAnchor>
+      );
+    } else {
+      return <>{getItemLabel(item)}</>;
+    }
   };
 
   return (

--- a/src/menu/styled-components.js
+++ b/src/menu/styled-components.js
@@ -99,7 +99,12 @@ export const StyledOptgroupHeader = styled<{}>('li', props => {
     paddingLeft: paddingX,
   };
 });
-
+export const StyledListItemAnchor = styled<StyledPropsT>('a', props => {
+  return {
+    display: 'block',
+    color: getFontColor(props),
+  };
+});
 export const StyledListItemElement = styled<StyledPropsT>('li', props => {
   const {$disabled, $theme, $size} = props;
   return {

--- a/src/menu/types.js
+++ b/src/menu/types.js
@@ -219,6 +219,7 @@ export type OptionListPropsT = {
   size?: $Keys<typeof OPTION_LIST_SIZE>,
   overrides?: {
     ListItem?: OverrideT<*>,
+    ListItemAnchor?: OverrideT<*>,
   },
   /** Utility to reset menu to default state. Useful for rendering child menus. */
   resetMenu?: () => void,


### PR DESCRIPTION
Fixes #2555 

#### Description

Add an optional href to menu item. 
When href is provided to a menu item, an anchor tag is rendered within the `li` with href as the link and target as `_blank`.

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
