### PR TITLE
docs(delighted): make the csat survey recurring

### DIFF
--- a/documentation-site/pages/_document.js
+++ b/documentation-site/pages/_document.js
@@ -43,7 +43,7 @@ export default class MyDocument extends Document {
     return {
       __html: `
         !function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var p=t.getElementsByTagName("script")[0];p.parentNode.insertBefore(o,p)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"5ey7SgIHHblqnpdL","delighted");
-        delighted.survey();
+        delighted.survey({recurringPeriod: 1});
       `,
     };
   }


### PR DESCRIPTION
We have to set the `recurringPeriod` to make sure we can resurvey folks (https://delighted.com/docs/api/web)

This doesn't mean we'll show this all the time - the project-level throttling settings are always considered:

<img width="574" alt="Screen Shot 2020-02-10 at 12 56 17 PM" src="https://user-images.githubusercontent.com/2174968/74189312-fdcef380-4c04-11ea-88b4-496ea46f9648.png">
