### PR TITLE
fix(checkbox): applies screen-reader improvements

### DIFF
--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -189,7 +189,8 @@ class StatelessCheckbox extends React.Component<PropsT, StatelessStateT> {
         {this.isToggle() ? (
           <ToggleTrack
             role="checkbox"
-            aria-checked={checked}
+            aria-checked={isIndeterminate ? 'mixed' : checked}
+            aria-invalid={isError || null}
             {...sharedProps}
             {...getOverrideProps(ToggleTrackOverride)}
           >
@@ -204,7 +205,8 @@ class StatelessCheckbox extends React.Component<PropsT, StatelessStateT> {
           <Checkmark
             role="checkbox"
             checked={checked}
-            aria-checked={checked}
+            aria-checked={isIndeterminate ? 'mixed' : checked}
+            aria-invalid={isError || null}
             {...sharedProps}
             {...getOverrideProps(CheckmarkOverride)}
           />
@@ -214,6 +216,9 @@ class StatelessCheckbox extends React.Component<PropsT, StatelessStateT> {
           name={name}
           checked={checked}
           required={required}
+          aria-checked={isIndeterminate ? 'mixed' : checked}
+          aria-describedby={this.props['aria-describedby']}
+          aria-errormessage={this.props['aria-errormessage']}
           aria-invalid={isError || null}
           aria-required={required || null}
           disabled={disabled}

--- a/src/checkbox/index.d.ts
+++ b/src/checkbox/index.d.ts
@@ -84,6 +84,8 @@ export interface CheckboxOverrides {
 }
 
 export interface CheckboxProps {
+  'aria-describedby'?: string;
+  'aria-errormessage'?: string;
   children?: React.ReactNode;
   overrides?: CheckboxOverrides;
   checked?: boolean;

--- a/src/checkbox/types.js
+++ b/src/checkbox/types.js
@@ -41,6 +41,10 @@ export type DefaultPropsT = {
 };
 
 export type PropsT = {
+  /** Id of element which contains a related caption */
+  'aria-describedby'?: string,
+  /** Id of element which contains a related error message */
+  'aria-errormessage'?: string,
   /** Component or String value for label of checkbox. */
   children?: React$Node,
   overrides?: OverridesT,

--- a/src/form-control/__tests__/form-control.test.js
+++ b/src/form-control/__tests__/form-control.test.js
@@ -45,6 +45,7 @@ Object {
   "$positive": false,
   "children": "Caption test",
   "data-baseweb": "form-control-caption",
+  "id": "bui-mock-id",
 }
 `);
 
@@ -60,6 +61,7 @@ Object {
   "$positive": false,
   "children": "Error test",
   "data-baseweb": "form-control-caption",
+  "id": "bui-mock-id",
 }
 `);
   });
@@ -180,6 +182,7 @@ Object {
   "$positive": false,
   "children": "Caption test",
   "data-baseweb": "form-control-caption",
+  "id": "bui-mock-id",
 }
 `);
   });
@@ -209,6 +212,7 @@ Object {
   "$positive": false,
   "children": "Caption test",
   "data-baseweb": "form-control-caption",
+  "id": "bui-mock-id",
 }
 `);
     rendered.setProps({
@@ -231,6 +235,7 @@ Object {
   "$positive": false,
   "children": "Caption test",
   "data-baseweb": "form-control-caption",
+  "id": "bui-mock-id",
 }
 `);
     expect(caption).toHaveText('Error test');
@@ -263,6 +268,7 @@ Object {
   "$positive": false,
   "children": "Caption test",
   "data-baseweb": "form-control-caption",
+  "id": "bui-mock-id",
 }
 `);
   });
@@ -295,6 +301,7 @@ Object {
   "$positive": false,
   "children": "Caption test",
   "data-baseweb": "form-control-caption",
+  "id": "bui-mock-id",
 }
 `);
 });
@@ -330,6 +337,7 @@ Object {
   "$positive": false,
   "children": "Caption test",
   "data-baseweb": "form-control-caption",
+  "id": "bui-mock-id",
 }
 `);
 });

--- a/src/form-control/form-control.js
+++ b/src/form-control/form-control.js
@@ -8,12 +8,13 @@ LICENSE file in the root directory of this source tree.
 // @flow
 import * as React from 'react';
 import {getOverride, getOverrideProps} from '../helpers/overrides.js';
+import getBuiId from '../utils/get-bui-id.js';
 import {
   Label as StyledLabel,
   Caption as StyledCaption,
   ControlContainer as StyledControlContainer,
 } from './styled-components.js';
-import type {FormControlPropsT} from './types.js';
+import type {FormControlPropsT, FormControlStateT} from './types.js';
 
 function chooseRenderedHint(caption, error, positive, sharedProps) {
   if (error && typeof error !== 'boolean') {
@@ -31,7 +32,10 @@ function chooseRenderedHint(caption, error, positive, sharedProps) {
   return null;
 }
 
-export default class FormControl extends React.Component<FormControlPropsT> {
+export default class FormControl extends React.Component<
+  FormControlPropsT,
+  FormControlStateT,
+> {
   static defaultProps = {
     overrides: {},
     label: null,
@@ -39,6 +43,7 @@ export default class FormControl extends React.Component<FormControlPropsT> {
     error: false,
     positive: false,
   };
+  state = {captionId: getBuiId()};
 
   render() {
     const {
@@ -102,6 +107,9 @@ export default class FormControl extends React.Component<FormControlPropsT> {
             const key = child.key || String(index);
             return React.cloneElement(child, {
               key,
+              'aria-errormessage': error ? this.state.captionId : null,
+              'aria-describedby':
+                caption || positive ? this.state.captionId : null,
               disabled:
                 typeof onlyChildProps.disabled !== 'undefined'
                   ? onlyChildProps.disabled
@@ -119,6 +127,7 @@ export default class FormControl extends React.Component<FormControlPropsT> {
           {(caption || error || positive) && (
             <Caption
               data-baseweb="form-control-caption"
+              id={this.state.captionId}
               {...sharedProps}
               {...getOverrideProps(CaptionOverride)}
             >

--- a/src/form-control/index.d.ts
+++ b/src/form-control/index.d.ts
@@ -12,6 +12,10 @@ export interface FormControlOverrides {
   ControlContainer?: Override<any>;
 }
 
+export interface FormControlState {
+  captionId: string;
+}
+
 export interface FormControlProps {
   children: React.ReactNode;
   disabled?: boolean;
@@ -22,4 +26,7 @@ export interface FormControlProps {
   positive?: React.ReactNode;
 }
 
-export class FormControl extends React.Component<FormControlProps> {}
+export class FormControl extends React.Component<
+  FormControlProps,
+  FormControlState
+> {}

--- a/src/form-control/types.js
+++ b/src/form-control/types.js
@@ -9,6 +9,10 @@ LICENSE file in the root directory of this source tree.
 import * as React from 'react';
 import type {OverrideT} from '../helpers/overrides.js';
 
+export type FormControlStateT = {|
+  captionId: string,
+|};
+
 export type FormControlPropsT = {
   overrides: {
     /** Customizes the label element. */

--- a/src/input/__tests__/__snapshots__/base-input.test.js.snap
+++ b/src/input/__tests__/__snapshots__/base-input.test.js.snap
@@ -27,6 +27,7 @@ Object {
 exports[`BaseInput - basic functionality: Base input has correct props 1`] = `
 Object {
   "aria-describedby": null,
+  "aria-errormessage": null,
   "aria-invalid": false,
   "aria-label": null,
   "aria-labelledby": null,

--- a/src/input/__tests__/__snapshots__/input.test.js.snap
+++ b/src/input/__tests__/__snapshots__/input.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Input - basic functionality: input has correct props 1`] = `
 Object {
   "aria-describedby": null,
+  "aria-errormessage": null,
   "aria-invalid": false,
   "aria-label": null,
   "aria-labelledby": null,
@@ -83,6 +84,7 @@ Object {
       $required={false}
       $size="default"
       aria-describedby={null}
+      aria-errormessage={null}
       aria-invalid={false}
       aria-label={null}
       aria-labelledby={null}
@@ -147,6 +149,7 @@ Object {
       $required={false}
       $size="default"
       aria-describedby={null}
+      aria-errormessage={null}
       aria-invalid={false}
       aria-label={null}
       aria-labelledby={null}
@@ -211,6 +214,7 @@ Object {
       $required={false}
       $size="default"
       aria-describedby={null}
+      aria-errormessage={null}
       aria-invalid={false}
       aria-label={null}
       aria-labelledby={null}

--- a/src/input/__tests__/__snapshots__/masked-input.test.js.snap
+++ b/src/input/__tests__/__snapshots__/masked-input.test.js.snap
@@ -55,6 +55,7 @@ Object {
 exports[`MaskedInput - basic functionality: Masked input has correct props 1`] = `
 Object {
   "aria-describedby": null,
+  "aria-errormessage": null,
   "aria-invalid": false,
   "aria-label": null,
   "aria-labelledby": null,

--- a/src/input/base-input.js
+++ b/src/input/base-input.js
@@ -31,6 +31,7 @@ class BaseInput<T: EventTarget> extends React.Component<
   InternalStateT,
 > {
   static defaultProps = {
+    'aria-errormessage': null,
     'aria-label': null,
     'aria-labelledby': null,
     'aria-describedby': null,
@@ -277,6 +278,7 @@ class BaseInput<T: EventTarget> extends React.Component<
         <Before {...sharedProps} {...beforeProps} />
         <Input
           ref={this.inputRef}
+          aria-errormessage={this.props['aria-errormessage']}
           aria-label={this.props['aria-label']}
           aria-labelledby={this.props['aria-labelledby']}
           aria-describedby={this.props['aria-describedby']}

--- a/src/input/types.js
+++ b/src/input/types.js
@@ -77,6 +77,8 @@ export type InputComponentsT = {|
 |};
 
 export type BaseInputPropsT<T> = {|
+  /** Id of element which contains a related error message */
+  'aria-errormessage'?: string,
   /** Sets aria-label attribute. */
   'aria-label'?: string,
   /** Sets aria-labelledby attribute. */

--- a/src/radio/index.d.ts
+++ b/src/radio/index.d.ts
@@ -52,6 +52,8 @@ export interface StatefulRadioGroupProps {
 export const StatefulRadioGroup: React.FC<StatefulRadioGroupProps>;
 
 export interface RadioGroupProps {
+  'aria-describedby'?: string;
+  'aria-errormessage'?: string;
   'aria-label'?: string;
   'aria-labelledby'?: string;
   overrides?: RadioOverrides & RadioGroupOverrides;

--- a/src/radio/radiogroup.js
+++ b/src/radio/radiogroup.js
@@ -76,6 +76,9 @@ class StatelessRadioGroup extends React.Component<PropsT, StatelessStateT> {
     return (
       <RadioGroupRoot
         role="radiogroup"
+        aria-describedby={this.props['aria-describedby']}
+        aria-errormessage={this.props['aria-errormessage']}
+        aria-invalid={this.props.isError || null}
         aria-label={this.props['aria-label']}
         aria-labelledby={this.props['aria-labelledby']}
         $align={this.props.align}

--- a/src/radio/types.js
+++ b/src/radio/types.js
@@ -42,6 +42,10 @@ export type DefaultPropsT = {
 };
 
 export type PropsT = {
+  /** Id of element which contains a related caption */
+  'aria-describedby'?: string,
+  /** Id of element which contains a related error message */
+  'aria-errormessage'?: string,
   /**
    * Used to define a string that labels the radio group. Use this prop if the label is not
    * visible on screen. If the label is visible, use the 'aria-labeledby' prop instead.

--- a/src/select/__tests__/__snapshots__/select.test.js.snap
+++ b/src/select/__tests__/__snapshots__/select.test.js.snap
@@ -27,6 +27,7 @@ exports[`Select component renders component in search mode and false for multipl
 >
   <Select
     aria-describedby={null}
+    aria-errormessage={null}
     aria-label={null}
     aria-labelledby={null}
     autoFocus={false}
@@ -547,6 +548,7 @@ exports[`Select component renders component in search mode and false for multipl
                                 aria-autocomplete="list"
                                 aria-describedby={null}
                                 aria-disabled={null}
+                                aria-errormessage={null}
                                 aria-expanded={false}
                                 aria-haspopup={false}
                                 aria-label={null}
@@ -588,6 +590,7 @@ exports[`Select component renders component in search mode and false for multipl
                                   aria-autocomplete="list"
                                   aria-describedby={null}
                                   aria-disabled={null}
+                                  aria-errormessage={null}
                                   aria-expanded={false}
                                   aria-haspopup={false}
                                   aria-label={null}
@@ -623,6 +626,7 @@ exports[`Select component renders component in search mode and false for multipl
                                     aria-autocomplete="list"
                                     aria-describedby={null}
                                     aria-disabled={null}
+                                    aria-errormessage={null}
                                     aria-expanded={false}
                                     aria-haspopup={false}
                                     aria-label={null}
@@ -643,6 +647,7 @@ exports[`Select component renders component in search mode and false for multipl
                                       aria-autocomplete="list"
                                       aria-describedby={null}
                                       aria-disabled={null}
+                                      aria-errormessage={null}
                                       aria-expanded={false}
                                       aria-haspopup={false}
                                       aria-label={null}
@@ -861,6 +866,7 @@ exports[`Select component renders component in search mode and true for multiple
 >
   <Select
     aria-describedby={null}
+    aria-errormessage={null}
     aria-label={null}
     aria-labelledby={null}
     autoFocus={false}
@@ -1381,6 +1387,7 @@ exports[`Select component renders component in search mode and true for multiple
                                 aria-autocomplete="list"
                                 aria-describedby={null}
                                 aria-disabled={null}
+                                aria-errormessage={null}
                                 aria-expanded={false}
                                 aria-haspopup={false}
                                 aria-label={null}
@@ -1422,6 +1429,7 @@ exports[`Select component renders component in search mode and true for multiple
                                   aria-autocomplete="list"
                                   aria-describedby={null}
                                   aria-disabled={null}
+                                  aria-errormessage={null}
                                   aria-expanded={false}
                                   aria-haspopup={false}
                                   aria-label={null}
@@ -1457,6 +1465,7 @@ exports[`Select component renders component in search mode and true for multiple
                                     aria-autocomplete="list"
                                     aria-describedby={null}
                                     aria-disabled={null}
+                                    aria-errormessage={null}
                                     aria-expanded={false}
                                     aria-haspopup={false}
                                     aria-label={null}
@@ -1477,6 +1486,7 @@ exports[`Select component renders component in search mode and true for multiple
                                       aria-autocomplete="list"
                                       aria-describedby={null}
                                       aria-disabled={null}
+                                      aria-errormessage={null}
                                       aria-expanded={false}
                                       aria-haspopup={false}
                                       aria-label={null}
@@ -1695,6 +1705,7 @@ exports[`Select component renders component in select mode and false for multipl
 >
   <Select
     aria-describedby={null}
+    aria-errormessage={null}
     aria-label={null}
     aria-labelledby={null}
     autoFocus={false}
@@ -2107,6 +2118,7 @@ exports[`Select component renders component in select mode and false for multipl
                                 aria-autocomplete="list"
                                 aria-describedby={null}
                                 aria-disabled={null}
+                                aria-errormessage={null}
                                 aria-expanded={false}
                                 aria-haspopup={false}
                                 aria-label={null}
@@ -2148,6 +2160,7 @@ exports[`Select component renders component in select mode and false for multipl
                                   aria-autocomplete="list"
                                   aria-describedby={null}
                                   aria-disabled={null}
+                                  aria-errormessage={null}
                                   aria-expanded={false}
                                   aria-haspopup={false}
                                   aria-label={null}
@@ -2183,6 +2196,7 @@ exports[`Select component renders component in select mode and false for multipl
                                     aria-autocomplete="list"
                                     aria-describedby={null}
                                     aria-disabled={null}
+                                    aria-errormessage={null}
                                     aria-expanded={false}
                                     aria-haspopup={false}
                                     aria-label={null}
@@ -2203,6 +2217,7 @@ exports[`Select component renders component in select mode and false for multipl
                                       aria-autocomplete="list"
                                       aria-describedby={null}
                                       aria-disabled={null}
+                                      aria-errormessage={null}
                                       aria-expanded={false}
                                       aria-haspopup={false}
                                       aria-label={null}
@@ -2546,6 +2561,7 @@ exports[`Select component renders component in select mode and true for multiple
 >
   <Select
     aria-describedby={null}
+    aria-errormessage={null}
     aria-label={null}
     aria-labelledby={null}
     autoFocus={false}
@@ -2958,6 +2974,7 @@ exports[`Select component renders component in select mode and true for multiple
                                 aria-autocomplete="list"
                                 aria-describedby={null}
                                 aria-disabled={null}
+                                aria-errormessage={null}
                                 aria-expanded={false}
                                 aria-haspopup={false}
                                 aria-label={null}
@@ -2999,6 +3016,7 @@ exports[`Select component renders component in select mode and true for multiple
                                   aria-autocomplete="list"
                                   aria-describedby={null}
                                   aria-disabled={null}
+                                  aria-errormessage={null}
                                   aria-expanded={false}
                                   aria-haspopup={false}
                                   aria-label={null}
@@ -3034,6 +3052,7 @@ exports[`Select component renders component in select mode and true for multiple
                                     aria-autocomplete="list"
                                     aria-describedby={null}
                                     aria-disabled={null}
+                                    aria-errormessage={null}
                                     aria-expanded={false}
                                     aria-haspopup={false}
                                     aria-label={null}
@@ -3054,6 +3073,7 @@ exports[`Select component renders component in select mode and true for multiple
                                       aria-autocomplete="list"
                                       aria-describedby={null}
                                       aria-disabled={null}
+                                      aria-errormessage={null}
                                       aria-expanded={false}
                                       aria-haspopup={false}
                                       aria-label={null}

--- a/src/select/default-props.js
+++ b/src/select/default-props.js
@@ -11,6 +11,7 @@ import {TYPE, SIZE} from './constants.js';
 const defaultProps = {
   'aria-label': null,
   'aria-describedby': null,
+  'aria-errormessage': null,
   'aria-labelledby': null,
   autoFocus: false,
   backspaceRemoves: true,

--- a/src/select/index.d.ts
+++ b/src/select/index.d.ts
@@ -72,6 +72,7 @@ export interface SelectOverrides {
 }
 export interface SelectProps {
   'aria-label'?: string;
+  'aria-errormessage': ?string,
   'aria-describedby'?: string;
   'aria-labelledby'?: string;
   autoFocus?: boolean;

--- a/src/select/index.d.ts
+++ b/src/select/index.d.ts
@@ -72,7 +72,7 @@ export interface SelectOverrides {
 }
 export interface SelectProps {
   'aria-label'?: string;
-  'aria-errormessage': ?string,
+  'aria-errormessage'?: string;
   'aria-describedby'?: string;
   'aria-labelledby'?: string;
   autoFocus?: boolean;

--- a/src/select/select-component.js
+++ b/src/select/select-component.js
@@ -657,6 +657,7 @@ class Select extends React.Component<PropsT, SelectStateT> {
         <AutosizeInput
           aria-autocomplete="list"
           aria-describedby={this.props['aria-describedby']}
+          aria-errormessage={this.props['aria-errormessage']}
           aria-disabled={this.props.disabled || null}
           aria-expanded={isOpen}
           aria-haspopup={isOpen}

--- a/src/select/types.js
+++ b/src/select/types.js
@@ -74,6 +74,7 @@ export type OverridesDropdownT = {
 export type PropsT = {
   'aria-label': ?string,
   'aria-describedby': ?string,
+  'aria-errormessage': ?string,
   'aria-labelledby': ?string,
   /** Defines if select element is focused on the first mount. */
   autoFocus: boolean,

--- a/src/textarea/__tests__/__snapshots__/textarea.test.js.snap
+++ b/src/textarea/__tests__/__snapshots__/textarea.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Textarea Basic functionality: Textarea has correct props 1`] = `
 Object {
   "aria-describedby": null,
+  "aria-errormessage": null,
   "aria-invalid": false,
   "aria-label": null,
   "aria-labelledby": null,
@@ -60,6 +61,7 @@ exports[`Textarea Basic functionality: textarea renders BaseInput with correct p
 Object {
   "adjoined": "none",
   "aria-describedby": null,
+  "aria-errormessage": null,
   "aria-label": null,
   "aria-labelledby": null,
   "autoComplete": "on",
@@ -106,6 +108,7 @@ exports[`Textarea With component overrides: components overrides get passed to t
 Object {
   "adjoined": "none",
   "aria-describedby": null,
+  "aria-errormessage": null,
   "aria-label": null,
   "aria-labelledby": null,
   "autoComplete": "on",


### PR DESCRIPTION
#### Description

- adds the `aria-checked` value `mixed` when the checkbox is `indeterminate`.
- applies a `bui` id to the caption element on `form-control`
- if `form-control` has an error, it will send the caption id as `aria-errormessage`
- if `form-control` has a caption, it will send the caption id as `aria-describedby`
- adds `aria-errormessage` prop to `input`

#### Scope

- [x] Patch: Bug Fix
