### PR TITLE
fix(typescript): Fix Typography definitions

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -600,6 +600,24 @@ interface Typography {
   font1250: Font;
   font1350: Font;
   font1450: Font;
+  ParagraphXSmall: Font;
+  ParagraphSmall: Font;
+  ParagraphMedium: Font;
+  ParagraphLarge: Font;
+  LabelXSmall: Font;
+  LabelSmall: Font;
+  LabelMedium: Font;
+  LabelLarge: Font;
+  HeadingXSmall: Font;
+  HeadingSmall: Font;
+  HeadingMedium: Font;
+  HeadingLarge: Font;
+  HeadingXLarge: Font;
+  HeadingXXLarge: Font;
+  DisplayXSmall: Font;
+  DisplaySmall: Font;
+  DisplayMedium: Font;
+  DisplayLarge: Font;
 }
 
 interface Sizing {


### PR DESCRIPTION
#### Description

The typography definitions only had primitives and the eslint plugin deprecated-theme-api would try and fix them to the new API which aren't in the definitions. This syncs up the typography definition with the current flow types.

#### Scope

- [X] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
