### PR TITLE
fix(link-checker): update sanitization

### DIFF
--- a/scripts/link-checker.js
+++ b/scripts/link-checker.js
@@ -116,7 +116,7 @@ function getRepositoryOwnerFromURL() {
 function sanitizeBranch() {
   return BUILDKITE_BRANCH.replace(/\//g, '-')
     .replace(/_/g, '')
-    .replace(/#/g, '-')
+    .replace(/#/g, '')
     .toLowerCase();
 }
 

--- a/scripts/link-checker.js
+++ b/scripts/link-checker.js
@@ -114,7 +114,7 @@ function getRepositoryOwnerFromURL() {
 
 // Best guess of how ZEIT sanitizes branch names
 function sanitizeBranch() {
-  return BUILDKITE_BRANCH.replace(/\//g, '')
+  return BUILDKITE_BRANCH.replace(/\//g, '-')
     .replace(/_/g, '')
     .replace(/#/g, '-')
     .toLowerCase();


### PR DESCRIPTION
Would be awesome if they documented how they generate URLs in case their API doesn't return deployment. This is what I'm seeing though:

```
"/" -> "-"
"-" -> "-"
"_" -> ""
"#" -> ""
```