### PR TITLE
test(eslint-plugin): cover vars without init

### DIFF
--- a/packages/eslint-plugin-baseui/__tests__/deprecated-theme-api-test.js
+++ b/packages/eslint-plugin-baseui/__tests__/deprecated-theme-api-test.js
@@ -149,6 +149,21 @@ const tests = {
         />
       `,
     },
+    {
+      code: `
+        export function Tag(props: Props) {
+          const [useCss, theme] = useStyletron();
+
+          let someVarWithoutInit;
+
+          const paramRowStyle = useCss({
+            display: 'flex',
+            flexWrap: 'wrap',
+            ...theme.typography.font200,
+          });
+        }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-baseui/src/deprecated-theme-api.js
+++ b/packages/eslint-plugin-baseui/src/deprecated-theme-api.js
@@ -480,8 +480,6 @@ function lintUseStyletron(context, node) {
       declarator = declaration.declarations.find(
         declarator =>
           declarator.type === 'VariableDeclarator' &&
-          // couldn't repro in local test cases why we need it
-          // just opened a story in our backlog to look into this more
           declarator.init &&
           declarator.init.type === 'CallExpression' &&
           declarator.init.callee.name === 'useStyletron',


### PR DESCRIPTION
Cover the case in the eslint plugin, when the user has a variable that's not initialized when declared

<img width="474" alt="Screen Shot 2020-03-02 at 10 50 34 AM" src="https://user-images.githubusercontent.com/2174968/75707406-ad7f0a80-5c73-11ea-8238-6bbfd144abcf.png">
