### PR TITLE
fix(flow): removes unused supression comments

### DIFF
--- a/src/accordion/panel.js
+++ b/src/accordion/panel.js
@@ -136,7 +136,6 @@ class Panel extends React.Component<PanelPropsT, {isFocusVisible: boolean}> {
                   size={16}
                   title={locale.accordion.collapse}
                   {...sharedProps}
-                  // $FlowFixMe
                   overrides={toggleIconOverrides}
                 />
               ) : (

--- a/src/icon/alert.js
+++ b/src/icon/alert.js
@@ -21,7 +21,6 @@ function Alert(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component: theme.icons && theme.icons.Alert ? theme.icons.Alert : null,
       props: {

--- a/src/icon/arrow-down.js
+++ b/src/icon/arrow-down.js
@@ -21,7 +21,6 @@ function ArrowDown(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.ArrowDown ? theme.icons.ArrowDown : null,

--- a/src/icon/arrow-left.js
+++ b/src/icon/arrow-left.js
@@ -21,7 +21,6 @@ function ArrowLeft(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.ArrowLeft ? theme.icons.ArrowLeft : null,

--- a/src/icon/arrow-right.js
+++ b/src/icon/arrow-right.js
@@ -21,7 +21,6 @@ function ArrowRight(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.ArrowRight ? theme.icons.ArrowRight : null,

--- a/src/icon/arrow-up.js
+++ b/src/icon/arrow-up.js
@@ -21,7 +21,6 @@ function ArrowUp(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.ArrowUp ? theme.icons.ArrowUp : null,

--- a/src/icon/blank.js
+++ b/src/icon/blank.js
@@ -21,7 +21,6 @@ function Blank(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component: theme.icons && theme.icons.Blank ? theme.icons.Blank : null,
       props: {

--- a/src/icon/check-indeterminate.js
+++ b/src/icon/check-indeterminate.js
@@ -21,7 +21,6 @@ function CheckIndeterminate(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.CheckIndeterminate

--- a/src/icon/check.js
+++ b/src/icon/check.js
@@ -21,7 +21,6 @@ function Check(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component: theme.icons && theme.icons.Check ? theme.icons.Check : null,
       props: {

--- a/src/icon/chevron-down.js
+++ b/src/icon/chevron-down.js
@@ -21,7 +21,6 @@ function ChevronDown(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.ChevronDown ? theme.icons.ChevronDown : null,

--- a/src/icon/chevron-left.js
+++ b/src/icon/chevron-left.js
@@ -21,7 +21,6 @@ function ChevronLeft(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.ChevronLeft ? theme.icons.ChevronLeft : null,

--- a/src/icon/chevron-right.js
+++ b/src/icon/chevron-right.js
@@ -21,7 +21,6 @@ function ChevronRight(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.ChevronRight

--- a/src/icon/chevron-up.js
+++ b/src/icon/chevron-up.js
@@ -21,7 +21,6 @@ function ChevronUp(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.ChevronUp ? theme.icons.ChevronUp : null,

--- a/src/icon/delete-alt.js
+++ b/src/icon/delete-alt.js
@@ -21,7 +21,6 @@ function DeleteAlt(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.DeleteAlt ? theme.icons.DeleteAlt : null,

--- a/src/icon/delete.js
+++ b/src/icon/delete.js
@@ -21,7 +21,6 @@ function Delete(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component: theme.icons && theme.icons.Delete ? theme.icons.Delete : null,
       props: {

--- a/src/icon/filter.js
+++ b/src/icon/filter.js
@@ -21,7 +21,6 @@ function Filter(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component: theme.icons && theme.icons.Filter ? theme.icons.Filter : null,
       props: {

--- a/src/icon/grab.js
+++ b/src/icon/grab.js
@@ -21,7 +21,6 @@ function Grab(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component: theme.icons && theme.icons.Grab ? theme.icons.Grab : null,
       props: {

--- a/src/icon/hide.js
+++ b/src/icon/hide.js
@@ -21,7 +21,6 @@ function Hide(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component: theme.icons && theme.icons.Hide ? theme.icons.Hide : null,
       props: {

--- a/src/icon/icon-template.txt
+++ b/src/icon/icon-template.txt
@@ -21,7 +21,6 @@ function %%ICON_NAME%%(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component: theme.icons && theme.icons.%%ICON_NAME%% ? theme.icons.%%ICON_NAME%% : null,
       props: {

--- a/src/icon/menu.js
+++ b/src/icon/menu.js
@@ -21,7 +21,6 @@ function Menu(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component: theme.icons && theme.icons.Menu ? theme.icons.Menu : null,
       props: {

--- a/src/icon/overflow.js
+++ b/src/icon/overflow.js
@@ -21,7 +21,6 @@ function Overflow(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.Overflow ? theme.icons.Overflow : null,

--- a/src/icon/plus.js
+++ b/src/icon/plus.js
@@ -21,7 +21,6 @@ function Plus(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component: theme.icons && theme.icons.Plus ? theme.icons.Plus : null,
       props: {

--- a/src/icon/search.js
+++ b/src/icon/search.js
@@ -21,7 +21,6 @@ function Search(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component: theme.icons && theme.icons.Search ? theme.icons.Search : null,
       props: {

--- a/src/icon/show.js
+++ b/src/icon/show.js
@@ -21,7 +21,6 @@ function Show(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component: theme.icons && theme.icons.Show ? theme.icons.Show : null,
       props: {

--- a/src/icon/spinner.js
+++ b/src/icon/spinner.js
@@ -21,7 +21,6 @@ function Spinner(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.Spinner ? theme.icons.Spinner : null,

--- a/src/icon/triangle-down.js
+++ b/src/icon/triangle-down.js
@@ -21,7 +21,6 @@ function TriangleDown(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.TriangleDown

--- a/src/icon/triangle-left.js
+++ b/src/icon/triangle-left.js
@@ -21,7 +21,6 @@ function TriangleLeft(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.TriangleLeft

--- a/src/icon/triangle-right.js
+++ b/src/icon/triangle-right.js
@@ -21,7 +21,6 @@ function TriangleRight(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.TriangleRight

--- a/src/icon/triangle-up.js
+++ b/src/icon/triangle-up.js
@@ -21,7 +21,6 @@ function TriangleUp(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component:
         theme.icons && theme.icons.TriangleUp ? theme.icons.TriangleUp : null,

--- a/src/icon/upload.js
+++ b/src/icon/upload.js
@@ -21,7 +21,6 @@ function Upload(props: IconPropsT, ref) {
   const SvgOverride = mergeOverride(
     // Icons from theme really targets the SVG override in the underlying Icon component, but
     // have props typed with IconPropsT. Provided the missing props inline below here.
-    // $FlowFixMe
     {
       component: theme.icons && theme.icons.Upload ? theme.icons.Upload : null,
       props: {

--- a/src/popover/__tests__/styled-component.test.js
+++ b/src/popover/__tests__/styled-component.test.js
@@ -78,7 +78,6 @@ describe('Popover styled components flow', () => {
   test('it provides flow error if we not provide all required props for StyledBody', () => {
     const BrokenCustomBody = props => {
       const {$isAnimating, children, ...rest} = props;
-      // $FlowFixMe missing $isAnimating prop
       return <StyledBody {...rest}>{children}</StyledBody>;
     };
     const CustomPopover = () => (


### PR DESCRIPTION
`yarn test` runs flow with the param `--max-warnings 0`, but CI does not pass that. Contributors that run just `yarn test` will see warnings from flow until this diff is landed
