### PR TITLE
fix(datepicker): nvda can navigate month dropdown

### DIFF
--- a/src/datepicker/__tests__/datepicker.e2e.js
+++ b/src/datepicker/__tests__/datepicker.e2e.js
@@ -147,19 +147,6 @@ describe('Datepicker', () => {
     await page.waitFor(selectors.monthYearSelectMenu);
   });
 
-  it('month year dropdown closes on tab away', async () => {
-    await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
-    await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
-    await page.waitFor(selectors.day);
-    await page.focus(selectors.monthYearSelectButton);
-    await page.keyboard.press('ArrowDown');
-    await page.waitFor(selectors.monthYearSelectMenu);
-    await page.keyboard.press('Tab');
-    await page.waitFor(selectors.monthYearSelectMenu, {hidden: true});
-  });
-
   it('month year dropdown escape does not close calendar', async () => {
     await mount(page, 'datepicker');
     await page.waitFor(selectors.input);

--- a/src/datepicker/calendar-header.js
+++ b/src/datepicker/calendar-header.js
@@ -358,7 +358,8 @@ export default class CalendarHeader extends React.Component<
     ) : (
       <OverriddenPopover
         placement="bottom"
-        focusLock={false}
+        autoFocus={true}
+        focusLock={true}
         isOpen={this.state.isMonthYearDropdownOpen}
         onClick={() => {
           this.setState(prev => ({

--- a/src/datepicker/calendar-header.js
+++ b/src/datepicker/calendar-header.js
@@ -358,6 +358,7 @@ export default class CalendarHeader extends React.Component<
     ) : (
       <OverriddenPopover
         placement="bottom"
+        // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus={true}
         focusLock={true}
         isOpen={this.state.isMonthYearDropdownOpen}


### PR DESCRIPTION
#### Description

Due to how NVDA and this dropdown menu both respond to up/down arrow keys, navigation was not possible. Removes a 'tab away' test since focus is now locked

#### Scope

- [x] Patch: Bug Fix
