### PR TITLE
fix(codesandbox): fix DarkTheme, focus-ring, add CI integration

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,4 @@
 {
-  "installCommand": "install --production=false",
   "buildCommand": "build",
   "publishDirectory": {
     "baseui": "dist"

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,0 +1,8 @@
+{
+  "installCommand": "install",
+  "buildCommand": "build",
+  "publishDirectory": {
+    "baseui": "dist"
+  },
+  "sandboxes": ["basic-usage-9olot"]
+}

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "install",
+  "installCommand": "yarn",
   "buildCommand": "build",
   "publishDirectory": {
     "baseui": "dist"

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "yarn",
+  "installCommand": "install --production=false",
   "buildCommand": "build",
   "publishDirectory": {
     "baseui": "dist"

--- a/documentation-site/components/const.js
+++ b/documentation-site/components/const.js
@@ -9,7 +9,8 @@ export const codesandboxIndexCode = `
 import React from "react";
 import ReactDOM from "react-dom";
 
-import {BaseProvider, LightTheme} from 'baseui';
+// CodeSandbox's bundler needs the /esm path, webpack not
+import {BaseProvider, LightTheme} from 'baseui/esm';
 import { Provider as StyletronProvider } from "styletron-react";
 import { Client as Styletron } from "styletron-engine-atomic";
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:copy-files": "shx cp README.md dist/README.md",
     "build:copy-flow-files": "node ./scripts/flow-copy-src.js",
     "build:copy-ts-files": "node ./scripts/ts-copy.js",
-    "build:package-json": "shx cp package.json dist/package.json & node ./scripts/build-package-json.js",
+    "build:package-json": "shx cp package.json dist/package.json && node ./scripts/build-package-json.js",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel ./src --out-dir ./dist --ignore **.test.js,**/__tests__/**,**/e2e.js,**/template-component/**,**/test/**",
     "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel ./src --out-dir ./dist/esm --ignore **.test.js,**/__tests__/**,**/e2e.js,**/template-component/**,**/test/**",
     "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel ./src --out-dir ./dist/es --ignore **.test.js,**/__tests__/**,**/e2e.js,**/template-component/**,**/test/**",

--- a/src/utils/focusVisible.js
+++ b/src/utils/focusVisible.js
@@ -46,7 +46,6 @@ const inputTypesWhitelist = {
  * @return {boolean}
  */
 function focusTriggersKeyboardModality(node) {
-  if (!node) return false;
   const {type, tagName} = node;
 
   if (tagName === 'INPUT' && inputTypesWhitelist[type] && !node.readOnly) {

--- a/src/utils/focusVisible.js
+++ b/src/utils/focusVisible.js
@@ -4,23 +4,16 @@ Copyright (c) 2018-2020 Uber Technologies, Inc.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
-/* eslint-env browser */
 
 // @flow
 // based on:
 // - https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/utils/focusVisible.js
 // - https://github.com/WICG/focus-visible/blob/v4.1.5/src/focus-visible.js
 
-// CodeSandbox is strangely reloading this file somehow
-// this ensures a single instance of these flags
-const initializedKey = Symbol.for('baseweb.focusVisible.initialized');
-const hadKeyboardEventKey = Symbol.for('baseweb.focusVisible.hadKeyboardEvent');
-const hadFocusVisibleRecentlyKey = Symbol.for(
-  'baseweb.focusVisible.hadFocusVisibleRecently',
-);
-const hadFocusVisibleRecentlyTimeoutKey = Symbol.for(
-  'baseweb.focusVisible.hadFocusVisibleRecentlyTimeout',
-);
+let initialized = false;
+let hadKeyboardEvent = true;
+let hadFocusVisibleRecently = false;
+let hadFocusVisibleRecentlyTimeout = null;
 
 const inputTypesWhitelist = {
   text: true,
@@ -74,7 +67,7 @@ function handleKeyDown(event) {
   if (event.metaKey || event.altKey || event.ctrlKey) {
     return;
   }
-  window[hadKeyboardEventKey] = true;
+  hadKeyboardEvent = true;
 }
 
 /**
@@ -85,7 +78,7 @@ function handleKeyDown(event) {
  * pointing device, while we still think we're in keyboard modality.
  */
 function handlePointerDown() {
-  window[hadKeyboardEventKey] = false;
+  hadKeyboardEvent = false;
 }
 
 function handleVisibilityChange() {
@@ -94,8 +87,8 @@ function handleVisibilityChange() {
     // on the element (Safari actually calls it twice).
     // If this tab change caused a blur on an element with focus-visible,
     // re-apply the class when the user switches back to the tab.
-    if (window[hadFocusVisibleRecentlyKey]) {
-      window[hadKeyboardEventKey] = true;
+    if (hadFocusVisibleRecently) {
+      hadKeyboardEvent = true;
     }
   }
 }
@@ -131,7 +124,7 @@ export function isFocusVisible(event) {
 
   // no need for validFocusTarget check. the user does that by attaching it to
   // focusable events only
-  return window[hadKeyboardEventKey] || focusTriggersKeyboardModality(target);
+  return hadKeyboardEvent || focusTriggersKeyboardModality(target);
 }
 
 /**
@@ -142,22 +135,19 @@ export function handleBlurVisible() {
   // rapidly by a visibility change.
   // If we don't see a visibility change within 100ms, it's probably a
   // regular focus change.
-  window[hadFocusVisibleRecentlyKey] = true;
+  hadFocusVisibleRecently = true;
   if (__BROWSER__) {
-    window.clearTimeout(window[hadFocusVisibleRecentlyTimeoutKey]);
-    window[hadFocusVisibleRecentlyTimeoutKey] = window.setTimeout(() => {
-      window[hadFocusVisibleRecentlyKey] = false;
+    window.clearTimeout(hadFocusVisibleRecentlyTimeout);
+    hadFocusVisibleRecentlyTimeout = window.setTimeout(() => {
+      hadFocusVisibleRecently = false;
     }, 100);
   }
 }
 
 //$FlowFixMe
 export function initFocusVisible(node) {
-  if (!window[initializedKey] && node != null) {
-    window[initializedKey] = true;
-    window[hadKeyboardEventKey] = true;
-    window[hadFocusVisibleRecentlyKey] = false;
-    window[hadFocusVisibleRecentlyTimeoutKey] = null;
+  if (!initialized && node != null) {
+    initialized = true;
     prepare(node.ownerDocument);
   }
 }


### PR DESCRIPTION
- fixes the CodeSandbox setup, `baseui/esm` needs to be used when importing `BaseProvider` so everything is importing from the same source, otherwise things like React context doesn't work, this is a problem only in CodeSandbox since its bundler doesn't respect our esm mapping (Webpack does)
- reverts changes made to not displaying focus-ring,  it was a workaround for this issue... the mystery is solved!
- adds CodeSandbox CI, so every PR should come up with sandbox that will have PR's `baseui` built and loaded
