### PR TITLE
docs(header-navigation): fix weird padding in burger menu button

### DIFF
--- a/documentation-site/components/header-navigation.js
+++ b/documentation-site/components/header-navigation.js
@@ -33,7 +33,7 @@ const Hamburger = themedStyled<{}>('div', ({$theme}) => ({
   display: 'block',
   userSelect: 'none',
   height: '32px',
-  paddingLeft: $theme.sizing.scale600,
+  marginLeft: $theme.sizing.scale600,
   cursor: 'pointer',
   [$theme.mediaQuery.medium]: {
     display: 'none',


### PR DESCRIPTION
#### Description

Fixes weird outline when Hamburger menu icon is focused on mobile

Before
![baseweb design_](https://user-images.githubusercontent.com/14029371/72824987-3fbae880-3c9c-11ea-84aa-2adb0f75d00b.png)

After
![localhost_3000_blog_visual-regression-testing](https://user-images.githubusercontent.com/14029371/72824980-3af63480-3c9c-11ea-9494-2a78e72eeb7a.png)


#### Scope

- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
