### PR TITLE
feat(input):  make "clear input" keyboard interactive

### DIFF
--- a/src/input/__tests__/input.e2e.js
+++ b/src/input/__tests__/input.e2e.js
@@ -85,6 +85,42 @@ describe('input', () => {
       });
     });
 
+    it('with delete icon via enter', async () => {
+      await mount(page, 'input-clearable');
+      await page.waitFor(selectors.input);
+
+      let inputValue = await page.$eval(selectors.input, input => input.value);
+      expect(inputValue).toBe('Thing');
+
+      await page.focus(selectors.clearIcon);
+      await page.keyboard.press('Enter');
+
+      inputValue = await page.$eval(selectors.input, input => input.value);
+      expect(inputValue).toBe('');
+
+      await page.waitFor(selectors.clearIcon, {
+        hidden: true,
+      });
+    });
+
+    it('with delete icon via space', async () => {
+      await mount(page, 'input-clearable');
+      await page.waitFor(selectors.input);
+
+      let inputValue = await page.$eval(selectors.input, input => input.value);
+      expect(inputValue).toBe('Thing');
+
+      await page.focus(selectors.clearIcon);
+      await page.keyboard.press(' ');
+
+      inputValue = await page.$eval(selectors.input, input => input.value);
+      expect(inputValue).toBe('');
+
+      await page.waitFor(selectors.clearIcon, {
+        hidden: true,
+      });
+    });
+
     // regression test for https://github.com/uber/baseweb/issues/1643
     // verify that the input receiving the clear event is cleared and not another input
     it('clears the correct input', async () => {

--- a/src/input/base-input.js
+++ b/src/input/base-input.js
@@ -248,8 +248,9 @@ class BaseInput<T: EventTarget> extends React.Component<
           title={ariaLabel}
           aria-label={ariaLabel}
           onClick={this.onClearIconClick}
-          onKeyUp={event => {
+          onKeyDown={event => {
             if (event.key && (event.key === 'Enter' || event.key === ' ')) {
+              event.preventDefault();
               this.onClearIconClick();
             }
           }}

--- a/src/input/base-input.js
+++ b/src/input/base-input.js
@@ -23,6 +23,7 @@ import {Button, KIND} from '../button/index.js';
 import Hide from '../icon/hide.js';
 import Show from '../icon/show.js';
 import createEvent from '../utils/create-event.js';
+import {isFocusVisible, forkFocus, forkBlur} from '../utils/focusVisible.js';
 
 const NullComponent = () => null;
 
@@ -66,6 +67,7 @@ class BaseInput<T: EventTarget> extends React.Component<
     isFocused: this.props.autoFocus || false,
     isMasked: this.props.type === 'password',
     initialType: this.props.type,
+    isFocusVisibleForClear: false,
   };
 
   componentDidMount() {
@@ -207,6 +209,18 @@ class BaseInput<T: EventTarget> extends React.Component<
     );
   }
 
+  handleFocusForClear = (event: SyntheticEvent<>) => {
+    if (isFocusVisible(event)) {
+      this.setState({isFocusVisibleForClear: true});
+    }
+  };
+
+  handleBlurForClear = (event: SyntheticEvent<>) => {
+    if (this.state.isFocusVisibleForClear !== false) {
+      this.setState({isFocusVisibleForClear: false});
+    }
+  };
+
   renderClear() {
     const {clearable, value, disabled, overrides = {}} = this.props;
     if (!clearable || !value || !value.length || disabled) {
@@ -230,12 +244,21 @@ class BaseInput<T: EventTarget> extends React.Component<
       >
         <ClearIcon
           size={16}
+          tabindex={0}
           title={ariaLabel}
           aria-label={ariaLabel}
           onClick={this.onClearIconClick}
+          onKeyUp={event => {
+            if (event.key && (event.key === 'Enter' || event.key === ' ')) {
+              this.onClearIconClick();
+            }
+          }}
           role="button"
+          $isFocusVisible={this.state.isFocusVisibleForClear}
           {...sharedProps}
           {...clearIconProps}
+          onFocus={forkFocus(clearIconProps, this.handleFocusForClear)}
+          onBlur={forkBlur(clearIconProps, this.handleBlurForClear)}
         />
       </ClearIconContainer>
     );

--- a/src/input/styled-components.js
+++ b/src/input/styled-components.js
@@ -31,9 +31,7 @@ export const StyledClearIcon = styled<
   {$isFocusVisible: boolean},
 >(DeleteAlt, ({$theme, $isFocusVisible}) => ({
   cursor: 'pointer',
-  ':focus': {
-    outline: $isFocusVisible ? `solid 3px ${$theme.colors.accent}` : 'none',
-  },
+  outline: $isFocusVisible ? `solid 3px ${$theme.colors.accent}` : 'none',
 }));
 
 function getInputPadding(size, sizing) {

--- a/src/input/styled-components.js
+++ b/src/input/styled-components.js
@@ -26,9 +26,15 @@ export const StyledClearIconContainer = styled<{
   };
 });
 
-export const StyledClearIcon = styled<typeof DeleteAlt, {}>(DeleteAlt, {
+export const StyledClearIcon = styled<
+  typeof DeleteAlt,
+  {$isFocusVisible: boolean},
+>(DeleteAlt, ({$theme, $isFocusVisible}) => ({
   cursor: 'pointer',
-});
+  ':focus': {
+    outline: $isFocusVisible ? `solid 3px ${$theme.colors.accent}` : 'none',
+  },
+}));
 
 function getInputPadding(size, sizing) {
   return {

--- a/src/input/types.js
+++ b/src/input/types.js
@@ -25,6 +25,8 @@ export type InternalStateT = {
   isFocused?: boolean,
   /** Renders input in 'masked' state if type equals "password" */
   isMasked?: boolean,
+  /** Tracks if focus should be visible on the clear button. */
+  isFocusVisibleForClear?: boolean,
 };
 
 export type StateT = {


### PR DESCRIPTION
This PR makes the Clear Icon keyboard navigable and interactive. You can activate the clear by focusing the icon button and pressing Enter or Space. The focus indicator uses our standard visibility checks.