### PR TITLE
feat(table-semantic): expose col, colIndex, row, and rowIndex props

### DIFF
--- a/src/table-semantic/__tests__/table-builder.test.js
+++ b/src/table-semantic/__tests__/table-builder.test.js
@@ -151,18 +151,91 @@ describe('Table Semantic Builder', () => {
       </TableBuilder>,
     );
 
-    wrapper
-      .find(StyledTableHeadCellSortable)
-      .at(0)
-      .simulate('click');
+    const headCells = wrapper.find(StyledTableHeadCellSortable);
 
-    wrapper
-      .find(StyledTableHeadCellSortable)
+    headCells.at(0).simulate('click');
+    headCells.at(1).simulate('click');
+
+    headCells
       .at(1)
-      .simulate('click');
+      .simulate('focus')
+      .simulate('keydown', {key: 'Enter'});
 
-    expect(mockOnSort.mock.calls.length).toBe(2);
-    expect(mockOnSort.mock.calls[0][0]).toBe('foo');
-    expect(mockOnSort.mock.calls[1][0]).toBe('bar');
+    headCells
+      .at(1)
+      .simulate('focus')
+      .simulate('keydown', {key: ' '});
+
+    headCells
+      .at(1)
+      .simulate('focus')
+      .simulate('keydown', {key: 'a'});
+
+    headCells.at(1).simulate('blur');
+
+    expect(mockOnSort.mock.calls.length).toBe(4);
+    expect(mockOnSort.mock.calls).toEqual([['foo'], ['bar'], ['bar'], ['bar']]);
+  });
+
+  it('exposes row and column data to overrides', () => {
+    const mockTableHeadCellStyle = jest.fn();
+    const mockTableBodyRowStyle = jest.fn();
+    const mockTableBodyCellStyle = jest.fn();
+
+    mount(
+      <TableBuilder
+        data={DATA}
+        overrides={{
+          TableHeadCell: {
+            style: mockTableHeadCellStyle,
+          },
+          TableBodyRow: {
+            style: mockTableBodyRowStyle,
+          },
+          TableBodyCell: {
+            style: mockTableBodyCellStyle,
+          },
+        }}
+      >
+        <TableBuilderColumn header="Foo" id="foo">
+          {row => row.foo}
+        </TableBuilderColumn>
+        <TableBuilderColumn header="Bar" id="bar">
+          {row => <a href={row.url}>{row.bar}</a>}
+        </TableBuilderColumn>
+      </TableBuilder>,
+    );
+
+    expect(mockTableHeadCellStyle.mock.calls.length).toBe(2);
+    expect(mockTableHeadCellStyle.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        $colIndex: 0,
+        $col: expect.objectContaining({
+          header: 'Foo',
+          id: 'foo',
+        }),
+      }),
+    );
+
+    expect(mockTableBodyRowStyle.mock.calls.length).toBe(3);
+    expect(mockTableBodyRowStyle.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        $rowIndex: 0,
+        $row: DATA[0],
+      }),
+    );
+
+    expect(mockTableBodyCellStyle.mock.calls.length).toBe(6);
+    expect(mockTableBodyCellStyle.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        $colIndex: 0,
+        $col: expect.objectContaining({
+          header: 'Foo',
+          id: 'foo',
+        }),
+        $rowIndex: 0,
+        $row: DATA[0],
+      }),
+    );
   });
 });

--- a/src/table-semantic/styled-components.js
+++ b/src/table-semantic/styled-components.js
@@ -48,59 +48,72 @@ export const StyledTableHeadRow = styled<{}>('tr', ({$theme}) => {
   return {};
 });
 
-export const StyledTableHeadCell = styled<{}>('th', ({$theme}) => {
-  return {
-    ...$theme.typography.font350,
-    position: 'sticky',
-    top: 0,
-    paddingTop: $theme.sizing.scale500,
-    paddingRight: $theme.sizing.scale600,
-    paddingBottom: $theme.sizing.scale500,
-    paddingLeft: $theme.sizing.scale600,
-    backgroundColor: $theme.colors.tableHeadBackgroundColor,
-    color: $theme.colors.contentPrimary,
-    textAlign: 'left',
-    verticalAlign: 'top',
-    whiteSpace: 'nowrap',
+type StyledTableHeadCellPropsT = {
+  $col?: {},
+  $colIndex?: ?number,
+};
 
-    // We have to use pseudo elements to add the border for headers
-    // because browsers don't properly handle borders on sticky cells.
-    // The cells stay fixed in place, but the borders scroll.
-    '::before': {
-      content: '""',
-      position: 'absolute',
-      top: '0',
-      right: '100%',
-      bottom: '0',
-      borderLeftColor: $theme.borders.border300.borderColor,
-      borderLeftStyle: $theme.borders.border300.borderStyle,
-      borderLeftWidth: $theme.borders.border300.borderWidth,
-    },
+export const StyledTableHeadCell = styled<StyledTableHeadCellPropsT>(
+  'th',
+  ({$theme}) => {
+    return {
+      ...$theme.typography.font350,
+      position: 'sticky',
+      top: 0,
+      paddingTop: $theme.sizing.scale500,
+      paddingRight: $theme.sizing.scale600,
+      paddingBottom: $theme.sizing.scale500,
+      paddingLeft: $theme.sizing.scale600,
+      backgroundColor: $theme.colors.tableHeadBackgroundColor,
+      color: $theme.colors.contentPrimary,
+      textAlign: 'left',
+      verticalAlign: 'top',
+      whiteSpace: 'nowrap',
 
-    // We have to use pseudo elements to add the shadow to prevent
-    // the shadows from casting on sibling cells.
-    '::after': {
-      content: '""',
-      position: 'absolute',
-      top: '100%',
-      right: '0',
-      left: '0',
-      height: $theme.sizing.scale100,
-      pointerEvents: 'none',
-      backgroundImage: `
+      // We have to use pseudo elements to add the border for headers
+      // because browsers don't properly handle borders on sticky cells.
+      // The cells stay fixed in place, but the borders scroll.
+      '::before': {
+        content: '""',
+        position: 'absolute',
+        top: '0',
+        right: '100%',
+        bottom: '0',
+        borderLeftColor: $theme.borders.border300.borderColor,
+        borderLeftStyle: $theme.borders.border300.borderStyle,
+        borderLeftWidth: $theme.borders.border300.borderWidth,
+      },
+
+      // We have to use pseudo elements to add the shadow to prevent
+      // the shadows from casting on sibling cells.
+      '::after': {
+        content: '""',
+        position: 'absolute',
+        top: '100%',
+        right: '0',
+        left: '0',
+        height: $theme.sizing.scale100,
+        pointerEvents: 'none',
+        backgroundImage: `
         linear-gradient(
           to bottom,
           rgba(0, 0, 0, 0.16),
           rgba(0, 0, 0, 0)
         )
       `,
-    },
-  };
-});
+      },
+    };
+  },
+);
+
+type StyledTableHeadCellSortablePropsT = {
+  ...StyledTableHeadCellPropsT,
+  $isFocusVisible: boolean,
+};
 
 export const StyledTableHeadCellSortable = withStyle<
   typeof StyledTableHeadCell,
-  {$isFocusVisible: boolean},
+  StyledTableHeadCellSortablePropsT,
 >(StyledTableHeadCell, ({$theme, $isFocusVisible}) => {
   return {
     cursor: 'pointer',
@@ -156,15 +169,27 @@ export const StyledTableBody = styled<{}>('tbody', ({$theme}) => {
   return {};
 });
 
-export const StyledTableBodyRow = styled<{}>('tr', ({$theme}) => {
-  return {
-    ':hover': {
-      backgroundColor: $theme.colors.tableStripedBackground,
-    },
-  };
-});
+type StyledTableBodyRowPropsT = {
+  $col?: {},
+  $colIndex?: ?number,
+};
+
+export const StyledTableBodyRow = styled<StyledTableBodyRowPropsT>(
+  'tr',
+  ({$theme}) => {
+    return {
+      ':hover': {
+        backgroundColor: $theme.colors.tableStripedBackground,
+      },
+    };
+  },
+);
 
 type StyledTableBodyCellPropsT = {
+  $col?: {},
+  $colIndex?: ?number,
+  $row?: {},
+  $rowIndex?: ?number,
   $isNumeric?: ?boolean,
 };
 

--- a/src/table-semantic/table-builder.js
+++ b/src/table-semantic/table-builder.js
@@ -33,7 +33,10 @@ export default class TableBuilder<T> extends React.Component<
   static defaultProps = {
     data: [],
   };
-  state = {isFocusVisible: false};
+
+  state = {
+    isFocusVisible: false,
+  };
 
   handleFocus = (event: SyntheticEvent<>) => {
     if (isFocusVisible(event)) {
@@ -129,6 +132,8 @@ export default class TableBuilder<T> extends React.Component<
         return (
           <ColTableHeadCell
             key={colIndex}
+            $col={col}
+            $colIndex={colIndex}
             {...tableHeadCellProps}
             {...colTableHeadCellProps}
           >
@@ -183,6 +188,8 @@ export default class TableBuilder<T> extends React.Component<
       return (
         <ColTableHeadCellSortable
           key={colIndex}
+          $col={col}
+          $colIndex={colIndex}
           role="button"
           tabIndex="0"
           aria-label={`${col.header}, ${sortLabel}`}
@@ -214,6 +221,10 @@ export default class TableBuilder<T> extends React.Component<
       return (
         <ColTableBodyCell
           key={colIndex}
+          $col={col}
+          $colIndex={colIndex}
+          $row={row}
+          $rowIndex={rowIndex}
           $isNumeric={col.numeric}
           {...tableBodyCellProps}
           {...colTableBodyCellProps}
@@ -240,7 +251,12 @@ export default class TableBuilder<T> extends React.Component<
           </TableHead>
           <TableBody {...tableBodyProps}>
             {data.map((row, rowIndex) => (
-              <TableBodyRow key={rowIndex} {...tableBodyRowProps}>
+              <TableBodyRow
+                key={rowIndex}
+                $row={row}
+                $rowIndex={rowIndex}
+                {...tableBodyRowProps}
+              >
                 {columns.map((col, colIndex) =>
                   renderCell(col, colIndex, row, rowIndex),
                 )}


### PR DESCRIPTION
Fixes #3208 

#### Description

Exposes row and column information to styled components as `$col`, `$colIndex`, `$row`, `$rowIndex` properties. This will allow overrides access to this information in order to make style changes like highlighting a row for example.

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
