### PR TITLE
fix(breadcrumbs): ignore null, true, and false

### DIFF
--- a/src/breadcrumbs/__tests__/__snapshots__/breadcrumbs.test.js.snap
+++ b/src/breadcrumbs/__tests__/__snapshots__/breadcrumbs.test.js.snap
@@ -12,6 +12,7 @@ exports[`Breadcrumbs displays separators in correct positions 1`] = `
     >
       <ForwardRef
         href="#"
+        key=".0"
       >
         Parent Page
       </ForwardRef>
@@ -29,6 +30,7 @@ exports[`Breadcrumbs displays separators in correct positions 1`] = `
     >
       <ForwardRef
         href="#"
+        key=".1"
       >
         Sub-Parent Page
       </ForwardRef>
@@ -44,7 +46,9 @@ exports[`Breadcrumbs displays separators in correct positions 1`] = `
       $itemIndex={2}
       key="breadcrumb-item-2"
     >
-      <span>
+      <span
+        key=".2"
+      >
         Current Page
       </span>
     </ForwardRef>

--- a/src/breadcrumbs/__tests__/breadcrumbs.test.js
+++ b/src/breadcrumbs/__tests__/breadcrumbs.test.js
@@ -35,4 +35,23 @@ describe('Breadcrumbs', () => {
       ),
     ).toMatchSnapshot();
   });
+
+  it('ignores null, true, and false', () => {
+    expect(
+      shallow(
+        <Breadcrumbs>
+          <span>Foo</span>
+          {null}
+          <span>Bar</span>
+          {true}
+          {false}
+        </Breadcrumbs>,
+      ),
+    ).toMatchElement(
+      <Breadcrumbs>
+        <span>Foo</span>
+        <span>Bar</span>
+      </Breadcrumbs>,
+    );
+  });
 });

--- a/src/breadcrumbs/breadcrumbs.js
+++ b/src/breadcrumbs/breadcrumbs.js
@@ -26,7 +26,7 @@ import {getOverrides, mergeOverrides} from '../helpers/overrides.js';
 type LocaleT = {|locale?: BreadcrumbLocaleT|};
 export function BreadcrumbsRoot(props: {|...BreadcrumbsPropsT, ...LocaleT|}) {
   const {overrides = {}} = props;
-  const numChildren = Children.count(props.children);
+  const childrenArray = Children.toArray(props.children);
   const childrenWithSeparators = [];
 
   const [Root, baseRootProps] = getOverrides(overrides.Root, StyledRoot);
@@ -50,7 +50,7 @@ export function BreadcrumbsRoot(props: {|...BreadcrumbsPropsT, ...LocaleT|}) {
   // $FlowFixMe
   baseIconProps.overrides = iconOverrides;
 
-  Children.forEach(props.children, (child, index) => {
+  childrenArray.forEach((child, index) => {
     childrenWithSeparators.push(
       <ListItem
         key={`breadcrumb-item-${index}`}
@@ -58,7 +58,7 @@ export function BreadcrumbsRoot(props: {|...BreadcrumbsPropsT, ...LocaleT|}) {
         {...baseListItemProps}
       >
         {child}
-        {index !== numChildren - 1 && (
+        {index !== childrenArray.length - 1 && (
           <Separator {...baseSeparatorProps} key={`separator-${index}`}>
             <ThemeContext.Consumer>
               {theme =>


### PR DESCRIPTION
#### Description

The `<Breadcrumbs />` component iterates over `children` to insert separators. It seems intuitive to ignore children that are `null`, `true`, or `false` in order to allow some of the idiomatic conditional rendering patterns in React.

Given this example:
```jsx
<Breadcrumbs>
  <span>foo</span>
  {false && <span>bar</span>}
  <span>qux</span>
</Breadcrumbs>
```

I would expect it to render `foo > qux`. However, it renders `foo > > qux`.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change

This is potentially a breaking change, but I would be suprised if anybody relied on the seemingly unintuitive behaviour to render empty breadcrumb items. Rendering empty items is still possible by using an empty string.