### PR TITLE
chore(build): split deploy steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -69,8 +69,24 @@ steps:
     agents:
       queue: workers
 
-  - name: ':deploy:'
-    command: './deploy.sh'
+  - name: ':deploy-npm:'
+    command: './scripts/deploy-npm.sh'
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers
+
+  - name: ':deploy-vscode:'
+    command: './scripts/deploy-vscode.sh'
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers
+
+  - name: ':deploy-docs:'
+    command: './scripts/deploy-docs.sh'
     plugins:
       'docker-compose#v3.0.3':
         run: baseui

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -8,7 +8,7 @@ apt-get install -y jq
 this_commit=$(echo $BUILDKITE_COMMIT | tr -d '"')
 tags=$(curl https://api.github.com/repos/uber/baseweb/git/refs/tags?access_token=${GITHUB_AUTH_TOKEN})
 latest_tagged_commit=$(echo $tags | jq '.[-1].object.sha' | tr -d '"')
-BASEDIR=$(pwd)
+BASEDIR=$(cd ../ && pwd)
 
 echo this commit: $this_commit
 echo latest tagged commit: $latest_tagged_commit
@@ -21,18 +21,11 @@ if [ "$BUILDKITE_BRANCH" = "master" ]; then
 fi
 
 #BUILDKITE_MESSAGE="Release v8.4.0 (#1532)"
-
 if [ "$this_commit" = "$latest_tagged_commit" ]; then
   echo current commit matches latest tagged commit
   echo deploying to now
   version=$(echo $BUILDKITE_MESSAGE | cut -d' ' -f 2)
   echo version $version
-
-  # deploy to npm
-  rm .npmrc
-  echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-  yarn build
-  npm publish dist
 
   # deploy to now the versioned docs site
   now --scope=uber-ui-platform --token=$ZEIT_NOW_TOKEN --public --no-clipboard deploy ./public > deployment.txt
@@ -44,20 +37,6 @@ if [ "$this_commit" = "$latest_tagged_commit" ]; then
      -H "Content-Type: application/json" \
      --data "{\"type\":\"CNAME\",\"name\":\"$cname.baseweb.design\",\"content\":\"alias.zeit.co\",\"ttl\":1,\"priority\":10,\"proxied\":false}"
   now --scope=uber-ui-platform --token=$ZEIT_NOW_TOKEN alias $deployment "$cname.baseweb.design"
-
-  # publish eslint-plugin-baseui
-  cd $BASEDIR
-  cd packages/eslint-plugin-baseui
-  node "$BASEDIR/scripts/sync-package-versions.js" package.json
-  npm publish
-
-  # publish the vscode extension
-  cd $BASEDIR
-  cd packages/baseweb-vscode-extension
-  node "$BASEDIR/scripts/sync-package-versions.js" package.json
-  yarn
-  yarn build
-  ./node_modules/.bin/vsce publish --yarn -p $AZURE_TOKEN
 else
   echo current commit does not match latest tagged commit
   echo exited without deploying to now

--- a/scripts/deploy-npm.sh
+++ b/scripts/deploy-npm.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+apt-get update
+apt-get install -y jq
+
+this_commit=$(echo $BUILDKITE_COMMIT | tr -d '"')
+tags=$(curl https://api.github.com/repos/uber/baseweb/git/refs/tags?access_token=${GITHUB_AUTH_TOKEN})
+latest_tagged_commit=$(echo $tags | jq '.[-1].object.sha' | tr -d '"')
+BASEDIR=$(cd ../ && pwd)
+
+echo this commit: $this_commit
+echo latest tagged commit: $latest_tagged_commit
+
+#BUILDKITE_MESSAGE="Release v8.4.0 (#1532)"
+if [ "$this_commit" = "$latest_tagged_commit" ]; then
+  echo current commit matches latest tagged commit
+  echo deploying to now
+  version=$(echo $BUILDKITE_MESSAGE | cut -d' ' -f 2)
+  echo version $version
+
+  # publish baseui
+  rm .npmrc
+  echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+  yarn build
+  npm publish dist
+
+  # publish eslint-plugin-baseui
+  cd $BASEDIR
+  cd packages/eslint-plugin-baseui
+  node "$BASEDIR/scripts/sync-package-versions.js" package.json
+  npm publish
+else
+  echo current commit does not match latest tagged commit
+  echo exited without deploying to now
+fi

--- a/scripts/deploy-vscode.sh
+++ b/scripts/deploy-vscode.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+apt-get update
+apt-get install -y jq
+
+this_commit=$(echo $BUILDKITE_COMMIT | tr -d '"')
+tags=$(curl https://api.github.com/repos/uber/baseweb/git/refs/tags?access_token=${GITHUB_AUTH_TOKEN})
+latest_tagged_commit=$(echo $tags | jq '.[-1].object.sha' | tr -d '"')
+BASEDIR=$(cd ../ && pwd)
+
+echo this commit: $this_commit
+echo latest tagged commit: $latest_tagged_commit
+
+#BUILDKITE_MESSAGE="Release v8.4.0 (#1532)"
+if [ "$this_commit" = "$latest_tagged_commit" ]; then
+  echo current commit matches latest tagged commit
+  echo deploying to now
+  version=$(echo $BUILDKITE_MESSAGE | cut -d' ' -f 2)
+  echo version $version
+
+  # publish the vscode extension
+  cd $BASEDIR
+  cd packages/baseweb-vscode-extension
+  node "$BASEDIR/scripts/sync-package-versions.js" package.json
+  yarn
+  yarn build
+  ./node_modules/.bin/vsce publish --yarn -p $AZURE_TOKEN
+else
+  echo current commit does not match latest tagged commit
+  echo exited without deploying to now
+fi


### PR DESCRIPTION
In the current deploy step, we've been doing quite a lot

- deploy baseui and the eslint plugin
- deploy the docs to netlify
- deploy the docs to zeit on tag creation
- deploy the vscode extension

If any of these steps failed, the next step failed too. This change makes sure that the jobs are independent of each other.