### PR TITLE
docs: fix some ref examples

### DIFF
--- a/documentation-site/examples/input/focus.js
+++ b/documentation-site/examples/input/focus.js
@@ -6,7 +6,7 @@ import {Input} from 'baseui/input';
 
 export default () => {
   const [css, theme] = useStyletron();
-  const inputRef = React.createRef();
+  const inputRef = React.useRef(null);
   return (
     <div className={css({display: 'flex'})}>
       <Input

--- a/documentation-site/examples/input/focus.tsx
+++ b/documentation-site/examples/input/focus.tsx
@@ -5,7 +5,7 @@ import {Input} from 'baseui/input';
 
 export default () => {
   const [css, theme] = useStyletron();
-  const inputRef = React.createRef<HTMLInputElement>();
+  const inputRef = React.useRef<HTMLInputElement>(null);
   return (
     <div className={css({display: 'flex'})}>
       <Input

--- a/documentation-site/examples/layer/basic-tether.js
+++ b/documentation-site/examples/layer/basic-tether.js
@@ -9,8 +9,6 @@ import {
 import {useStyletron} from 'baseui';
 import {Button} from 'baseui/button';
 
-const layerRef = React.createRef();
-
 function Wrapper(props) {
   const [css] = useStyletron();
   const {offset, color, children, forwardedRef} = props;

--- a/documentation-site/examples/layer/basic.js
+++ b/documentation-site/examples/layer/basic.js
@@ -5,8 +5,6 @@ import {Layer} from 'baseui/layer';
 import {useStyletron} from 'baseui';
 import {Button} from 'baseui/button';
 
-const layerRef = React.createRef();
-
 function Wrapper(props: any) {
   const [css] = useStyletron();
   const {offset, color, children, forwardedRef} = props;


### PR DESCRIPTION
You need to use `React.useRef` instead of `React.createRef` in functional components; otherwise, it will return a new reference with each render and that was making the input focus example unreliable.

Also checked the rest of examples and found some unused instances of createRef (also it should never go outside of the component).