### PR TITLE
fix(datepicker): yard config autoFocusCalendar prop type

### DIFF
--- a/documentation-site/components/yard/config/datepicker.ts
+++ b/documentation-site/components/yard/config/datepicker.ts
@@ -67,7 +67,7 @@ const DatepickerConfig: TConfig = {
     },
     autoFocusCalendar: {
       value: undefined,
-      type: PropTypes.Function,
+      type: PropTypes.Boolean,
       description:
         'Defines if the calendar is set to be focused on an initial render.',
       hidden: true,


### PR DESCRIPTION
Fixes #2533 (kinda, fixes the documentation to expose this functionality)

#### Description

I was looking into #2533 and it turns out it was fixed already. But in the documentation the prop type was incorrect so I fixed that.

With autoFocusCalendar prop set to true, and after a single click:

![image](https://user-images.githubusercontent.com/2348903/72656164-597fc700-394e-11ea-87dc-c89de9edfe57.png)



#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
