### PR TITLE
fix(table-semantic): screen-reader fixes and nicer focus

### DIFF
--- a/src/table-semantic/styled-components.js
+++ b/src/table-semantic/styled-components.js
@@ -101,16 +101,16 @@ export const StyledTableHeadCell = styled<{}>('th', ({$theme}) => {
 
 export const StyledTableHeadCellSortable = withStyle<
   typeof StyledTableHeadCell,
-  {},
->(StyledTableHeadCell, ({$theme}) => {
+  {$isFocusVisible: boolean},
+>(StyledTableHeadCell, ({$theme, $isFocusVisible}) => {
   return {
     cursor: 'pointer',
     paddingRight: $theme.sizing.scale1000,
-
+    outline: 'none',
     ':focus': {
-      backgroundColor: $theme.colors.tableStripedBackground,
+      outline: $isFocusVisible ? `3px solid ${$theme.colors.accent}` : 'none',
+      outlineOffset: '-3px',
     },
-
     ':hover': {
       backgroundColor: $theme.colors.tableStripedBackground,
     },

--- a/src/table-semantic/table-builder.js
+++ b/src/table-semantic/table-builder.js
@@ -150,15 +150,33 @@ export default class TableBuilder<T> extends React.Component<
 
       switch (col.id === sortColumn && sortOrder) {
         case 'ASC':
-          sortIcon = <SortAscIcon {...sortAscIconProps} />;
+          sortIcon = (
+            <SortAscIcon
+              aria-hidden={true}
+              role="presentation"
+              {...sortAscIconProps}
+            />
+          );
           sortLabel = 'ascending sorting';
           break;
         case 'DESC':
-          sortIcon = <SortDescIcon {...sortDescIconProps} />;
+          sortIcon = (
+            <SortDescIcon
+              aria-hidden={true}
+              role="presentation"
+              {...sortDescIconProps}
+            />
+          );
           sortLabel = 'descending sorting';
           break;
         default:
-          sortIcon = <SortNoneIcon {...sortNoneIconProps} />;
+          sortIcon = (
+            <SortNoneIcon
+              aria-hidden={true}
+              role="presentation"
+              {...sortNoneIconProps}
+            />
+          );
           break;
       }
 

--- a/src/table-semantic/table-builder.js
+++ b/src/table-semantic/table-builder.js
@@ -22,14 +22,29 @@ import {
   StyledSortNoneIcon,
 } from './styled-components.js';
 import {getOverrides} from '../helpers/overrides.js';
+import {isFocusVisible, forkFocus, forkBlur} from '../utils/focusVisible.js';
 
 import type {TableBuilderPropsT} from './types.js';
 
 export default class TableBuilder<T> extends React.Component<
   TableBuilderPropsT<T>,
+  {isFocusVisible: boolean},
 > {
   static defaultProps = {
     data: [],
+  };
+  state = {isFocusVisible: false};
+
+  handleFocus = (event: SyntheticEvent<>) => {
+    if (isFocusVisible(event)) {
+      this.setState({isFocusVisible: true});
+    }
+  };
+
+  handleBlur = (event: SyntheticEvent<>) => {
+    if (this.state.isFocusVisible !== false) {
+      this.setState({isFocusVisible: false});
+    }
   };
 
   render() {
@@ -102,7 +117,7 @@ export default class TableBuilder<T> extends React.Component<
       .filter(Boolean)
       .map(child => child.props);
 
-    function renderHeader(col, colIndex) {
+    function renderHeader(col, colIndex, isFocusVisible) {
       const colOverrides = col.overrides || {};
 
       if (!col.sortable) {
@@ -131,13 +146,16 @@ export default class TableBuilder<T> extends React.Component<
       );
 
       let sortIcon = null;
+      let sortLabel = 'not sorted';
 
       switch (col.id === sortColumn && sortOrder) {
         case 'ASC':
           sortIcon = <SortAscIcon {...sortAscIconProps} />;
+          sortLabel = 'ascending sorting';
           break;
         case 'DESC':
           sortIcon = <SortDescIcon {...sortDescIconProps} />;
+          sortLabel = 'descending sorting';
           break;
         default:
           sortIcon = <SortNoneIcon {...sortNoneIconProps} />;
@@ -149,7 +167,15 @@ export default class TableBuilder<T> extends React.Component<
           key={colIndex}
           role="button"
           tabIndex="0"
+          aria-label={`${col.header}, ${sortLabel}`}
+          $isFocusVisible={isFocusVisible}
           onClick={() => onSort && onSort(col.id)}
+          onKeyDown={(e: KeyboardEvent) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onSort && onSort(col.id);
+            }
+          }}
           {...tableHeadCellSortableProps}
           {...colTableHeadCellSortableProps}
         >
@@ -181,10 +207,17 @@ export default class TableBuilder<T> extends React.Component<
 
     return (
       <Root data-baseweb="table-builder-semantic" {...rootProps} {...rest}>
-        <Table $width={horizontalScrollWidth} {...tableProps}>
+        <Table
+          $width={horizontalScrollWidth}
+          {...tableProps}
+          onBlur={forkBlur(tableProps, this.handleBlur)}
+          onFocus={forkFocus(tableProps, this.handleFocus)}
+        >
           <TableHead {...tableHeadProps}>
             <TableHeadRow {...tableHeadRowProps}>
-              {columns.map((col, colIndex) => renderHeader(col, colIndex))}
+              {columns.map((col, colIndex) =>
+                renderHeader(col, colIndex, this.state.isFocusVisible),
+              )}
             </TableHeadRow>
           </TableHead>
           <TableBody {...tableBodyProps}>


### PR DESCRIPTION
- sortable header has the button role so I added `Enter` and `Space` key handler for activation (an important a11y rule)
- applied nicer focus styles instead of the default outline
- it now announces if the column is sorted + how through the aria-label