### PR TITLE
docs(theming): respect media prop

### DIFF
--- a/documentation-site/components/theming/breakpoints.js
+++ b/documentation-site/components/theming/breakpoints.js
@@ -20,7 +20,7 @@ export function Breakpoint({
   return (
     <Property
       name={name}
-      concern="breakpoints"
+      concern={media ? 'mediaQuery' : 'breakpoints'}
       renderValue={() =>
         media
           ? LightTheme.mediaQuery[name]


### PR DESCRIPTION
#### Description

Documentation site's 'Theming' page provides misleading information regarding `mediaQuery` property usage. This pull request makes `Breakpoint` component to respect `media` prop when passing concern prop to `Property` component, therefore fixes the bug.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
