### PR TITLE
fix(flow): maintain suppression comment position

### DIFF
--- a/scripts/flow-copy-src.js
+++ b/scripts/flow-copy-src.js
@@ -50,7 +50,11 @@ async function run() {
           '@babel/plugin-proposal-class-properties',
         ],
       });
-      return transformed.code;
+
+      return transformed.code
+        .split('\n')
+        .filter(Boolean)
+        .join('\n');
     }),
   );
 


### PR DESCRIPTION
#### Description

Babel does not support maintaining comment position thus leading to unsuppressed flow errors being included in published `.js.flow` files. This change removes any empty lines which will continue suppress flow errors as defined in the source code. This [astexplorer scenario](https://astexplorer.net/#/gist/9b9b721ec08d6e3e7f1440d6a548cf86/d21fd9270463c6311b17a0918f6e90cd98d8795c) reproduces the issue.

#### Scope

- [x] Patch: Bug Fix