### PR TITLE
feat(modal): handle modal closure through the Layer's onDocumentClick handler

### DIFF
--- a/documentation-site/examples/modal/buried-interactive-element.js
+++ b/documentation-site/examples/modal/buried-interactive-element.js
@@ -15,7 +15,11 @@ export default function() {
   return (
     <React.Fragment>
       <Button onClick={() => setOpen(s => !s)}>Open Modal</Button>
-      <Modal onClose={() => setOpen(false)} isOpen={isOpen}>
+      <Modal
+        onClose={() => setOpen(false)}
+        isOpen={isOpen}
+        unstable_ModalBackdropScroll
+      >
         <FocusOnce>
           <ModalHeader>Some Header</ModalHeader>
         </FocusOnce>

--- a/documentation-site/examples/modal/buried-interactive-element.tsx
+++ b/documentation-site/examples/modal/buried-interactive-element.tsx
@@ -14,7 +14,11 @@ export default function() {
   return (
     <React.Fragment>
       <Button onClick={() => setOpen(s => !s)}>Open Modal</Button>
-      <Modal onClose={() => setOpen(false)} isOpen={isOpen}>
+      <Modal
+        onClose={() => setOpen(false)}
+        isOpen={isOpen}
+        unstable_ModalBackdropScroll
+      >
         <FocusOnce>
           <ModalHeader>Some Header</ModalHeader>
         </FocusOnce>

--- a/src/modal/__tests__/__snapshots__/modal.test.js.snap
+++ b/src/modal/__tests__/__snapshots__/modal.test.js.snap
@@ -13,6 +13,7 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
   unstable_ModalBackdropScroll={false}
 >
   <mockConstructor
+    onDocumentClick={[Function]}
     onEscape={[Function]}
   >
     <ForwardRef
@@ -309,7 +310,6 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
                   $role="dialog"
                   $size="default"
                   $unstable_ModalBackdropScroll={false}
-                  onClick={[Function]}
                 >
                   <MockStyledComponent
                     $animate={true}
@@ -320,8 +320,14 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
                     $role="dialog"
                     $size="default"
                     $unstable_ModalBackdropScroll={false}
-                    forwardedRef={null}
-                    onClick={[Function]}
+                    forwardedRef={
+                      Object {
+                        "current": <div
+                          styled-component="true"
+                          test-style="[object Object]"
+                        />,
+                      }
+                    }
                   >
                     <Portal />
                   </MockStyledComponent>

--- a/src/modal/__tests__/modal-select.scenario.js
+++ b/src/modal/__tests__/modal-select.scenario.js
@@ -16,8 +16,14 @@ const Example = () => {
   const [isOpen, setIsOpen] = React.useState(true);
   return (
     <div>
-      <Button onClick={() => setIsOpen(true)}>Open Modal</Button>
-      <Modal isOpen={isOpen} onClose={() => setIsOpen(false)}>
+      <Button onClick={() => setIsOpen(true)} className="open-modal-button">
+        Open Modal
+      </Button>
+      <Modal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        overrides={{Backdrop: {props: {'data-e2e': 'backdrop'}}}}
+      >
         <ModalHeader>Hello world</ModalHeader>
         <ModalBody>
           <StatefulSelect

--- a/src/modal/__tests__/modal.e2e.js
+++ b/src/modal/__tests__/modal.e2e.js
@@ -19,6 +19,7 @@ const selectors = {
   selectDropDown: '[role="listbox"]',
   selectedList: '[data-id="selected"]',
   dropDownOption: '[role="option"]',
+  backdrop: '[data-e2e="backdrop"]',
 };
 
 const optionAtPosition = position =>
@@ -92,6 +93,27 @@ describe('modal', () => {
       select => select.textContent,
     );
     expect(selectedValue).toBe('AliceBlue');
+  });
+
+  it('closes one layer at a time on click outside', async () => {
+    await mount(page, 'modal-select');
+    await page.waitFor(selectors.dialog);
+
+    await page.click(selectors.selectInput);
+    await page.waitFor(selectors.selectDropDown);
+
+    // clicking outside of the modal content
+    // and outside the select dropdown
+    await page.click(selectors.openModal);
+    await page.waitFor(selectors.selectDropDown, {
+      hidden: true,
+    });
+    await page.waitFor(selectors.dialog);
+
+    await page.click(selectors.openModal);
+    await page.waitFor(selectors.dialog, {
+      hidden: true,
+    });
   });
 
   it('closes one popover at a time on esc key press', async () => {

--- a/src/modal/__tests__/modal.test.js
+++ b/src/modal/__tests__/modal.test.js
@@ -20,7 +20,6 @@ import {
   StyledDialog,
   CLOSE_SOURCE,
 } from '../index.js';
-
 import {styled} from '../../styles/index.js';
 
 jest.useFakeTimers();
@@ -102,21 +101,6 @@ describe('Modal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenLastCalledWith({
       closeSource: CLOSE_SOURCE.closeButton,
-    });
-  });
-
-  test('backdrop triggers close', () => {
-    const onClose = jest.fn();
-    wrapper = mount(
-      <Modal isOpen onClose={onClose}>
-        <ModalBody>Modal Body</ModalBody>
-      </Modal>,
-    );
-
-    wrapper.find(StyledBackdrop).simulate('click');
-    expect(onClose).toHaveBeenCalledTimes(1);
-    expect(onClose).toHaveBeenLastCalledWith({
-      closeSource: CLOSE_SOURCE.backdrop,
     });
   });
 

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -138,8 +138,21 @@ class Modal extends React.Component<ModalPropsT, ModalStateT> {
     if (!this.props.closeable) {
       return;
     }
-
     this.triggerClose(CLOSE_SOURCE.escape);
+  };
+
+  onDocumentClick = (e: MouseEvent) => {
+    if (
+      e.target &&
+      e.target instanceof HTMLElement &&
+      // Handles modal closure when unstable_ModalBackdropScroll is set to true
+      (e.target.contains(this.getRef('DialogContainer').current) ||
+        // Handles modal closure when unstable_ModalBackdropScroll is set to false
+        // $FlowFixMe
+        e.target.contains(this.getRef('DeprecatedBackdrop').current))
+    ) {
+      this.onBackdropClick();
+    }
   };
 
   onBackdropClick = () => {
@@ -147,16 +160,6 @@ class Modal extends React.Component<ModalPropsT, ModalStateT> {
       return;
     }
     this.triggerClose(CLOSE_SOURCE.backdrop);
-  };
-
-  // Handles modal closure when unstable_ModalBackdropScroll is set to true
-  onDialogContainerBackdropClick = (e: Event) => {
-    if (
-      e.target instanceof HTMLElement &&
-      e.target.contains(this.getRef('DialogContainer').current)
-    ) {
-      this.onBackdropClick();
-    }
   };
 
   onCloseClick = () => {
@@ -304,7 +307,6 @@ class Modal extends React.Component<ModalPropsT, ModalStateT> {
     const dialogContainerConditionalProps = unstable_ModalBackdropScroll
       ? {
           ref: this.getRef('DialogContainer'),
-          onClick: this.onDialogContainerBackdropClick,
         }
       : {};
 
@@ -325,7 +327,9 @@ class Modal extends React.Component<ModalPropsT, ModalStateT> {
               <Backdrop
                 {...(unstable_ModalBackdropScroll
                   ? {}
-                  : {onClick: this.onBackdropClick})}
+                  : {
+                      ref: this.getRef('DeprecatedBackdrop'),
+                    })}
                 {...sharedProps}
                 {...backdropProps}
               />
@@ -379,7 +383,11 @@ class Modal extends React.Component<ModalPropsT, ModalStateT> {
       return null;
     }
     return (
-      <Layer onEscape={this.onEscape} mountNode={this.props.mountNode}>
+      <Layer
+        onEscape={this.onEscape}
+        onDocumentClick={this.onDocumentClick}
+        mountNode={this.props.mountNode}
+      >
         {this.renderModal()}
       </Layer>
     );


### PR DESCRIPTION
Handling modal closure on a backdrop click through the Layer's `onDocumentClick` handler solves the issue when multiple layers rendered on top of a modal layer and a backdrop click removes all those layers instead of handling only the top-most layer's handlers.
An example here is a modal that renders a select component. When the select's dropdown is open a click on the backdrop (that is also outside of the select dropdown click) will only close the select's dropdown and the modal will remain open.