### PR TITLE
docs: update the roadmap

### DIFF
--- a/documentation-site/pages/discover-more/roadmap.mdx
+++ b/documentation-site/pages/discover-more/roadmap.mdx
@@ -12,7 +12,7 @@ export default Layout;
 
 # Roadmap
 
-_The last update: 5 December 2019_
+_The last update: 26 February 2020_
 
 If you want to see what we are working on and what won't be worked on, you've come to the right place.
 
@@ -23,11 +23,9 @@ Items are not necessarily in priority order.
 <Table
   columns={['Feature']}
   data={[
-    ['Monolithic engine for Styletron (support child selectors)'],
     ['Support for nested overrides in the playground'],
     ['Better mobile support for all components'],
     ['Updated visuals for the sidebar and tree view components'],
-    ['VS Code plugin'],
   ]}
 />
 


### PR DESCRIPTION
- removed the monolithic engine too since it's technically done (and even published), just going through a lengthy review process