### PR TITLE
fix(deps): remove main field

### DIFF
--- a/documentation-site/components/const.js
+++ b/documentation-site/components/const.js
@@ -9,8 +9,7 @@ export const codesandboxIndexCode = `
 import React from "react";
 import ReactDOM from "react-dom";
 
-// CodeSandbox's bundler needs the /esm path, webpack not
-import {BaseProvider, LightTheme} from 'baseui/esm';
+import {BaseProvider, LightTheme} from 'baseui';
 import { Provider as StyletronProvider } from "styletron-react";
 import { Client as Styletron } from "styletron-engine-atomic";
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "baseweb"
   ],
   "license": "MIT",
-  "main": "index.js",
   "types": "index.d.ts",
   "sideEffects": false,
   "module": "./esm/index.js",


### PR DESCRIPTION
This should make both CodeSandbox and Webpack happy. We don't need this field since our main file is `./index.js` anyway.
