### PR TITLE
fix(build): remove type definition from esm target

### DIFF
--- a/src/datepicker/index.js
+++ b/src/datepicker/index.js
@@ -20,5 +20,5 @@ export {ORIENTATION, STATE_CHANGE_TYPE} from './constants.js';
 export * from './styled-components.js';
 // Flow
 export type * from './types.js';
-export * from '../timepicker/types.js';
-export * from '../timezonepicker/types.js';
+export type * from '../timepicker/types.js';
+export type * from '../timezonepicker/types.js';

--- a/src/tabs/index.js
+++ b/src/tabs/index.js
@@ -18,4 +18,4 @@ export {
   TabContent as StyledTabContent,
 } from './styled-components.js';
 // Flow
-export type * from './types';
+export type * from './types.js';

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -35,4 +35,4 @@ export {
   DarkTheme as darkThemeOverrides,
 };
 
-export * from './types';
+export type * from './types.js';

--- a/src/timepicker/index.js
+++ b/src/timepicker/index.js
@@ -7,4 +7,4 @@ LICENSE file in the root directory of this source tree.
 // @flow
 export {default as TimePicker} from './timepicker.js';
 // Flow
-export * from './types';
+export type * from './types.js';

--- a/src/tooltip/index.js
+++ b/src/tooltip/index.js
@@ -23,4 +23,4 @@ export {
 } from './styled-components.js';
 
 // Flow
-export * from './types';
+export type * from './types.js';


### PR DESCRIPTION
Remove type definition from esm target.
Follow up work of https://github.com/uber/baseweb/pull/2497.

#### Description

It fixes the following error:
<img width="1084" alt="Screenshot 2020-03-18 at 17 39 02" src="https://user-images.githubusercontent.com/353504/76991896-a9790b00-694a-11ea-80c5-9694b22a8445.png">

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
