### PR TITLE
fix(storybook): broken styles in storybook after HMR

### DIFF
--- a/e2e/storybook/config.js
+++ b/e2e/storybook/config.js
@@ -21,6 +21,7 @@ initializeRTL();
 
 // Add providers for theme and styletron
 const engine = new Styletron();
+
 addDecorator((story, context) => {
   return (
     <StyletronProvider value={engine}>
@@ -36,3 +37,7 @@ addDecorator((story, context) => {
 addParameters({options: {showAddonPanel: false}});
 
 configure(() => require('./load-stories.js'), module);
+
+if (module.hot) {
+  configure(() => require('./load-stories.js'), module);
+}


### PR DESCRIPTION

#### Description

e2e/config.js is re-invoked with every update, so this was yielding a brand new styletron instance for every update, which would sometimes yield broken styles from order dependency of rendering.

https://github.com/storybookjs/storybook/issues/1417

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
