### PR TITLE
feat(popover): add autoFocus and returnFocus

### DIFF
--- a/documentation-site/components/yard/config/popover.ts
+++ b/documentation-site/components/yard/config/popover.ts
@@ -5,6 +5,8 @@ import {
   PLACEMENT,
   TRIGGER_TYPE,
 } from 'baseui/popover';
+import {Button} from 'baseui/button';
+import {Input} from 'baseui/input';
 import {PropTypes} from 'react-view';
 import {TConfig} from '../types';
 
@@ -17,6 +19,8 @@ const PopoverConfig: TConfig = {
     'baseui/popover': {named: ['StatefulPopover']},
   },
   scope: {
+    Button,
+    Input,
     StatefulPopover,
     ACCESSIBILITY_TYPE,
     PLACEMENT,
@@ -25,14 +29,28 @@ const PopoverConfig: TConfig = {
   theme: [],
   props: {
     content: {
-      value: `() => 'Hello, there! 👋'`,
+      value: `
+        () => <div>Hello, there! 👋
+          <Input placeholder="Focusable Element" />
+        </div>
+      `,
       type: PropTypes.Function,
       description: `The content of the popover.`,
+      imports: {
+        'baseui/input': {
+          named: ['Input'],
+        },
+      },
     },
     children: {
-      value: `Click me`,
+      value: `<Button>Click me</Button>`,
       type: PropTypes.ReactNode,
       description: `The content that will trigger the popover.`,
+      imports: {
+        'baseui/button': {
+          named: ['Button'],
+        },
+      },
     },
     placement: {
       value: 'PLACEMENT.auto',
@@ -66,6 +84,19 @@ const PopoverConfig: TConfig = {
       type: PropTypes.Boolean,
       description:
         'If true, an arrow will be shown pointing from the popover to the trigger element.',
+    },
+    returnFocus: {
+      value: true,
+      type: PropTypes.Boolean,
+      description:
+        'If true, focus will shift back to the original element after popover closes. Set this to false if focusing the original element triggers the popover.',
+    },
+    autoFocus: {
+      value: true,
+      type: PropTypes.Boolean,
+      description:
+        'If true, focus will shift to the first interactive element within the popover.',
+      hidden: true,
     },
     accessibilityType: {
       value: 'ACCESSIBILITY_TYPE.menu',

--- a/documentation-site/components/yard/config/popover.ts
+++ b/documentation-site/components/yard/config/popover.ts
@@ -86,6 +86,11 @@ const PopoverConfig: TConfig = {
       description:
         'If true, an arrow will be shown pointing from the popover to the trigger element.',
     },
+    focusLock: {
+      value: true,
+      type: PropTypes.Boolean,
+      description: 'If true, focus will be locked to the popover contents.',
+    },
     returnFocus: {
       value: true,
       type: PropTypes.Boolean,

--- a/documentation-site/components/yard/config/popover.ts
+++ b/documentation-site/components/yard/config/popover.ts
@@ -29,10 +29,11 @@ const PopoverConfig: TConfig = {
   theme: [],
   props: {
     content: {
-      value: `
-        () => <div>Hello, there! 👋
-          <Input placeholder="Focusable Element" />
-        </div>
+      value: `() => (
+  <div>Hello, there! 👋
+    <Input placeholder="Focusable Element" />
+  </div>
+)
       `,
       type: PropTypes.Function,
       description: `The content of the popover.`,

--- a/documentation-site/components/yard/config/tooltip.ts
+++ b/documentation-site/components/yard/config/tooltip.ts
@@ -6,6 +6,8 @@ import {
 } from 'baseui/tooltip';
 import {PropTypes} from 'react-view';
 import {TConfig} from '../types';
+import {Button} from 'baseui/button';
+import {Input} from 'baseui/input';
 
 const tooltipProps = require('!!extract-react-types-loader!../../../../src/popover/stateful-popover.js');
 
@@ -17,6 +19,8 @@ const TooltipConfig: TConfig = {
     'baseui/tooltip': {named: ['StatefulTooltip']},
   },
   scope: {
+    Button,
+    Input,
     StatefulTooltip,
     ACCESSIBILITY_TYPE,
     PLACEMENT,

--- a/documentation-site/pages/components/popover.mdx
+++ b/documentation-site/pages/components/popover.mdx
@@ -52,6 +52,7 @@ structured content and imagery/illustration. It’s usage depends on the context
 
 ## Accessibility
 
+- Upon opening, focus will be transferred to the first interactive element (unless `autofocus` is set to false)
 - The anchor will be focusable and user can tab to it using their keyboard.
 - When triggerType="hover" focusing on the anchor will open the tooltip automatically
 - When triggerType="click" a focused tooltip can be triggered via spacebar (assuming the anchor is a button)

--- a/src/datepicker/calendar-header.js
+++ b/src/datepicker/calendar-header.js
@@ -340,6 +340,7 @@ export default class CalendarHeader extends React.Component<
     ) : (
       <OverriddenPopover
         placement="bottom"
+        focusLock={false}
         mountNode={this.props.popoverMountNode}
         isOpen={this.state.isMonthYearDropdownOpen}
         onClick={() => {

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -245,7 +245,7 @@ export default class Datepicker extends React.Component<
         {locale => (
           <React.Fragment>
             <PopoverComponent
-              returnFocus={false}
+              focusLock={false}
               mountNode={this.props.mountNode}
               placement={PLACEMENT.bottom}
               isOpen={this.state.isOpen}

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -245,6 +245,7 @@ export default class Datepicker extends React.Component<
         {locale => (
           <React.Fragment>
             <PopoverComponent
+              returnFocus={false}
               mountNode={this.props.mountNode}
               placement={PLACEMENT.bottom}
               isOpen={this.state.isOpen}

--- a/src/menu/__tests__/menu.e2e.js
+++ b/src/menu/__tests__/menu.e2e.js
@@ -114,6 +114,15 @@ describe('menu-child', () => {
     await page.waitFor(childSelector);
   });
 
+  it('allows child menu to release focus and closes menu when different menu item selected', async () => {
+    await mount(page, 'menu-child');
+    await hoverItem(page, 0, 5);
+    await page.waitFor(childSelector);
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowDown');
+    await page.waitFor(childSelector, {hidden: true});
+  });
+
   it('highlights child menu item on hover', async () => {
     await mount(page, 'menu-child');
     await hoverItem(page, 0, 5);

--- a/src/menu/maybe-child-menu.js
+++ b/src/menu/maybe-child-menu.js
@@ -31,6 +31,7 @@ export default function MaybeChildMenu(props: PropsT) {
 
   return (
     <Popover
+      focusLock={false}
       isOpen={props.isOpen}
       content={ChildMenu}
       ignoreBoundary

--- a/src/phone-input/country-select.js
+++ b/src/phone-input/country-select.js
@@ -156,6 +156,7 @@ export default function CountrySelect(props: CountrySelectPropsT) {
     },
     Popover: {
       props: {
+        returnFocus: false,
         placement: PLACEMENT.bottomLeft,
       },
     },

--- a/src/phone-input/country-select.js
+++ b/src/phone-input/country-select.js
@@ -156,7 +156,7 @@ export default function CountrySelect(props: CountrySelectPropsT) {
     },
     Popover: {
       props: {
-        returnFocus: false,
+        focusLock: false,
         placement: PLACEMENT.bottomLeft,
       },
     },

--- a/src/phone-input/default-props.js
+++ b/src/phone-input/default-props.js
@@ -15,7 +15,7 @@ const defaultProps = {
   'aria-label': 'Please choose a country dial code and enter a phone number.',
   'aria-describedby': null,
   'aria-labelledby': null,
-  autoFocus: false,
+  returnFocus: false,
   country: {label: 'United States', id: 'US', dialCode: '+1'},
   disabled: false,
   error: false,

--- a/src/phone-input/default-props.js
+++ b/src/phone-input/default-props.js
@@ -15,7 +15,7 @@ const defaultProps = {
   'aria-label': 'Please choose a country dial code and enter a phone number.',
   'aria-describedby': null,
   'aria-labelledby': null,
-  returnFocus: false,
+  focusLock: false,
   country: {label: 'United States', id: 'US', dialCode: '+1'},
   disabled: false,
   error: false,

--- a/src/popover/__tests__/__snapshots__/popover.test.js.snap
+++ b/src/popover/__tests__/__snapshots__/popover.test.js.snap
@@ -9,6 +9,7 @@ exports[`Popover component as anchor 1`] = `
       Hello world
     </strong>
   }
+  focusLock={true}
   ignoreBoundary={false}
   isOpen={true}
   onClick={[MockFunction]}
@@ -206,7 +207,7 @@ exports[`Popover component as anchor 1`] = `
             onBlur={[Function]}
             onFocus={[Function]}
           >
-            <Body
+            <ForwardRef
               $arrowOffset={
                 Object {
                   "left": 0,
@@ -289,7 +290,7 @@ exports[`Popover component as anchor 1`] = `
                     }
                   }
                 >
-                  <Inner
+                  <ForwardRef
                     $arrowOffset={
                       Object {
                         "left": 0,
@@ -346,10 +347,10 @@ exports[`Popover component as anchor 1`] = `
                         </strong>
                       </div>
                     </MockStyledComponent>
-                  </Inner>
+                  </ForwardRef>
                 </div>
               </MockStyledComponent>
-            </Body>
+            </ForwardRef>
           </div>
         </ForwardRef>
       </ForwardRef>

--- a/src/popover/__tests__/__snapshots__/popover.test.js.snap
+++ b/src/popover/__tests__/__snapshots__/popover.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Popover component as anchor 1`] = `
 <Popover
   accessibilityType="menu"
+  autoFocus={true}
   content={
     <strong>
       Hello world
@@ -15,6 +16,7 @@ exports[`Popover component as anchor 1`] = `
   onMouseLeaveDelay={200}
   overrides={Object {}}
   placement="auto"
+  returnFocus={true}
   showArrow={false}
   triggerType="click"
 >
@@ -52,93 +54,73 @@ exports[`Popover component as anchor 1`] = `
       />
     </MockStyledComponent>
   </CustomComponent>
-  <mockConstructor
-    key="new-layer"
-    onMount={[Function]}
-    onUnmount={[Function]}
+  <ForwardRef
+    autoFocus={true}
+    noFocusGuards={true}
+    returnFocus={true}
   >
-    <mockConstructor
-      anchorRef={
-        <span
-          aria-controls="bui-mock-id"
-          aria-expanded="true"
-          aria-haspopup="true"
-          styled-component="true"
-          test-style="[object Object]"
-        />
-      }
-      arrowRef={null}
-      onPopperUpdate={[Function]}
-      placement="auto"
-      popperOptions={
-        Object {
-          "modifiers": Object {
-            "preventOverflow": Object {
-              "enabled": true,
-            },
-          },
-        }
-      }
-      popperRef={
-        <div
-          data-baseweb="popover"
-          id="bui-mock-id"
-          styled-component="true"
-          test-style="[object Object]"
-        >
-          <div
-            styled-component="true"
-            test-style="[object Object]"
-          >
-            <strong>
-              Hello world
-            </strong>
-          </div>
-        </div>
-      }
+    <ForwardRef
+      as="div"
+      autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={true}
+      persistentFocus={false}
+      returnFocus={true}
+      sideCar={[Function]}
     >
-      <ForwardRef
-        $arrowOffset={
+      <SideEffect(FocusWatcher)
+        autoFocus={true}
+        disabled={false}
+        id={Object {}}
+        observed={
+          <div
+            data-focus-lock-disabled="false"
+          >
+            <div
+              data-baseweb="popover"
+              id="bui-mock-id"
+              styled-component="true"
+              test-style="[object Object]"
+            >
+              <div
+                styled-component="true"
+                test-style="[object Object]"
+              >
+                <strong>
+                  Hello world
+                </strong>
+              </div>
+            </div>
+          </div>
+        }
+        onActivation={[Function]}
+        onDeactivation={[Function]}
+        persistentFocus={false}
+        returnFocus={[Function]}
+        shards={Array []}
+        sideCar={
           Object {
-            "left": 0,
-            "top": 0,
+            "assignMedium": [Function],
+            "assignSyncMedium": [Function],
+            "options": Object {
+              "async": true,
+              "ssr": false,
+            },
+            "read": [Function],
+            "useMedium": [Function],
           }
         }
-        $isAnimating={false}
-        $isOpen={true}
-        $placement="auto"
-        $popoverOffset={
-          Object {
-            "left": 0,
-            "top": 0,
-          }
-        }
-        $showArrow={false}
-        data-baseweb="popover"
-        id="bui-mock-id"
-        key="popover-body"
       >
-        <MockStyledComponent
-          $arrowOffset={
-            Object {
-              "left": 0,
-              "top": 0,
-            }
-          }
-          $isAnimating={false}
-          $isOpen={true}
-          $placement="auto"
-          $popoverOffset={
-            Object {
-              "left": 0,
-              "top": 0,
-            }
-          }
-          $showArrow={false}
-          data-baseweb="popover"
-          forwardedRef={
-            Object {
-              "current": <div
+        <FocusWatcher
+          autoFocus={true}
+          disabled={false}
+          id={Object {}}
+          observed={
+            <div
+              data-focus-lock-disabled="false"
+            >
+              <div
                 data-baseweb="popover"
                 id="bui-mock-id"
                 styled-component="true"
@@ -152,32 +134,76 @@ exports[`Popover component as anchor 1`] = `
                     Hello world
                   </strong>
                 </div>
-              </div>,
+              </div>
+            </div>
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          returnFocus={[Function]}
+          shards={Array []}
+          sideCar={
+            Object {
+              "assignMedium": [Function],
+              "assignSyncMedium": [Function],
+              "options": Object {
+                "async": true,
+                "ssr": false,
+              },
+              "read": [Function],
+              "useMedium": [Function],
             }
           }
-          id="bui-mock-id"
+        />
+      </SideEffect(FocusWatcher)>
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <mockConstructor
+          key="new-layer"
+          onMount={[Function]}
+          onUnmount={[Function]}
         >
-          <div
-            data-baseweb="popover"
-            id="bui-mock-id"
-            styled-component="true"
-            test-style={
+          <mockConstructor
+            anchorRef={
+              <span
+                aria-controls="bui-mock-id"
+                aria-expanded="true"
+                aria-haspopup="true"
+                styled-component="true"
+                test-style="[object Object]"
+              />
+            }
+            arrowRef={null}
+            onPopperUpdate={[Function]}
+            placement="auto"
+            popperOptions={
               Object {
-                "backgroundColor": "$theme.colors.backgroundPrimary",
-                "borderBottomLeftRadius": "$theme.borders.popoverBorderRadius",
-                "borderBottomRightRadius": "$theme.borders.popoverBorderRadius",
-                "borderTopLeftRadius": "$theme.borders.popoverBorderRadius",
-                "borderTopRightRadius": "$theme.borders.popoverBorderRadius",
-                "boxShadow": "$theme.lighting.shadow600",
-                "left": 0,
-                "opacity": 0,
-                "position": "absolute",
-                "top": 0,
-                "transform": "translate3d(-16px, 0px, 0)",
-                "transitionDuration": "0s",
-                "transitionProperty": "opacity,transform",
-                "transitionTimingFunction": "$theme.animation.easeOutCurve",
+                "modifiers": Object {
+                  "preventOverflow": Object {
+                    "enabled": true,
+                  },
+                },
               }
+            }
+            popperRef={
+              <div
+                data-baseweb="popover"
+                id="bui-mock-id"
+                styled-component="true"
+                test-style="[object Object]"
+              >
+                <div
+                  styled-component="true"
+                  test-style="[object Object]"
+                >
+                  <strong>
+                    Hello world
+                  </strong>
+                </div>
+              </div>
             }
           >
             <ForwardRef
@@ -197,7 +223,9 @@ exports[`Popover component as anchor 1`] = `
                 }
               }
               $showArrow={false}
-              key="popover-inner"
+              data-baseweb="popover"
+              id="bui-mock-id"
+              key="popover-body"
             >
               <MockStyledComponent
                 $arrowOffset={
@@ -216,9 +244,31 @@ exports[`Popover component as anchor 1`] = `
                   }
                 }
                 $showArrow={false}
-                forwardedRef={null}
+                data-baseweb="popover"
+                forwardedRef={
+                  Object {
+                    "current": <div
+                      data-baseweb="popover"
+                      id="bui-mock-id"
+                      styled-component="true"
+                      test-style="[object Object]"
+                    >
+                      <div
+                        styled-component="true"
+                        test-style="[object Object]"
+                      >
+                        <strong>
+                          Hello world
+                        </strong>
+                      </div>
+                    </div>,
+                  }
+                }
+                id="bui-mock-id"
               >
                 <div
+                  data-baseweb="popover"
+                  id="bui-mock-id"
                   styled-component="true"
                   test-style={
                     Object {
@@ -227,22 +277,84 @@ exports[`Popover component as anchor 1`] = `
                       "borderBottomRightRadius": "$theme.borders.popoverBorderRadius",
                       "borderTopLeftRadius": "$theme.borders.popoverBorderRadius",
                       "borderTopRightRadius": "$theme.borders.popoverBorderRadius",
-                      "color": "$theme.colors.contentPrimary",
-                      "position": "relative",
+                      "boxShadow": "$theme.lighting.shadow600",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "top": 0,
+                      "transform": "translate3d(-16px, 0px, 0)",
+                      "transitionDuration": "0s",
+                      "transitionProperty": "opacity,transform",
+                      "transitionTimingFunction": "$theme.animation.easeOutCurve",
                     }
                   }
                 >
-                  <strong>
-                    Hello world
-                  </strong>
+                  <ForwardRef
+                    $arrowOffset={
+                      Object {
+                        "left": 0,
+                        "top": 0,
+                      }
+                    }
+                    $isAnimating={false}
+                    $isOpen={true}
+                    $placement="auto"
+                    $popoverOffset={
+                      Object {
+                        "left": 0,
+                        "top": 0,
+                      }
+                    }
+                    $showArrow={false}
+                    key="popover-inner"
+                  >
+                    <MockStyledComponent
+                      $arrowOffset={
+                        Object {
+                          "left": 0,
+                          "top": 0,
+                        }
+                      }
+                      $isAnimating={false}
+                      $isOpen={true}
+                      $placement="auto"
+                      $popoverOffset={
+                        Object {
+                          "left": 0,
+                          "top": 0,
+                        }
+                      }
+                      $showArrow={false}
+                      forwardedRef={null}
+                    >
+                      <div
+                        styled-component="true"
+                        test-style={
+                          Object {
+                            "backgroundColor": "$theme.colors.backgroundPrimary",
+                            "borderBottomLeftRadius": "$theme.borders.popoverBorderRadius",
+                            "borderBottomRightRadius": "$theme.borders.popoverBorderRadius",
+                            "borderTopLeftRadius": "$theme.borders.popoverBorderRadius",
+                            "borderTopRightRadius": "$theme.borders.popoverBorderRadius",
+                            "color": "$theme.colors.contentPrimary",
+                            "position": "relative",
+                          }
+                        }
+                      >
+                        <strong>
+                          Hello world
+                        </strong>
+                      </div>
+                    </MockStyledComponent>
+                  </ForwardRef>
                 </div>
               </MockStyledComponent>
             </ForwardRef>
-          </div>
-        </MockStyledComponent>
-      </ForwardRef>
-    </mockConstructor>
-  </mockConstructor>
+          </mockConstructor>
+        </mockConstructor>
+      </div>
+    </ForwardRef>
+  </ForwardRef>
 </Popover>
 `;
 

--- a/src/popover/__tests__/__snapshots__/popover.test.js.snap
+++ b/src/popover/__tests__/__snapshots__/popover.test.js.snap
@@ -54,159 +54,159 @@ exports[`Popover component as anchor 1`] = `
       />
     </MockStyledComponent>
   </CustomComponent>
-  <ForwardRef
-    autoFocus={true}
-    noFocusGuards={true}
-    returnFocus={true}
+  <mockConstructor
+    key="new-layer"
+    onMount={[Function]}
+    onUnmount={[Function]}
   >
-    <ForwardRef
-      as="div"
-      autoFocus={true}
-      disabled={false}
-      lockProps={Object {}}
-      noFocusGuards={true}
-      persistentFocus={false}
-      returnFocus={true}
-      sideCar={[Function]}
-    >
-      <SideEffect(FocusWatcher)
-        autoFocus={true}
-        disabled={false}
-        id={Object {}}
-        observed={
-          <div
-            data-focus-lock-disabled="false"
-          >
-            <div
-              data-baseweb="popover"
-              id="bui-mock-id"
-              styled-component="true"
-              test-style="[object Object]"
-            >
-              <div
-                styled-component="true"
-                test-style="[object Object]"
-              >
-                <strong>
-                  Hello world
-                </strong>
-              </div>
-            </div>
-          </div>
-        }
-        onActivation={[Function]}
-        onDeactivation={[Function]}
-        persistentFocus={false}
-        returnFocus={[Function]}
-        shards={Array []}
-        sideCar={
-          Object {
-            "assignMedium": [Function],
-            "assignSyncMedium": [Function],
-            "options": Object {
-              "async": true,
-              "ssr": false,
+    <mockConstructor
+      anchorRef={
+        <span
+          aria-controls="bui-mock-id"
+          aria-expanded="true"
+          aria-haspopup="true"
+          styled-component="true"
+          test-style="[object Object]"
+        />
+      }
+      arrowRef={null}
+      onPopperUpdate={[Function]}
+      placement="auto"
+      popperOptions={
+        Object {
+          "modifiers": Object {
+            "preventOverflow": Object {
+              "enabled": true,
             },
-            "read": [Function],
-            "useMedium": [Function],
-          }
+          },
         }
+      }
+      popperRef={
+        <div
+          data-baseweb="popover"
+          id="bui-mock-id"
+          styled-component="true"
+          test-style="[object Object]"
+        >
+          <div
+            styled-component="true"
+            test-style="[object Object]"
+          >
+            <strong>
+              Hello world
+            </strong>
+          </div>
+        </div>
+      }
+    >
+      <ForwardRef
+        autoFocus={true}
+        noFocusGuards={true}
+        returnFocus={true}
       >
-        <FocusWatcher
+        <ForwardRef
+          as="div"
           autoFocus={true}
           disabled={false}
-          id={Object {}}
-          observed={
-            <div
-              data-focus-lock-disabled="false"
-            >
+          lockProps={Object {}}
+          noFocusGuards={true}
+          persistentFocus={false}
+          returnFocus={true}
+          sideCar={[Function]}
+        >
+          <SideEffect(FocusWatcher)
+            autoFocus={true}
+            disabled={false}
+            id={Object {}}
+            observed={
               <div
-                data-baseweb="popover"
-                id="bui-mock-id"
-                styled-component="true"
-                test-style="[object Object]"
+                data-focus-lock-disabled="false"
               >
                 <div
+                  data-baseweb="popover"
+                  id="bui-mock-id"
                   styled-component="true"
                   test-style="[object Object]"
                 >
-                  <strong>
-                    Hello world
-                  </strong>
+                  <div
+                    styled-component="true"
+                    test-style="[object Object]"
+                  >
+                    <strong>
+                      Hello world
+                    </strong>
+                  </div>
                 </div>
               </div>
-            </div>
-          }
-          onActivation={[Function]}
-          onDeactivation={[Function]}
-          persistentFocus={false}
-          returnFocus={[Function]}
-          shards={Array []}
-          sideCar={
-            Object {
-              "assignMedium": [Function],
-              "assignSyncMedium": [Function],
-              "options": Object {
-                "async": true,
-                "ssr": false,
-              },
-              "read": [Function],
-              "useMedium": [Function],
             }
-          }
-        />
-      </SideEffect(FocusWatcher)>
-      <div
-        data-focus-lock-disabled={false}
-        onBlur={[Function]}
-        onFocus={[Function]}
-      >
-        <mockConstructor
-          key="new-layer"
-          onMount={[Function]}
-          onUnmount={[Function]}
-        >
-          <mockConstructor
-            anchorRef={
-              <span
-                aria-controls="bui-mock-id"
-                aria-expanded="true"
-                aria-haspopup="true"
-                styled-component="true"
-                test-style="[object Object]"
-              />
-            }
-            arrowRef={null}
-            onPopperUpdate={[Function]}
-            placement="auto"
-            popperOptions={
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            returnFocus={[Function]}
+            shards={Array []}
+            sideCar={
               Object {
-                "modifiers": Object {
-                  "preventOverflow": Object {
-                    "enabled": true,
-                  },
+                "assignMedium": [Function],
+                "assignSyncMedium": [Function],
+                "options": Object {
+                  "async": true,
+                  "ssr": false,
                 },
+                "read": [Function],
+                "useMedium": [Function],
               }
             }
-            popperRef={
-              <div
-                data-baseweb="popover"
-                id="bui-mock-id"
-                styled-component="true"
-                test-style="[object Object]"
-              >
-                <div
-                  styled-component="true"
-                  test-style="[object Object]"
-                >
-                  <strong>
-                    Hello world
-                  </strong>
-                </div>
-              </div>
-            }
           >
-            <ForwardRef
+            <FocusWatcher
+              autoFocus={true}
+              disabled={false}
+              id={Object {}}
+              observed={
+                <div
+                  data-focus-lock-disabled="false"
+                >
+                  <div
+                    data-baseweb="popover"
+                    id="bui-mock-id"
+                    styled-component="true"
+                    test-style="[object Object]"
+                  >
+                    <div
+                      styled-component="true"
+                      test-style="[object Object]"
+                    >
+                      <strong>
+                        Hello world
+                      </strong>
+                    </div>
+                  </div>
+                </div>
+              }
+              onActivation={[Function]}
+              onDeactivation={[Function]}
+              persistentFocus={false}
+              returnFocus={[Function]}
+              shards={Array []}
+              sideCar={
+                Object {
+                  "assignMedium": [Function],
+                  "assignSyncMedium": [Function],
+                  "options": Object {
+                    "async": true,
+                    "ssr": false,
+                  },
+                  "read": [Function],
+                  "useMedium": [Function],
+                }
+              }
+            />
+          </SideEffect(FocusWatcher)>
+          <div
+            data-focus-lock-disabled={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
+          >
+            <Body
               $arrowOffset={
                 Object {
                   "left": 0,
@@ -289,7 +289,7 @@ exports[`Popover component as anchor 1`] = `
                     }
                   }
                 >
-                  <ForwardRef
+                  <Inner
                     $arrowOffset={
                       Object {
                         "left": 0,
@@ -346,15 +346,15 @@ exports[`Popover component as anchor 1`] = `
                         </strong>
                       </div>
                     </MockStyledComponent>
-                  </ForwardRef>
+                  </Inner>
                 </div>
               </MockStyledComponent>
-            </ForwardRef>
-          </mockConstructor>
-        </mockConstructor>
-      </div>
-    </ForwardRef>
-  </ForwardRef>
+            </Body>
+          </div>
+        </ForwardRef>
+      </ForwardRef>
+    </mockConstructor>
+  </mockConstructor>
 </Popover>
 `;
 

--- a/src/popover/__tests__/__snapshots__/stateful-popover.test.js.snap
+++ b/src/popover/__tests__/__snapshots__/stateful-popover.test.js.snap
@@ -5,6 +5,7 @@ exports[`StatefulPopover basic render: renders <Popover/> as child to container 
   accessibilityType="menu"
   autoFocus={true}
   content={[Function]}
+  focusLock={true}
   ignoreBoundary={false}
   isOpen={true}
   onBlur={[Function]}

--- a/src/popover/__tests__/__snapshots__/stateful-popover.test.js.snap
+++ b/src/popover/__tests__/__snapshots__/stateful-popover.test.js.snap
@@ -3,6 +3,7 @@
 exports[`StatefulPopover basic render: renders <Popover/> as child to container 1`] = `
 <Popover
   accessibilityType="menu"
+  autoFocus={true}
   content={[Function]}
   ignoreBoundary={false}
   isOpen={true}
@@ -21,6 +22,7 @@ exports[`StatefulPopover basic render: renders <Popover/> as child to container 
   }
   placement="topLeft"
   popperOptions={Object {}}
+  returnFocus={true}
   showArrow={true}
   triggerType="hover"
 >

--- a/src/popover/__tests__/popover.test.js
+++ b/src/popover/__tests__/popover.test.js
@@ -176,6 +176,7 @@ describe('Popover', () => {
     wrapper = mount(
       <Popover
         content={content}
+        returnFocus={false}
         isOpen={false}
         triggerType="hover"
         onClick={onClickPopover}
@@ -199,7 +200,11 @@ describe('Popover', () => {
     wrapper.setProps({isOpen: true});
 
     // Portal should have the popover body and content
-    let popoverBody = wrapper.childAt(1).childAt(0);
+    let popoverBody = wrapper
+      .childAt(1)
+      .childAt(0)
+      .childAt(1)
+      .childAt(0);
     popoverBody.simulate('mouseleave');
     expect(onMouseLeave).not.toBeCalled();
     jest.runAllTimers();
@@ -224,10 +229,12 @@ describe('Popover', () => {
 
     const calls = document.addEventListener.mock.calls;
     expect(document.addEventListener).toBeCalled();
-    expect(calls[0][0]).toBe('mousedown');
-    expect(calls[1][0]).toBe('keyup');
+    expect(calls[0][0]).toBe('focusin');
+    expect(calls[1][0]).toBe('focusout');
+    expect(calls[2][0]).toBe('mousedown');
+    expect(calls[3][0]).toBe('keyup');
 
-    calls[1][1]({
+    calls[3][1]({
       key: 'Escape',
       code: 27,
       keyCode: 27,

--- a/src/popover/__tests__/popover.test.js
+++ b/src/popover/__tests__/popover.test.js
@@ -199,12 +199,7 @@ describe('Popover', () => {
     // Show the popover
     wrapper.setProps({isOpen: true});
 
-    // Portal should have the popover body and content
-    let popoverBody = wrapper
-      .childAt(1)
-      .childAt(0)
-      .childAt(1)
-      .childAt(0);
+    let popoverBody = wrapper.find('Body[data-baseweb="popover"]');
     popoverBody.simulate('mouseleave');
     expect(onMouseLeave).not.toBeCalled();
     jest.runAllTimers();

--- a/src/popover/__tests__/popover.test.js
+++ b/src/popover/__tests__/popover.test.js
@@ -199,7 +199,7 @@ describe('Popover', () => {
     // Show the popover
     wrapper.setProps({isOpen: true});
 
-    let popoverBody = wrapper.find('Body[data-baseweb="popover"]');
+    let popoverBody = wrapper.find('[data-baseweb="popover"]').first();
     popoverBody.simulate('mouseleave');
     expect(onMouseLeave).not.toBeCalled();
     jest.runAllTimers();

--- a/src/popover/__tests__/popover.test.js
+++ b/src/popover/__tests__/popover.test.js
@@ -211,6 +211,47 @@ describe('Popover', () => {
     expect(onClickPopover).not.toBeCalled();
   });
 
+  test('autoFocus and returnFocus', () => {
+    const buttonId = 'foo';
+    const firstInputId = 'bar';
+    const FocusMe = React.forwardRef(() => {
+      const el = React.useRef(null);
+      React.useEffect(() => {
+        el.current && el.current.focus();
+      });
+      return (
+        <button id={buttonId} ref={el} type="button">
+          Click me
+        </button>
+      );
+    });
+    const content = (
+      <div>
+        <input id={firstInputId} />
+        <input id="baz" />
+      </div>
+    );
+    wrapper = mount(
+      <Popover content={content} isOpen={false}>
+        <FocusMe />
+      </Popover>,
+    );
+
+    // Show the popover
+    wrapper.simulate('click');
+    wrapper.setProps({isOpen: true});
+
+    // focused element (document.activeElement) should be the first input
+    expect(document.activeElement).not.toBeNull();
+    expect((document.activeElement: any).id).toEqual(firstInputId);
+
+    wrapper.setProps({isOpen: false});
+
+    // focused element (document.activeElement) should return to button
+    expect(document.activeElement).not.toBeNull();
+    expect((document.activeElement: any).id).toEqual(buttonId);
+  });
+
   test('dismissOnEsc', () => {
     const onClick = jest.fn();
     const onEsc = jest.fn();

--- a/src/popover/default-props.js
+++ b/src/popover/default-props.js
@@ -10,6 +10,8 @@ import type {BasePopoverPropsT} from './types.js';
 
 const baseDefaultProps: $Shape<BasePopoverPropsT> = {
   accessibilityType: ACCESSIBILITY_TYPE.menu,
+  returnFocus: true,
+  autoFocus: true,
   // Remove the `ignoreBoundary` prop in the next major version
   // and have it replaced with the TetherBehavior props overrides
   ignoreBoundary: false,

--- a/src/popover/default-props.js
+++ b/src/popover/default-props.js
@@ -10,8 +10,9 @@ import type {BasePopoverPropsT} from './types.js';
 
 const baseDefaultProps: $Shape<BasePopoverPropsT> = {
   accessibilityType: ACCESSIBILITY_TYPE.menu,
-  returnFocus: true,
+  focusLock: true,
   autoFocus: true,
+  returnFocus: true,
   // Remove the `ignoreBoundary` prop in the next major version
   // and have it replaced with the TetherBehavior props overrides
   ignoreBoundary: false,

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -459,13 +459,17 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
               onPopperUpdate={this.onPopperUpdate}
               placement={this.state.placement}
             >
-              <FocusLock
-                noFocusGuards={true}
-                returnFocus={this.props.returnFocus}
-                autoFocus={this.props.autoFocus} // eslint-disable-line jsx-a11y/no-autofocus
-              >
-                {this.renderPopover()}
-              </FocusLock>
+              {this.props.focusLock ? (
+                <FocusLock
+                  noFocusGuards={true}
+                  returnFocus={this.props.returnFocus}
+                  autoFocus={this.props.autoFocus} // eslint-disable-line jsx-a11y/no-autofocus
+                >
+                  {this.renderPopover()}
+                </FocusLock>
+              ) : (
+                this.renderPopover()
+              )}
             </TetherBehavior>
           </Layer>,
         );

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 /* global document */
 /* eslint-disable react/no-find-dom-node */
 import * as React from 'react';
+import FocusLock from 'react-focus-lock';
 
 import {getOverride, getOverrideProps} from '../helpers/overrides.js';
 import getBuiId from '../utils/get-bui-id.js';
@@ -439,28 +440,34 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
     if (__BROWSER__) {
       if (this.state.isMounted && this.props.isOpen) {
         rendered.push(
-          <Layer
-            key={'new-layer'}
-            mountNode={this.props.mountNode}
-            onMount={() => this.setState({isLayerMounted: true})}
-            onUnmount={() => this.setState({isLayerMounted: false})}
+          <FocusLock
+            noFocusGuards={true}
+            returnFocus={this.props.returnFocus}
+            autoFocus={this.props.autoFocus} // eslint-disable-line jsx-a11y/no-autofocus
           >
-            <TetherBehavior
-              anchorRef={this.anchorRef.current}
-              arrowRef={this.arrowRef.current}
-              popperRef={this.popperRef.current}
-              // Remove the `ignoreBoundary` prop in the next major version
-              // and have it replaced with the TetherBehavior props overrides
-              popperOptions={{
-                ...defaultPopperOptions,
-                ...this.props.popperOptions,
-              }}
-              onPopperUpdate={this.onPopperUpdate}
-              placement={this.state.placement}
+            <Layer
+              key={'new-layer'}
+              mountNode={this.props.mountNode}
+              onMount={() => this.setState({isLayerMounted: true})}
+              onUnmount={() => this.setState({isLayerMounted: false})}
             >
-              {this.renderPopover()}
-            </TetherBehavior>
-          </Layer>,
+              <TetherBehavior
+                anchorRef={this.anchorRef.current}
+                arrowRef={this.arrowRef.current}
+                popperRef={this.popperRef.current}
+                // Remove the `ignoreBoundary` prop in the next major version
+                // and have it replaced with the TetherBehavior props overrides
+                popperOptions={{
+                  ...defaultPopperOptions,
+                  ...this.props.popperOptions,
+                }}
+                onPopperUpdate={this.onPopperUpdate}
+                placement={this.state.placement}
+              >
+                {this.renderPopover()}
+              </TetherBehavior>
+            </Layer>
+          </FocusLock>,
         );
       }
     }

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -440,34 +440,34 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
     if (__BROWSER__) {
       if (this.state.isMounted && this.props.isOpen) {
         rendered.push(
-          <FocusLock
-            noFocusGuards={true}
-            returnFocus={this.props.returnFocus}
-            autoFocus={this.props.autoFocus} // eslint-disable-line jsx-a11y/no-autofocus
+          <Layer
+            key={'new-layer'}
+            mountNode={this.props.mountNode}
+            onMount={() => this.setState({isLayerMounted: true})}
+            onUnmount={() => this.setState({isLayerMounted: false})}
           >
-            <Layer
-              key={'new-layer'}
-              mountNode={this.props.mountNode}
-              onMount={() => this.setState({isLayerMounted: true})}
-              onUnmount={() => this.setState({isLayerMounted: false})}
+            <TetherBehavior
+              anchorRef={this.anchorRef.current}
+              arrowRef={this.arrowRef.current}
+              popperRef={this.popperRef.current}
+              // Remove the `ignoreBoundary` prop in the next major version
+              // and have it replaced with the TetherBehavior props overrides
+              popperOptions={{
+                ...defaultPopperOptions,
+                ...this.props.popperOptions,
+              }}
+              onPopperUpdate={this.onPopperUpdate}
+              placement={this.state.placement}
             >
-              <TetherBehavior
-                anchorRef={this.anchorRef.current}
-                arrowRef={this.arrowRef.current}
-                popperRef={this.popperRef.current}
-                // Remove the `ignoreBoundary` prop in the next major version
-                // and have it replaced with the TetherBehavior props overrides
-                popperOptions={{
-                  ...defaultPopperOptions,
-                  ...this.props.popperOptions,
-                }}
-                onPopperUpdate={this.onPopperUpdate}
-                placement={this.state.placement}
+              <FocusLock
+                noFocusGuards={true}
+                returnFocus={this.props.returnFocus}
+                autoFocus={this.props.autoFocus} // eslint-disable-line jsx-a11y/no-autofocus
               >
                 {this.renderPopover()}
-              </TetherBehavior>
-            </Layer>
-          </FocusLock>,
+              </FocusLock>
+            </TetherBehavior>
+          </Layer>,
         );
       }
     }

--- a/src/popover/types.js
+++ b/src/popover/types.js
@@ -61,6 +61,15 @@ export type BasePopoverPropsT = {
    * See the A11Y section at the bottom of this document for more details.
    */
   accessibilityType?: AccessibilityTypeT,
+  /** If true, focus will shift to the first interactive element within the popover.
+   * If false, the popover container itself will receive focus.
+   * Moving focus into a newly opened popover is important for accessibility purposes, so please be careful!
+   */
+  autoFocus?: boolean,
+  /** If true, focus will shift back to the original element that triggered the popover
+   * Becareful with elements that open the popover on focus (e.g. input) this will cause the popover to reopen on close!
+   */
+  returnFocus?: boolean,
   'data-baseweb'?: string,
   id?: string,
   /** If true, popover element will not avoid element boundaries. */

--- a/src/popover/types.js
+++ b/src/popover/types.js
@@ -61,6 +61,9 @@ export type BasePopoverPropsT = {
    * See the A11Y section at the bottom of this document for more details.
    */
   accessibilityType?: AccessibilityTypeT,
+  /** If true, focus will be locked to elements within the popover.
+   */
+  focusLock?: boolean,
   /** If true, focus will shift to the first interactive element within the popover.
    * If false, the popover container itself will receive focus.
    * Moving focus into a newly opened popover is important for accessibility purposes, so please be careful!

--- a/src/select/__tests__/__snapshots__/select.test.js.snap
+++ b/src/select/__tests__/__snapshots__/select.test.js.snap
@@ -86,6 +86,7 @@ exports[`Select component renders component in search mode and false for multipl
   >
     <Popover
       accessibilityType="menu"
+      autoFocus={true}
       content={[Function]}
       ignoreBoundary={false}
       isOpen={false}
@@ -93,6 +94,7 @@ exports[`Select component renders component in search mode and false for multipl
       onMouseLeaveDelay={200}
       overrides={Object {}}
       placement="bottom"
+      returnFocus={true}
       showArrow={false}
       triggerType="click"
     >
@@ -915,6 +917,7 @@ exports[`Select component renders component in search mode and true for multiple
   >
     <Popover
       accessibilityType="menu"
+      autoFocus={true}
       content={[Function]}
       ignoreBoundary={false}
       isOpen={false}
@@ -922,6 +925,7 @@ exports[`Select component renders component in search mode and true for multiple
       onMouseLeaveDelay={200}
       overrides={Object {}}
       placement="bottom"
+      returnFocus={true}
       showArrow={false}
       triggerType="click"
     >
@@ -1744,6 +1748,7 @@ exports[`Select component renders component in select mode and false for multipl
   >
     <Popover
       accessibilityType="menu"
+      autoFocus={true}
       content={[Function]}
       ignoreBoundary={false}
       isOpen={false}
@@ -1751,6 +1756,7 @@ exports[`Select component renders component in select mode and false for multipl
       onMouseLeaveDelay={200}
       overrides={Object {}}
       placement="bottom"
+      returnFocus={true}
       showArrow={false}
       triggerType="click"
     >
@@ -2590,6 +2596,7 @@ exports[`Select component renders component in select mode and true for multiple
   >
     <Popover
       accessibilityType="menu"
+      autoFocus={true}
       content={[Function]}
       ignoreBoundary={false}
       isOpen={false}
@@ -2597,6 +2604,7 @@ exports[`Select component renders component in select mode and true for multiple
       onMouseLeaveDelay={200}
       overrides={Object {}}
       placement="bottom"
+      returnFocus={true}
       showArrow={false}
       triggerType="click"
     >

--- a/src/select/__tests__/__snapshots__/select.test.js.snap
+++ b/src/select/__tests__/__snapshots__/select.test.js.snap
@@ -88,6 +88,7 @@ exports[`Select component renders component in search mode and false for multipl
       accessibilityType="menu"
       autoFocus={true}
       content={[Function]}
+      focusLock={false}
       ignoreBoundary={false}
       isOpen={false}
       onMouseEnterDelay={200}
@@ -919,6 +920,7 @@ exports[`Select component renders component in search mode and true for multiple
       accessibilityType="menu"
       autoFocus={true}
       content={[Function]}
+      focusLock={false}
       ignoreBoundary={false}
       isOpen={false}
       onMouseEnterDelay={200}
@@ -1750,6 +1752,7 @@ exports[`Select component renders component in select mode and false for multipl
       accessibilityType="menu"
       autoFocus={true}
       content={[Function]}
+      focusLock={false}
       ignoreBoundary={false}
       isOpen={false}
       onMouseEnterDelay={200}
@@ -2598,6 +2601,7 @@ exports[`Select component renders component in select mode and true for multiple
       accessibilityType="menu"
       autoFocus={true}
       content={[Function]}
+      focusLock={false}
       ignoreBoundary={false}
       isOpen={false}
       onMouseEnterDelay={200}

--- a/src/select/select-component.js
+++ b/src/select/select-component.js
@@ -930,6 +930,7 @@ class Select extends React.Component<PropsT, SelectStateT> {
               if (!ref) return;
               this.anchor = ref.anchorRef;
             }}
+            focusLock={false}
             mountNode={this.props.mountNode}
             isOpen={isOpen}
             content={() => {

--- a/src/tooltip/__tests__/__snapshots__/stateful-tooltip.test.js.snap
+++ b/src/tooltip/__tests__/__snapshots__/stateful-tooltip.test.js.snap
@@ -5,6 +5,7 @@ exports[`StatefulTooltip basic render: renders <StatefulContainer/> 1`] = `
   accessibilityType="tooltip"
   autoFocus={true}
   content={[MockFunction]}
+  focusLock={true}
   initialState={
     Object {
       "isOpen": true,
@@ -35,6 +36,7 @@ exports[`StatefulTooltip basic render: renders <Tooltip/> 1`] = `
   accessibilityType="tooltip"
   autoFocus={true}
   content={[Function]}
+  focusLock={true}
   ignoreBoundary={false}
   isOpen={true}
   onBlur={[Function]}

--- a/src/tooltip/__tests__/__snapshots__/stateful-tooltip.test.js.snap
+++ b/src/tooltip/__tests__/__snapshots__/stateful-tooltip.test.js.snap
@@ -3,6 +3,7 @@
 exports[`StatefulTooltip basic render: renders <StatefulContainer/> 1`] = `
 <StatefulContainer
   accessibilityType="tooltip"
+  autoFocus={true}
   content={[MockFunction]}
   initialState={
     Object {
@@ -20,6 +21,7 @@ exports[`StatefulTooltip basic render: renders <StatefulContainer/> 1`] = `
   }
   placement="topLeft"
   popperOptions={Object {}}
+  returnFocus={true}
   showArrow={true}
   stateReducer={[MockFunction]}
   triggerType="hover"
@@ -31,6 +33,7 @@ exports[`StatefulTooltip basic render: renders <StatefulContainer/> 1`] = `
 exports[`StatefulTooltip basic render: renders <Tooltip/> 1`] = `
 <Tooltip
   accessibilityType="tooltip"
+  autoFocus={true}
   content={[Function]}
   ignoreBoundary={false}
   isOpen={true}
@@ -49,6 +52,7 @@ exports[`StatefulTooltip basic render: renders <Tooltip/> 1`] = `
   }
   placement="topLeft"
   popperOptions={Object {}}
+  returnFocus={true}
   showArrow={true}
   triggerType="hover"
 >

--- a/src/tooltip/default-props.js
+++ b/src/tooltip/default-props.js
@@ -10,6 +10,8 @@ import type {BaseTooltipPropsT} from './types.js';
 
 const baseDefaultProps: $Shape<BaseTooltipPropsT> = {
   accessibilityType: ACCESSIBILITY_TYPE.tooltip,
+  autoFocus: true,
+  returnFocus: true,
   onMouseEnterDelay: 200,
   onMouseLeaveDelay: 200,
   overrides: {},

--- a/src/tooltip/default-props.js
+++ b/src/tooltip/default-props.js
@@ -10,6 +10,7 @@ import type {BaseTooltipPropsT} from './types.js';
 
 const baseDefaultProps: $Shape<BaseTooltipPropsT> = {
   accessibilityType: ACCESSIBILITY_TYPE.tooltip,
+  focusLock: true,
   autoFocus: true,
   returnFocus: true,
   onMouseEnterDelay: 200,


### PR DESCRIPTION
Fixes #2633 

#### Description

Added props to popover

focusLock?:  boolean = true - whether to render with FocusLock or not (required for components that use popover but don't expect to be focus locked)
autoFocus?:  boolean = true - whether to autofocus first focusable element within content
returnFocus?: boolean = true - whether to return focus to original element after closing popover

implemented using FocusLock component similar to Drawer

returnFocus needs to be set to `false` if focusing the original element opens the popover in the first place or the popover will open again on close. (i.e. DatePicker)

set `noFocusGuard={true}` prop on FocusLock since it violates a11y rule elements should not have tabindex greater than 0 (e.g. https://dequeuniversity.com/rules/axe/3.2/tabindex)

updated some snapshots to account for element changes
fixed some tests to work as it did before (mostly tests that grab values at specific indexes which are different now after inserting new stuff)

updated documentation with the three new props, and updated example element to include focusable components so that the autoFocus / returnFocus can be demonstrated

had to set `focusLock` to `false` on components that used popover since it was breaking e2e tests
- datepicker
- calendar-header
- country-select
- select-component
- maybe-child-menu (added new e2e test to test for functionality of navigating into child menu and navigating back out and to a different menu item)
#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
