### PR TITLE
docs(components): add title

### DIFF
--- a/documentation-site/pages/components/index.mdx
+++ b/documentation-site/pages/components/index.mdx
@@ -12,4 +12,6 @@ export default props => (
   <Layout {...props} maxContentWidth="95vw" hideSideNavigation />
 );
 
+# Components
+
 <Gallery />


### PR DESCRIPTION
#### Description

Currently there is no title set in Components page as seen below:
![image](https://user-images.githubusercontent.com/8682104/77250377-f0674900-6c47-11ea-914c-00e7d66c09b1.png)

This pull request adds a heading to components page's template and therefore sets title.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
