### PR TITLE
docs: add tabs example with custom keys

### DIFF
--- a/documentation-site/examples/tabs/custom-keys.js
+++ b/documentation-site/examples/tabs/custom-keys.js
@@ -1,0 +1,29 @@
+// @flow
+import * as React from 'react';
+import {Tabs, Tab} from 'baseui/tabs';
+
+export default () => {
+  const [activeKey, setActiveKey] = React.useState('black');
+  return (
+    <Tabs
+      activeKey={activeKey}
+      onChange={({activeKey}) => setActiveKey(activeKey)}
+    >
+      <Tab key="black" title="Black">
+        <span role="img" aria-label="black">
+          ⚫️ ️
+        </span>
+      </Tab>
+      <Tab key="white" title="White">
+        <span role="img" aria-label="white">
+          ⚪️
+        </span>
+      </Tab>
+      <Tab key="blue" title="Blue">
+        <span role="img" aria-label="blue">
+          🔵
+        </span>
+      </Tab>
+    </Tabs>
+  );
+};

--- a/documentation-site/examples/tabs/custom-keys.tsx
+++ b/documentation-site/examples/tabs/custom-keys.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import {Tabs, Tab} from 'baseui/tabs';
+
+export default () => {
+  const [activeKey, setActiveKey] = React.useState('black');
+  return (
+    <Tabs
+      activeKey={activeKey}
+      onChange={({activeKey}) => setActiveKey(String(activeKey))}
+    >
+      <Tab key="black" title="Black">
+        <span role="img" aria-label="black">
+          ⚫️ ️
+        </span>
+      </Tab>
+      <Tab key="white" title="White">
+        <span role="img" aria-label="white">
+          ⚪️
+        </span>
+      </Tab>
+      <Tab key="blue" title="Blue">
+        <span role="img" aria-label="blue">
+          🔵
+        </span>
+      </Tab>
+    </Tabs>
+  );
+};

--- a/documentation-site/pages/components/tabs.mdx
+++ b/documentation-site/pages/components/tabs.mdx
@@ -11,6 +11,7 @@ import Exports from '../../components/exports';
 
 import TabsControlled from 'examples/tabs/controlled.js';
 import TabsUncontrolled from 'examples/tabs/uncontrolled.js';
+import TabsCustomKeys from 'examples/tabs/custom-keys.js';
 import TabsVertical from 'examples/tabs/vertical.js';
 import TabsRenderAll from 'examples/tabs/renderall.js';
 import TabsOverrides from 'examples/tabs/overrides.js';
@@ -46,6 +47,12 @@ The Tabs component is used for navigating frequently accesssed, but distinct cat
 <Example title="Uncontrolled Tabs Usage" path="tabs/uncontrolled.js">
   <TabsUncontrolled />
 </Example>
+
+<Example title="With Custom Keys" path="tabs/custom-keys.js">
+  <TabsCustomKeys />
+</Example>
+
+We use tab order to provide default keys for each tab. You can however, pass in your own key to a tab and set `activeKey` accordingly.
 
 <Example title="Tabs SEO Friendly" path="tabs/renderall.js">
   <TabsRenderAll />


### PR DESCRIPTION
Adds a new example to tabs documentation.