### PR TITLE
fix(datepicker): Changes in the year Selection

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -220,7 +220,16 @@ export default class Datepicker extends React.Component<
       }
     } else {
       const dateString = this.normalizeDashes(inputValue);
-      let date = new Date(dateString);
+      let yearString = dateString.split('/')[0].trim();
+      let date;
+
+      if (yearString != '' && yearString.length < 4) {
+        yearString = yearString + '0'.repeat(4 - yearString.length);
+        date = new Date(yearString, 0, 1);
+      } else {
+        date = new Date(dateString);
+      }
+
       const formatString = this.props.formatString;
       if (formatString) {
         // Prevent early parsing of value.


### PR DESCRIPTION
Fixes #3230 

#### Description
The current date is calculated by passing the dateString to the Date constructor, in doing this the default date is always shown as 2001 when the first input is entered and with this the user entered date is discarded.
In the commit, i am creating a date object by considering the first value as the year so the user entered value is shown in the datepicker. 

#### Scope

- [X] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
