### PR TITLE
fix(docs): add forward ref on input tag + update overrides ts types

### DIFF
--- a/documentation-site/examples/dnd-list/overrides_whole_subcomponent.tsx
+++ b/documentation-site/examples/dnd-list/overrides_whole_subcomponent.tsx
@@ -19,7 +19,7 @@ export default class Example extends React.Component<
         }
         overrides={{
           Label: {
-            component: ({$value}) => (
+            component: ({$value}: any) => (
               <div style={{flexGrow: 1}}>
                 {$value}{' '}
                 <button

--- a/documentation-site/examples/input/with-tags.js
+++ b/documentation-site/examples/input/with-tags.js
@@ -4,30 +4,32 @@ import {useStyletron} from 'baseui';
 import {Input, StyledInput} from 'baseui/input';
 import {Tag, VARIANT as TAG_VARIANT} from 'baseui/tag';
 
-const InputReplacement = ({tags, removeTag, ...restProps}) => {
-  const [css] = useStyletron();
-  return (
-    <div
-      className={css({
-        flex: '1 1 0%',
-        flexWrap: 'wrap',
-        display: 'flex',
-        alignItems: 'center',
-      })}
-    >
-      {tags.map((tag, index) => (
-        <Tag
-          variant={TAG_VARIANT.solid}
-          onActionClick={() => removeTag(tag)}
-          key={index}
-        >
-          {tag}
-        </Tag>
-      ))}
-      <StyledInput {...restProps} />
-    </div>
-  );
-};
+const InputReplacement = React.forwardRef(
+  ({tags, removeTag, ...restProps}, ref) => {
+    const [css] = useStyletron();
+    return (
+      <div
+        className={css({
+          flex: '1 1 0%',
+          flexWrap: 'wrap',
+          display: 'flex',
+          alignItems: 'center',
+        })}
+      >
+        {tags.map((tag, index) => (
+          <Tag
+            variant={TAG_VARIANT.solid}
+            onActionClick={() => removeTag(tag)}
+            key={index}
+          >
+            {tag}
+          </Tag>
+        ))}
+        <StyledInput ref={ref} {...restProps} />
+      </div>
+    );
+  },
+);
 
 export default () => {
   const [value, setValue] = React.useState('');

--- a/documentation-site/examples/input/with-tags.tsx
+++ b/documentation-site/examples/input/with-tags.tsx
@@ -3,30 +3,32 @@ import {useStyletron} from 'baseui';
 import {Input, StyledInput} from 'baseui/input';
 import {Tag, VARIANT as TAG_VARIANT} from 'baseui/tag';
 
-const InputReplacement = ({tags, removeTag, ...restProps}: any) => {
-  const [css] = useStyletron();
-  return (
-    <div
-      className={css({
-        flex: '1 1 0%',
-        flexWrap: 'wrap',
-        display: 'flex',
-        alignItems: 'center',
-      })}
-    >
-      {tags.map((tag: string, index: number) => (
-        <Tag
-          variant={TAG_VARIANT.solid}
-          onActionClick={() => removeTag(tag)}
-          key={index}
-        >
-          {tag}
-        </Tag>
-      ))}
-      <StyledInput {...restProps} />
-    </div>
-  );
-};
+const InputReplacement = React.forwardRef(
+  ({tags, removeTag, ...restProps}: any, ref) => {
+    const [css] = useStyletron();
+    return (
+      <div
+        className={css({
+          flex: '1 1 0%',
+          flexWrap: 'wrap',
+          display: 'flex',
+          alignItems: 'center',
+        })}
+      >
+        {tags.map((tag: string, index: number) => (
+          <Tag
+            variant={TAG_VARIANT.solid}
+            onActionClick={() => removeTag(tag)}
+            key={index}
+          >
+            {tag}
+          </Tag>
+        ))}
+        <StyledInput ref={ref} {...restProps} />
+      </div>
+    );
+  },
+);
 
 export default () => {
   const [value, setValue] = React.useState('');

--- a/documentation-site/examples/pagination/overrides.tsx
+++ b/documentation-site/examples/pagination/overrides.tsx
@@ -17,12 +17,12 @@ export default () => (
         }),
       },
       PrevButton: {
-        component: ({onClick}) => (
+        component: ({onClick}: any) => (
           <Button onClick={onClick}>Left</Button>
         ),
       },
       NextButton: {
-        component: ({onClick}) => (
+        component: ({onClick}: any) => (
           <Button onClick={onClick}>Right</Button>
         ),
       },

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -6,8 +6,12 @@ type StyleOverride<T> =
   | StyleObject
   | ((props: {$theme: Theme} & React.PropsWithChildren<T>) => StyleObject);
 
+type ComponentOverride<T> =
+  | React.ComponentType<T>
+  | React.RefForwardingComponent<T>;
+
 interface OverrideObject<T> {
-  component?: React.ComponentType<T>;
+  component?: ComponentOverride<T>;
   props?: any;
   style?: StyleOverride<T>;
 }


### PR DESCRIPTION
Fixes #2591

#### Description
- Add forward ref to the example
- Update the overrides component type to accept ForwardRef hoc

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
