### PR TITLE
docs(menu): update example for menu with href,

### DIFF
--- a/documentation-site/examples/menu/href.js
+++ b/documentation-site/examples/menu/href.js
@@ -1,0 +1,15 @@
+// @flow
+import * as React from 'react';
+import {StatefulMenu} from 'baseui/menu';
+
+export default () => {
+  return (
+    <StatefulMenu
+      items={[
+        {label: 'www.example.com', href: '//www.example.com'},
+        {label: 'www.example.net', href: '//www.example.net'},
+        {label: 'www.example.org', href: '//www.example.org'},
+      ]}
+    />
+  );
+};

--- a/documentation-site/examples/menu/href.tsx
+++ b/documentation-site/examples/menu/href.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import {StatefulMenu} from 'baseui/menu';
+
+export default () => {
+  return (
+    <StatefulMenu
+      items={[
+        {label: 'www.example.com', href: '//www.example.com'},
+        {label: 'www.example.net', href: '//www.example.net'},
+        {label: 'www.example.org', href: '//www.example.org'},
+      ]}
+    />
+  );
+};

--- a/documentation-site/pages/components/menu.mdx
+++ b/documentation-site/pages/components/menu.mdx
@@ -17,6 +17,7 @@ import Child from 'examples/menu/child.js';
 import ChildRenderAll from 'examples/menu/child-render-all.js';
 import Grouped from 'examples/menu/grouped.js';
 import VirtualList from 'examples/menu/virtual-list.js';
+import Href from 'examples/menu/href.js';
 
 import Overrides from '../../components/overrides';
 import {StatefulMenu, OptionProfile} from 'baseui/menu';
@@ -93,6 +94,10 @@ The provided id will be set as a value for the item container's `id` attribute t
   additionalPackages={{'react-virtualized': '^9.21.0'}}
 >
   <VirtualList />
+</Example>
+
+<Example title="Menu with URL href" path="menu/href.js">
+  <Href />
 </Example>
 
 ## Overrides


### PR DESCRIPTION
#### Description

Update example to show Menu handles the key "href" in items.

![screenshot_1](https://user-images.githubusercontent.com/1376093/74461951-479c3000-4eca-11ea-9dbb-b399429bdf3c.png)

Possible related to ticket:

https://github.com/uber/baseweb/pull/2631

#### Scope
N/A

