### PR TITLE
feat(form control): add input to themes

### DIFF
--- a/documentation-site/components/yard/config/form-control.ts
+++ b/documentation-site/components/yard/config/form-control.ts
@@ -15,7 +15,7 @@ const TextareaConfig: TConfig = {
     FormControl,
     Input,
   },
-  theme: [],
+  theme: ['caption'],
   props: {
     children: {
       value: '<Input />',

--- a/src/form-control/styled-components.js
+++ b/src/form-control/styled-components.js
@@ -38,7 +38,7 @@ export const Caption = styled<StylePropsT>('div', props => {
     $theme: {colors, sizing, typography},
   } = props;
 
-  let fontColor = colors.contentSecondary;
+  let fontColor = colors.caption;
   if ($error) {
     fontColor = colors.negative400;
   } else if ($positive) {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -274,6 +274,9 @@ interface Colors {
   fileUploaderBorderColorDefault: string;
   fileUploaderMessageColor: string;
 
+  // FormControl
+  caption: string;
+
   // Links
   linkText: string;
   linkVisited: string;

--- a/src/themes/dark-theme/color-component-tokens.js
+++ b/src/themes/dark-theme/color-component-tokens.js
@@ -93,6 +93,9 @@ export default (
   fileUploaderBorderColorDefault: themePrimitives.mono500,
   fileUploaderMessageColor: themePrimitives.mono100,
 
+  // FormControl
+  caption: themePrimitives.mono200,
+
   // Links
   linkText: themePrimitives.primary,
   linkVisited: themePrimitives.primary100,

--- a/src/themes/light-theme/color-component-tokens.js
+++ b/src/themes/light-theme/color-component-tokens.js
@@ -93,6 +93,9 @@ export default (
   fileUploaderBorderColorDefault: themePrimitives.mono500,
   fileUploaderMessageColor: themePrimitives.mono600,
 
+  // FormControl
+  caption: themePrimitives.mono600,
+
   // Links
   linkText: themePrimitives.primary,
   linkVisited: themePrimitives.primary700,

--- a/src/themes/light-theme/color-component-tokens.js
+++ b/src/themes/light-theme/color-component-tokens.js
@@ -94,7 +94,7 @@ export default (
   fileUploaderMessageColor: themePrimitives.mono600,
 
   // FormControl
-  caption: themePrimitives.mono600,
+  caption: themePrimitives.mono800,
 
   // Links
   linkText: themePrimitives.primary,

--- a/src/themes/types.js
+++ b/src/themes/types.js
@@ -221,6 +221,9 @@ export type ComponentColorTokensT = {|
   fileUploaderBorderColorDefault: string,
   fileUploaderMessageColor: string,
 
+  // FormControl
+  caption: string,
+
   // Links
   linkText: string,
   linkVisited: string,


### PR DESCRIPTION
#### Description
This allows changing the color of the caption text instead of having to use the same color as `contentSecondary`

<!-- Describe your changes below in as much detail as possible -->

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
