### PR TITLE
fix(data-table): makes initial sort always ascending

### DIFF
--- a/src/data-table/__tests__/column-numerical.test.js
+++ b/src/data-table/__tests__/column-numerical.test.js
@@ -636,7 +636,7 @@ describe('numerical column', () => {
     const input = [2, 1, 3, 4];
     input.sort(column.sortFn);
 
-    const output = [4, 3, 2, 1];
+    const output = [1, 2, 3, 4];
     for (let i = 0; i < input.length; i++) {
       expect(input[i]).toBe(output[i]);
     }

--- a/src/data-table/__tests__/data-table-columns.e2e.js
+++ b/src/data-table/__tests__/data-table-columns.e2e.js
@@ -95,11 +95,11 @@ describe('data table columns', () => {
 
     await sortColumnAtIndex(page, index);
     const desc = await getCellContentsAtColumnIndex(page, COLUMN_COUNT, index);
-    expect(matchArrayElements(desc, ['4', '3', '2', '1'])).toBe(true);
+    expect(matchArrayElements(desc, ['1', '2', '3', '4'])).toBe(true);
 
     await sortColumnAtIndex(page, index);
     const asc = await getCellContentsAtColumnIndex(page, COLUMN_COUNT, index);
-    expect(matchArrayElements(asc, ['1', '2', '3', '4'])).toBe(true);
+    expect(matchArrayElements(asc, ['4', '3', '2', '1'])).toBe(true);
 
     await sortColumnAtIndex(page, index);
     const restored = await getCellContentsAtColumnIndex(

--- a/src/data-table/column-numerical.js
+++ b/src/data-table/column-numerical.js
@@ -535,9 +535,8 @@ function NumericalColumn(options: OptionsT): NumericalColumnT {
       return <NumericalFilter {...props} options={normalizedOptions} />;
     },
     sortable: normalizedOptions.sortable,
-    // initial sort should display largest values first
     sortFn: function(a, b) {
-      return b - a;
+      return a - b;
     },
     title: normalizedOptions.title,
   };


### PR DESCRIPTION
### Description

All other columns would initial sort in ascending order. Numerical should do the same

#### Scope

- [x] Patch: Bug Fix
