### PR TITLE
fix(vscode): revert longhand properties

### DIFF
--- a/packages/baseweb-vscode-extension/ext-src/coloring.ts
+++ b/packages/baseweb-vscode-extension/ext-src/coloring.ts
@@ -42,14 +42,8 @@ export default (context: vscode.ExtensionContext) => {
           : coloringStyle === 'underline'
           ? '0 0 2px'
           : '0',
-      borderLeftStyle: 'solid',
-      borderRightStyle: 'solid',
-      borderTopStyle: 'solid',
-      borderBottomStyle: 'solid',
-      borderLeftColor: colorVal,
-      borderRightColor: colorVal,
-      borderTopColor: colorVal,
-      borderBottomColor: colorVal,
+      borderStyle: 'solid',
+      borderColor: colorVal,
       backgroundColor:
         coloringStyle === 'background' ? colorVal : 'transparent',
       ...(coloringStyle === 'background' && colorVal.startsWith('#')


### PR DESCRIPTION
bug introduced in https://github.com/uber/baseweb/pull/3172

That specific vscode API accepts only shorthand properties.
