### PR TITLE
fix(input): vertically align 'show password' icon

### DIFF
--- a/src/input/styled-components.js
+++ b/src/input/styled-components.js
@@ -24,6 +24,7 @@ export const StyledMaskToggleButton = styled<{
   }[$size];
   return {
     display: 'flex',
+    alignItems: 'center',
     borderTop: 'none',
     borderBottom: 'none',
     borderLeft: 'none',


### PR DESCRIPTION
### Description

Prior to this change, the icon button for showing/hiding the text in a password-type input was vertically aligned to the top of the input. This change vertically centers the icon to match the other input icons.

Adds `alignItems: 'center'` to `StyledMaskToggleButton`

Before:
<img width="603" alt="Screen Shot 2020-03-26 at 9 10 16 AM" src="https://user-images.githubusercontent.com/2684662/77650294-a4ffb400-6f41-11ea-9d43-b39db3454f2c.png">

After:
<img width="610" alt="Screen Shot 2020-03-26 at 9 08 55 AM" src="https://user-images.githubusercontent.com/2684662/77650300-a92bd180-6f41-11ea-9963-b32e53e9e869.png">


#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
