### PR TITLE
fix(input): adds inputMode to props in typescript

### DIFF
--- a/src/input/index.d.ts
+++ b/src/input/index.d.ts
@@ -47,6 +47,7 @@ export interface BaseInputProps<T> {
   positive?: boolean;
   id?: string;
   'data-baseweb'?: string;
+  inputMode?: string;
   inputRef?: React.Ref<T>;
   name?: string;
   onBlur?: React.FocusEventHandler<T>;


### PR DESCRIPTION
#### Description

Adds `inputMode` prop to `Input` component — exists in `types.js` but is missing in `index.d.ts`

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
