### PR TITLE
fix: properly override clearicon styles and props

### DIFF
--- a/src/select/select-component.js
+++ b/src/select/select-component.js
@@ -763,12 +763,12 @@ class Select extends React.Component<PropsT, SelectStateT> {
           Svg: {
             component: StyledClearIcon,
             props:
-              overrides.StyledClearIcon && overrides.StyledClearIcon.props
-                ? overrides.StyledClearIcon.props
+              overrides.ClearIcon && overrides.ClearIcon.props
+                ? overrides.ClearIcon.props
                 : {},
             style:
-              overrides.StyledClearIcon && overrides.StyledClearIcon.style
-                ? overrides.StyledClearIcon.style
+              overrides.ClearIcon && overrides.ClearIcon.style
+                ? overrides.ClearIcon.style
                 : {},
           },
         }}


### PR DESCRIPTION
Fixes #3066

#### Description

Styling for ClearIcon from Select component can be overridden.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
