### PR TITLE
docs(input): add placeholder to input tags example

### DIFF
--- a/documentation-site/examples/input/with-tags.js
+++ b/documentation-site/examples/input/with-tags.js
@@ -59,6 +59,7 @@ export default () => {
   };
   return (
     <Input
+      placeholder={tags.length ? '' : 'Enter A Tag'}
       value={value}
       onChange={e => setValue(e.currentTarget.value)}
       overrides={{

--- a/documentation-site/examples/input/with-tags.tsx
+++ b/documentation-site/examples/input/with-tags.tsx
@@ -60,6 +60,7 @@ export default () => {
   };
   return (
     <Input
+      placeholder={tags.length ? '' : 'Enter A Tag'}
       value={value}
       onChange={e => setValue(e.currentTarget.value)}
       overrides={{


### PR DESCRIPTION
Fixes #2752

#### Description
I added a placeholder depending on the tags state in the input
Something like the code sandbox in the issue

**New Changes**
![Screenshot_20200214_155526](https://user-images.githubusercontent.com/44949822/74538655-5a077f80-4f45-11ea-8f31-1d8bac4babf3.jpg)

**When there are tags**
![Screenshot_20200214_155645](https://user-images.githubusercontent.com/44949822/74538756-8b804b00-4f45-11ea-9830-303aeb951a48.jpg)


<!-- Describe your changes below in as much detail as possible -->

#### Scope
N/A

**Note**: this small contribution taught me a lot about how your code is structured and how the workflow is going so I am looking forward to contributing more whenever I'm free :nerd_face: 