### PR TITLE
fix(deploy): move deploy scripts back to the root

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,7 +70,7 @@ steps:
       queue: workers
 
   - name: ':deploy-npm:'
-    command: './scripts/deploy-npm.sh'
+    command: './deploy-npm.sh'
     plugins:
       'docker-compose#v3.0.3':
         run: baseui
@@ -78,7 +78,7 @@ steps:
       queue: workers
 
   - name: ':deploy-vscode:'
-    command: './scripts/deploy-vscode.sh'
+    command: './deploy-vscode.sh'
     plugins:
       'docker-compose#v3.0.3':
         run: baseui
@@ -86,7 +86,7 @@ steps:
       queue: workers
 
   - name: ':deploy-docs:'
-    command: './scripts/deploy-docs.sh'
+    command: './deploy-docs.sh'
     plugins:
       'docker-compose#v3.0.3':
         run: baseui

--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -8,7 +8,6 @@ apt-get install -y jq
 this_commit=$(echo $BUILDKITE_COMMIT | tr -d '"')
 tags=$(curl https://api.github.com/repos/uber/baseweb/git/refs/tags?access_token=${GITHUB_AUTH_TOKEN})
 latest_tagged_commit=$(echo $tags | jq '.[-1].object.sha' | tr -d '"')
-BASEDIR=$(cd ../ && pwd)
 
 echo this commit: $this_commit
 echo latest tagged commit: $latest_tagged_commit
@@ -17,7 +16,7 @@ echo latest tagged commit: $latest_tagged_commit
 if [ "$BUILDKITE_BRANCH" = "master" ]; then
   # we build the doc site on purpose here - it will slow down builds on the master only
   FORCE_EXTRACT_REACT_TYPES=true yarn documentation:build
-  ./node_modules/.bin/netlify deploy --dir=public --prod
+  yarn netlify deploy --dir=public --prod
 fi
 
 #BUILDKITE_MESSAGE="Release v8.4.0 (#1532)"

--- a/deploy-npm.sh
+++ b/deploy-npm.sh
@@ -8,7 +8,7 @@ apt-get install -y jq
 this_commit=$(echo $BUILDKITE_COMMIT | tr -d '"')
 tags=$(curl https://api.github.com/repos/uber/baseweb/git/refs/tags?access_token=${GITHUB_AUTH_TOKEN})
 latest_tagged_commit=$(echo $tags | jq '.[-1].object.sha' | tr -d '"')
-BASEDIR=$(cd ../ && pwd)
+BASEDIR=$(pwd)
 
 echo this commit: $this_commit
 echo latest tagged commit: $latest_tagged_commit

--- a/deploy-vscode.sh
+++ b/deploy-vscode.sh
@@ -8,7 +8,7 @@ apt-get install -y jq
 this_commit=$(echo $BUILDKITE_COMMIT | tr -d '"')
 tags=$(curl https://api.github.com/repos/uber/baseweb/git/refs/tags?access_token=${GITHUB_AUTH_TOKEN})
 latest_tagged_commit=$(echo $tags | jq '.[-1].object.sha' | tr -d '"')
-BASEDIR=$(cd ../ && pwd)
+BASEDIR=$(pwd)
 
 echo this commit: $this_commit
 echo latest tagged commit: $latest_tagged_commit


### PR DESCRIPTION
currently, there is no simple way in buildkite to change the current working directory for scripts that are run - because we are running quite a few different binaries from these scripts files, it's quite easy to mix things up

because of these downsides, I am moving back the deploy scripts to the root of the project