### PR TITLE
fix(button): respect focus handler props

### DIFF
--- a/src/button/button.js
+++ b/src/button/button.js
@@ -103,8 +103,11 @@ class Button extends React.Component<
         {...baseButtonProps}
         // Applies last to override passed in onClick
         onClick={this.internalOnClick}
-        onFocus={forkFocus(baseButtonProps, this.handleFocus)}
-        onBlur={forkBlur(baseButtonProps, this.handleBlur)}
+        onFocus={forkFocus(
+          {...restProps, ...baseButtonProps},
+          this.handleFocus,
+        )}
+        onBlur={forkBlur({...restProps, ...baseButtonProps}, this.handleBlur)}
       >
         {isLoading ? (
           <React.Fragment>


### PR DESCRIPTION
Originally I was going to update the Popover "hover" trigger to also
trigger on focus events. Reading through our docs, I noticed that we
already have this feature (under the Accessibility section). Sure
enough, we already pass through the focus events to the anchor (or
wrapping span).

The issue is that Button overwrites any `onFocus` and `onBlur` handlers
passed as top level props. It respects overrides for those props but
technically people can pass `onFocus` and `onBlur` as top level props
so this commit updates the handlers to restore that option.