### PR TITLE
fix(input): adds missing props (pattern and aria-errormessage) to the TS defs

### DIFF
--- a/src/input/index.d.ts
+++ b/src/input/index.d.ts
@@ -35,6 +35,7 @@ export interface BaseInputOverrides<T> {
 }
 
 export interface BaseInputProps<T> {
+  'aria-errormessage'?: string;
   'aria-label'?: string;
   'aria-labelledby'?: string;
   'aria-describedby'?: string;
@@ -48,6 +49,7 @@ export interface BaseInputProps<T> {
   id?: string;
   'data-baseweb'?: string;
   inputMode?: string;
+  pattern?: string,
   inputRef?: React.Ref<T>;
   name?: string;
   onBlur?: React.FocusEventHandler<T>;


### PR DESCRIPTION
#### Description

Adds `pattern`  to `BaseInput`'s TS types. Also `aria-errormessage` was missing (it's in the flow types) so I added that too.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
