### PR TITLE
fix(build): exclude tabs types from esm target

### DIFF
--- a/src/tabs/index.js
+++ b/src/tabs/index.js
@@ -18,4 +18,4 @@ export {
   TabContent as StyledTabContent,
 } from './styled-components.js';
 // Flow
-export * from './types';
+export type * from './types';


### PR DESCRIPTION
related to https://github.com/uber/baseweb/pull/2497
