### PR TITLE
fix(eslint-plugin-baseui): object spread crash

### DIFF
--- a/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
+++ b/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
@@ -100,6 +100,18 @@ const tests = {
         }
       `,
     },
+
+    // Modal - Backdrop
+    // Regression: object spread in overrides
+    {
+      code: `
+        import {Modal as BaseModal} from "baseui/modal"
+        const overrides = { Backdrop: {}}
+        export default function(props) {
+          return <BaseModal overrides={{ ...overrides }} />
+        }
+      `,
+    },
   ],
   invalid: [
     // Accordion - renderPanelContent

--- a/packages/eslint-plugin-baseui/src/deprecated-component-api.js
+++ b/packages/eslint-plugin-baseui/src/deprecated-component-api.js
@@ -283,7 +283,10 @@ module.exports = {
           if (node.parent.value.expression.type === 'ObjectExpression') {
             // Find object property with "Backdrop" as key.
             const property = node.parent.value.expression.properties.find(
-              property => property.key.name === 'Backdrop',
+              property =>
+                property.key &&
+                property.key.name &&
+                property.key.name === 'Backdrop',
             );
             if (property) {
               context.report({


### PR DESCRIPTION
Fixes an `eslint-plugin-baseui` error when spreading an object in `overrides` for `Modal`.