### PR TITLE
fix(menu): avoid react error, state update in render

### DIFF
--- a/src/menu/stateful-container.js
+++ b/src/menu/stateful-container.js
@@ -253,12 +253,6 @@ export default class MenuStatefulContainer extends React.Component<
     }
     const requiredItemProps = this.props.getRequiredItemProps(item, index);
     const activedescendantId = requiredItemProps.id || null;
-    if (
-      this.state.highlightedIndex === index &&
-      this.state.activedescendantId !== activedescendantId
-    ) {
-      this.setState({activedescendantId});
-    }
     return {
       id: requiredItemProps.id || this.optionIds[index],
       disabled: !!item.disabled,

--- a/src/menu/stateful-container.js
+++ b/src/menu/stateful-container.js
@@ -252,7 +252,6 @@ export default class MenuStatefulContainer extends React.Component<
       this.optionIds[index] = getBuiId();
     }
     const requiredItemProps = this.props.getRequiredItemProps(item, index);
-    const activedescendantId = requiredItemProps.id || null;
     return {
       id: requiredItemProps.id || this.optionIds[index],
       disabled: !!item.disabled,


### PR DESCRIPTION
Addresses initial concern here: https://github.com/uber/baseweb/issues/2980, but does not resolve broader issue.

#### Description

This `setState` call was being used to set the `activeDescendantId`, given the case where `highlightedIndex` is initially provided. This is probably an edge case we don't need to worry about in exchange for resolving the react error

#### Scope

- [x] Patch: Bug Fix
