### PR TITLE
feat(datepicker): autoAdvanceCalendar - advance multimonth on select

### DIFF
--- a/documentation-site/components/yard/config/datepicker.ts
+++ b/documentation-site/components/yard/config/datepicker.ts
@@ -66,10 +66,17 @@ const DatepickerConfig: TConfig = {
       },
     },
     autoFocusCalendar: {
-      value: undefined,
-      type: PropTypes.Function,
+      value: false,
+      type: PropTypes.Boolean,
       description:
         'Defines if the calendar is set to be focused on an initial render.',
+      hidden: true,
+    },
+    autoAdvanceCalendar: {
+      value: true,
+      type: PropTypes.Boolean,
+      description:
+        'Defines if a multi-month calendar should shift so that the first selected date appears in the first month',
       hidden: true,
     },
     excludeDates: {

--- a/src/datepicker/__tests__/datepicker-range-multi-month-no-advance.scenario.js
+++ b/src/datepicker/__tests__/datepicker-range-multi-month-no-advance.scenario.js
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2018-2020 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+
+import {StyledDay, StatefulDatepicker} from '../index.js';
+
+export const name = 'datepicker-range-multi-month-no-advance';
+
+export const component = () => (
+  <StatefulDatepicker
+    aria-label="Select a date"
+    initialState={{value: []}}
+    range
+    monthsShown={2}
+    autoAdvanceCalendar={false}
+    highlightedDate={new Date('March 10, 2019')}
+    clearable={true}
+    overrides={{
+      Day: {
+        // eslint-disable-next-line react/display-name
+        component: props => (
+          <StyledDay data-highlighted={props.$isHighlighted} {...props} />
+        ),
+      },
+      MonthYearSelectButton: {props: {'data-id': 'monthYearSelectButton'}},
+      MonthYearSelectStatefulMenu: {
+        props: {overrides: {List: {props: {'data-id': 'monthYearSelectMenu'}}}},
+      },
+    }}
+  />
+);

--- a/src/datepicker/__tests__/datepicker-range-multi-month.scenario.js
+++ b/src/datepicker/__tests__/datepicker-range-multi-month.scenario.js
@@ -1,0 +1,36 @@
+/*
+Copyright (c) 2018-2020 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+
+import {StyledDay, StatefulDatepicker} from '../index.js';
+
+export const name = 'datepicker-range-multi-month';
+
+export const component = () => (
+  <StatefulDatepicker
+    aria-label="Select a date"
+    initialState={{value: []}}
+    range
+    monthsShown={2}
+    highlightedDate={new Date('March 10, 2019')}
+    clearable={true}
+    overrides={{
+      Day: {
+        // eslint-disable-next-line react/display-name
+        component: props => (
+          <StyledDay data-highlighted={props.$isHighlighted} {...props} />
+        ),
+      },
+      MonthYearSelectButton: {props: {'data-id': 'monthYearSelectButton'}},
+      MonthYearSelectStatefulMenu: {
+        props: {overrides: {List: {props: {'data-id': 'monthYearSelectMenu'}}}},
+      },
+    }}
+  />
+);

--- a/src/datepicker/__tests__/datepicker-range.e2e.js
+++ b/src/datepicker/__tests__/datepicker-range.e2e.js
@@ -16,6 +16,7 @@ const selectors = {
   day: '[aria-label="Choose Sunday, March 10th 2019. It\'s available."]',
   day2: '[aria-label="Choose Thursday, March 28th 2019. It\'s available."]',
   day4: '[aria-label="Choose Monday, April 1st 2019. It\'s available."]',
+  day5: '[aria-label="Choose Wednesday, May 1st 2019. It\'s available."]',
   rightArrow: '[aria-label="Next month"]',
   monthYearSelectButton: '[data-id="monthYearSelectButton"]',
   monthYearSelectMenu: '[data-id="monthYearSelectMenu"]',
@@ -76,5 +77,90 @@ describe('Datepicker, Range', () => {
       input => input.value,
     );
     expect(selectedValue2).toBe('2019/03/10 – 2019/03/28');
+  });
+
+  it('selects range in multi-month', async () => {
+    await mount(page, 'datepicker-range-multi-month');
+    await page.waitFor(selectors.input);
+    await page.click(selectors.input);
+    await page.waitFor(selectors.calendar);
+    await page.click(selectors.day);
+    await page.waitFor(selectors.calendar);
+    const selectedValue1 = await page.$eval(
+      selectors.input,
+      input => input.value,
+    );
+    expect(selectedValue1).toBe('2019/03/10 –     /  /  ');
+
+    await page.click(selectors.day4);
+    await page.waitFor(selectors.calendar, {
+      hidden: true,
+    });
+    const selectedValue2 = await page.$eval(
+      selectors.input,
+      input => input.value,
+    );
+    expect(selectedValue2).toBe('2019/03/10 – 2019/04/01');
+  });
+
+  it('selects range in multi-month - selecting from second month should advance calendar so that the selected day falls in the first month', async () => {
+    await mount(page, 'datepicker-range-multi-month');
+    await page.waitFor(selectors.input);
+    await page.click(selectors.input);
+    await page.waitFor(selectors.calendar);
+    // datepicker should show 2 months - March and April
+    // we can see both a day in March and a day in April are rendered
+    await page.waitFor(selectors.day);
+    await page.click(selectors.day4);
+    await page.waitFor(selectors.calendar);
+    const selectedValue1 = await page.$eval(
+      selectors.input,
+      input => input.value,
+    );
+    expect(selectedValue1).toBe('2019/04/01 –     /  /  ');
+
+    // after clicking on a date in April, in the second month, the months should advance so that April is now the first month, with March hidden and May now visible
+    // we finish off the test by clicking on a day in May
+    await page.waitFor(selectors.day, {hidden: true});
+    await page.click(selectors.day5);
+    await page.waitFor(selectors.calendar, {
+      hidden: true,
+    });
+    const selectedValue2 = await page.$eval(
+      selectors.input,
+      input => input.value,
+    );
+    expect(selectedValue2).toBe('2019/04/01 – 2019/05/01');
+  });
+
+  it('selects range in multi-month - do not auto advance calendar months (autoAdvanceCalendar: false)', async () => {
+    await mount(page, 'datepicker-range-multi-month-no-advance');
+    await page.waitFor(selectors.input);
+    await page.click(selectors.input);
+    await page.waitFor(selectors.calendar);
+    // datepicker should show 2 months - March and April
+    // we can see both a day in March and a day in April are rendered
+    await page.waitFor(selectors.day);
+    await page.click(selectors.day4);
+    await page.waitFor(selectors.calendar);
+    const selectedValue1 = await page.$eval(
+      selectors.input,
+      input => input.value,
+    );
+    expect(selectedValue1).toBe('2019/04/01 –     /  /  ');
+
+    // after clicking on a date in April, in the second month, the months should NOT change at all. March should still be visible, and May should not be rendered
+    // we finish off the test by clicking on a day in March (simulating clicking the "end" of the range first, then the "beginning" of the range last)
+    await page.waitFor(selectors.day5, {hidden: true});
+    await page.waitFor(selectors.day);
+    await page.click(selectors.day);
+    await page.waitFor(selectors.calendar, {
+      hidden: true,
+    });
+    const selectedValue2 = await page.$eval(
+      selectors.input,
+      input => input.value,
+    );
+    expect(selectedValue2).toBe('2019/03/10 – 2019/04/01');
   });
 });

--- a/src/datepicker/calendar.js
+++ b/src/datepicker/calendar.js
@@ -60,6 +60,7 @@ export default class Calendar extends React.Component<
 > {
   static defaultProps = {
     autoFocusCalendar: false,
+    autoAdvanceCalendar: true,
     excludeDates: null,
     filterDate: null,
     highlightedDate: null,
@@ -119,10 +120,12 @@ export default class Calendar extends React.Component<
       this.focusCalendar();
     }
 
-    if (prevProps.value !== this.props.value) {
-      this.setState({
-        date: this.getDateInView(),
-      });
+    if (this.props.autoAdvanceCalendar) {
+      if (prevProps.value !== this.props.value) {
+        this.setState({
+          date: this.getDateInView(),
+        });
+      }
     }
   }
 

--- a/src/datepicker/index.d.ts
+++ b/src/datepicker/index.d.ts
@@ -51,6 +51,7 @@ export class StatefulContainer extends React.Component<
 
 export interface CalendarProps {
   autoFocusCalendar?: boolean;
+  autoAdvanceCalendar?: boolean;
   excludeDates?: Date[];
   quickSelect?: boolean;
   quickSelectOptions?: Array<{id: string; beginDate: Date; endDate?: Date}>;

--- a/src/datepicker/types.js
+++ b/src/datepicker/types.js
@@ -118,6 +118,8 @@ export type CalendarInternalState = {
 export type CalendarPropsT = {
   /** Defines if the calendar is set to be focused on an initial render. */
   autoFocusCalendar?: boolean,
+  /** Should we update the "display from here" date of the calendar when date selected? For multiple month calendar views, having this set to true will adjust the calendar so that the selected date will be the first month rendered */
+  autoAdvanceCalendar?: boolean,
   /** A list of dates to disable. */
   excludeDates?: ?Array<Date>,
   /** Display select for quickly choosing date ranges. `range` must be true as well. */


### PR DESCRIPTION
Fixes #2471 

#### Description

Added option

`autoAdvanceCalendar?: boolean (default: true)`

This option controls whether to shift months so that the first selected date appears in the first month (more relevant in multi-month calendar views)

Added yard config for option
Fixed autoFocusCalendar yard type (duplicates https://github.com/uber/baseweb/pull/2654)

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
