### PR TITLE
fix(cf): use bearer token

### DIFF
--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -31,8 +31,7 @@ if [ "$this_commit" = "$latest_tagged_commit" ]; then
   deployment=`cat deployment.txt`
   cname="${version//./-}"
   curl -X POST "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records" \
-     -H "X-Auth-Email: $CF_AUTH_EMAIL" \
-     -H "X-Auth-Key: $CF_API_KEY" \
+     -H "Authorization: Bearer $CF_API_KEY" \
      -H "Content-Type: application/json" \
      --data "{\"type\":\"CNAME\",\"name\":\"$cname.baseweb.design\",\"content\":\"alias.zeit.co\",\"ttl\":1,\"priority\":10,\"proxied\":false}"
   now --scope=uber-ui-platform --token=$ZEIT_NOW_TOKEN alias $deployment "$cname.baseweb.design"


### PR DESCRIPTION
Previously we used account-wide API Keys, instead of the more limited API Tokens