### PR TITLE
feat(pin-code): add autoComplete prop

### DIFF
--- a/src/pin-code/default-props.js
+++ b/src/pin-code/default-props.js
@@ -12,6 +12,7 @@ const defaultProps = {
   'aria-label': 'Please enter your pin code',
   'aria-labelledby': null,
   'aria-describedby': null,
+  autoComplete: 'one-time-code',
   autoFocus: false,
   disabled: false,
   error: false,

--- a/src/pin-code/pin-code.js
+++ b/src/pin-code/pin-code.js
@@ -57,7 +57,7 @@ export default class PinCode extends React.Component<PropsT, StateT> {
               aria-label={this.props['aria-label']}
               aria-labelledby={this.props['aria-labelledby']}
               aria-describedby={this.props['aria-describedby']}
-              autoComplete="one-time-code"
+              autoComplete={this.props.autoComplete}
               disabled={this.props.disabled}
               error={this.props.error}
               id={this.props.id ? this.props.id + '-' + i : null}

--- a/src/pin-code/types.js
+++ b/src/pin-code/types.js
@@ -19,6 +19,8 @@ export type PropsT = {
   'aria-labelledby': ?string,
   /** Sets aria-describedby attribute for each input element. */
   'aria-describedby': ?string,
+  /** Sets autocomplete attribute for each input element. */
+  autoComplete: ?string,
   /** If true, the first input will be focused upon mounting. */
   autoFocus: boolean,
   /** Render the component in a disabled state. */


### PR DESCRIPTION
#### Description

Some developers were confused that `autoComplete` was not included even though it was shown on the docs site. This was due to re-using props from the `Input` component.

#### Scope

- [x] Minor: New Feature
