### PR TITLE
fix(tree-view): add $isExpanded and $hasChildren styling props

### DIFF
--- a/src/tree-view/tree-label.js
+++ b/src/tree-view/tree-label.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 import React from 'react';
-import type {TreeLabelT} from './types.js';
+import type {TreeLabelT, SharedStylePropsT} from './types.js';
 import {StyledIconContainer, StyledItemContent} from './styled-components.js';
 import CheckIndeterminateIcon from '../icon/check-indeterminate.js';
 import PlusIcon from '../icon/plus.js';
@@ -20,6 +20,10 @@ const TreeLabel: React$ComponentType<TreeLabelT> = ({
   node,
   ...props
 }) => {
+  const sharedProps: SharedStylePropsT = {
+    $isExpanded: !!isExpanded,
+    $hasChildren: !!hasChildren,
+  };
   const {
     IconContainer: IconContainerOverride,
     ExpandIcon: ExapandIconOverride,
@@ -34,13 +38,22 @@ const TreeLabel: React$ComponentType<TreeLabelT> = ({
   const TreeItemContent =
     getOverride(TreeItemContentOverride) || StyledItemContent;
   return (
-    <TreeItemContent {...props}>
+    <TreeItemContent {...sharedProps} {...props}>
       {hasChildren && (
-        <IconContainer {...getOverrideProps(IconContainerOverride)}>
+        <IconContainer
+          {...sharedProps}
+          {...getOverrideProps(IconContainerOverride)}
+        >
           {!isExpanded ? (
-            <ExpandIcon {...getOverrideProps(ExapandIconOverride)} />
+            <ExpandIcon
+              {...sharedProps}
+              {...getOverrideProps(ExapandIconOverride)}
+            />
           ) : (
-            <CollapseIcon {...getOverrideProps(CollapseIconOverride)} />
+            <CollapseIcon
+              {...sharedProps}
+              {...getOverrideProps(CollapseIconOverride)}
+            />
           )}
         </IconContainer>
       )}

--- a/src/tree-view/types.js
+++ b/src/tree-view/types.js
@@ -41,6 +41,11 @@ export type TreeLabelT = {
   node: TreeNodeT,
 };
 
+export type SharedStylePropsT = {
+  $hasChildren: boolean,
+  $isExpanded: boolean,
+};
+
 export type TreeNodePropsT = {
   node: TreeNodeT,
   onToggle?: (node: TreeNodeT) => void,


### PR DESCRIPTION
Fixes #2720 

#### Description

NOTE: this branch is based off of https://github.com/uber/baseweb/pull/2716
I didn't want to add these changes to the main PR so I'm just putting this here for now.

simply add $isExpanded and $hasChildren styling props to the styled-components inside TreeLabel (i.e. TreeItemContent, ExpandIcon, CollapseIcon, IconContainer).


#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
