### PR TITLE
fix(timepicker): do not remove on backspace

### DIFF
--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -262,6 +262,7 @@ class TimePicker extends React.Component<TimePickerPropsT, TimePickerStateT> {
               // if value is defined, it should be an array type
               value={value ? [value] : value}
               clearable={false}
+              backspaceRemoves={false}
               {...selectProps}
             />
           );


### PR DESCRIPTION
In previous versions, the backspace did nothing once a value is selected. This PR restores that behavior.

Why now? A recent PR caused the timepicker to throw an error if the user pressed the backspace

<img width="569" alt="Screen Shot 2020-03-20 at 2 38 16 PM" src="https://user-images.githubusercontent.com/2174968/77208922-3098c100-6aba-11ea-8503-5ec5f3443582.png">
