### PR TITLE
fix(docs): recommend better style util packages

### DIFF
--- a/documentation-site/pages/guides/theming.mdx
+++ b/documentation-site/pages/guides/theming.mdx
@@ -435,7 +435,7 @@ The theme object acts as a centralized API for customizing global styling proper
 
 Let's look at how you can use the theme object while extending our components and when building out your interfaces.
 
-> In some cases, the theme object may contain short-hand CSS properties, like the [border](#borders) values. If you had spread these values in the methods below, Styletron would raise warnings. In these cases, you can use a utility function that expands short-hand CSS properties to long-hand CSS properties. For this use-case, you may find the library called [css-property-parser](https://github.com/mahirshah/css-property-parser#expandshorthandpropertyproperty-string-value-string-recursivelyresolvefalse-includeinitialvaluesfalse-object) useful.
+> In some cases, the theme object may contain short-hand CSS properties, like the [border](#borders) values. If you had spread these values in the methods below, Styletron would raise warnings. In these cases, you can use a utility function that expands short-hand CSS properties to long-hand CSS properties. For this use-case, you may find [inline-style-expand-shorthand](https://github.com/robinweser/inline-style-expand-shorthand) or [lostyle](https://github.com/rtsao/lostyle) useful.
 
 ### Extension
 


### PR DESCRIPTION
inline-style-expand-shorthand only works on hyphenated css property names, not camelCased css-is-js properties