### PR TITLE
Fix large breakpoint in documentation

### DIFF
--- a/documentation-site/pages/components/block.mdx
+++ b/documentation-site/pages/components/block.mdx
@@ -54,7 +54,7 @@ By default, the breakpoint values are
 breakpoints: {
   small: 320,
   medium: 600,
-  large: 1280,
+  large: 1136,
 }
 ```
 


### PR DESCRIPTION
Fixes incorrect large breakpoint value in documentation.

#### Description

As per `src/themes/shared/breakpoints.js`, the large breakpoint value is actually `1136` not `1280`.

#### Scope

- [x ] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
