### PR TITLE
chore(docs): migrate from deprecated github api param

### DIFF
--- a/documentation-site/pages/index.js
+++ b/documentation-site/pages/index.js
@@ -217,8 +217,12 @@ const Index = (props: {
 
 async function fetchContributorsByPage(page = 1) {
   const res = await fetch(
-    `https://api.github.com/repos/uber/baseweb/contributors?access_token=${process
-      .env.GITHUB_AUTH_TOKEN || ''}&page=${page}`,
+    `https://api.github.com/repos/uber/baseweb/contributors?&page=${page}`,
+    {
+      headers: {
+        Authorization: process.env.GITHUB_AUTH_TOKEN || '',
+      },
+    },
   );
   return res.json();
 }


### PR DESCRIPTION
https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters