### PR TITLE
fix(flow): fix flow warnings that failed yarn:test

### DIFF
--- a/src/datepicker/styled-components.js
+++ b/src/datepicker/styled-components.js
@@ -589,7 +589,6 @@ export const StyledDay = styled<SharedStylePropsT>('div', props => {
       borderBottomRightRadius: '100%',
       ...(getDayStyles(code, props.$theme)[':after'] || {}),
     },
-    // $FlowFixMe fails flow check in 0.111+
     ...($range
       ? {
           // :before pseudo element defines a grey background style that extends

--- a/src/timepicker/__tests__/timepicker.test.js
+++ b/src/timepicker/__tests__/timepicker.test.js
@@ -35,9 +35,7 @@ describe('Timepicker', () => {
     const [hours, minutes] = secondsToHourMinute(option.id);
     date.setHours(hours, minutes, 0);
     expect(onChange).toHaveBeenCalled();
-    // $FlowFixMe
     expect(onChange.mock.calls[0][0].getMinutes()).toEqual(date.getMinutes());
-    // $FlowFixMe
     expect(onChange.mock.calls[0][0].getHours()).toEqual(date.getHours());
   });
 });


### PR DESCRIPTION
Fixes #2943 

#### Description

Fixes the flow warnings that caused yarn:test to fail from a clean clone.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
