### PR TITLE
fix(input): fix color of inputTextDisabled for Input

### DIFF
--- a/src/input/styled-components.js
+++ b/src/input/styled-components.js
@@ -318,7 +318,7 @@ export const InputContainer = styled<SharedPropsT>(
 function getInputColors($disabled, $isFocused, $error, colors) {
   if ($disabled) {
     return {
-      color: colors.contentSecondary,
+      color: colors.inputTextDisabled,
       caretColor: colors.contentPrimary,
       '::placeholder': {
         color: colors.inputTextDisabled,


### PR DESCRIPTION
#### Description

When the `Input` component is disabled, the color should equal the `inputTextDisabled` color. Currently, `inputTextDisabled` color is only used for the placeholder and `contentSecondary` is used for the disabled color.

The `Select` component uses `inputTextDisabled` for both disabled input text and disabled placeholder.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
