### PR TITLE
fix(side-nav): pass item to StyledNavItemElement

### DIFF
--- a/src/side-navigation/__tests__/nav-override.scenario.js
+++ b/src/side-navigation/__tests__/nav-override.scenario.js
@@ -1,0 +1,40 @@
+/*
+Copyright (c) 2018-2020 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+
+import {Navigation} from '../index.js';
+
+export default function Scenario() {
+  const [activeItemId, setActiveItemId] = React.useState('222');
+  return (
+    <Navigation
+      items={[
+        {
+          title: '111',
+          itemId: '111',
+          isInvalid: true,
+        },
+        {
+          title: '222',
+          itemId: '222',
+          isInvalid: false,
+        },
+      ]}
+      activeItemId={activeItemId}
+      onChange={({item}) => setActiveItemId(item.itemId)}
+      overrides={{
+        NavItem: {
+          style: ({$item: {isInvalid}}) => ({
+            color: isInvalid ? 'red' : 'black',
+          }),
+        },
+      }}
+    />
+  );
+}

--- a/src/side-navigation/styled-components.js
+++ b/src/side-navigation/styled-components.js
@@ -101,7 +101,7 @@ export const StyledNavItem = ((React.forwardRef<
   any,
 >(
   ({item, ...restProps}, ref) => (
-    <StyledNavItemElement ref={ref} {...restProps} />
+    <StyledNavItemElement ref={ref} {...restProps} $item={item} />
   ),
   // eslint-disable-next-line flowtype/no-weak-types
 ): any): StyletronComponent<SharedPropsT>);


### PR DESCRIPTION
Before version 9.31, one could do something like this to override the side-nav:

```
overrides={{
        NavItem: {
          style: ({item: {isInvalid}}) => ({
            color: isInvalid ? 'red' : 'black',
          }),
        },
      }}
```

after 9.31, that's no longer possibe