### PR TITLE
chore(docs): add documentation on commit message format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,10 @@ Usually, we reject contributions if they meet any of the following requirements:
   - TypeScript coverage for the API
 - Documentation added to the docs site. You start the doc site using `yarn documentation:dev:watch`.
 
+## Git Commit Formatting
+
+Commit messages should be formatted according to [commitlint](https://commitlint.js.org/#/concepts-commit-conventions) specifications. Doing so allows us to better document the baseweb changelog.
+
 ## Sending Pull Requests
 
 When send a pull request, please make sure that you have one of the [following labels](https://github.com/uber-workflow/probot-app-pr-label/blob/master/index.js#L20) set:


### PR DESCRIPTION
fixes: https://github.com/uber/baseweb/issues/1866

#### Description

This check uses a package called `commitlint` and it does not provide the ability to customize the error message if your commit is improperly formatted. This pr adds some extra documentation to the contributions page so that new contributors will at least be aware of it.
