### PR TITLE
feat(styles): add withWrapper to base module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 export {
   styled,
   withStyle,
+  withWrapper,
   useStyletron,
   createThemedStyled,
   createThemedWithStyle,


### PR DESCRIPTION
Adds the `withWrapper` styling util to the base level import path.