### PR TITLE
fix(data-table): reverts expand border in non customizable data-table

### DIFF
--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -115,14 +115,11 @@ function CellPlacement({columnIndex, rowIndex, data, style}) {
       className={css({
         ...theme.borders.border200,
         backgroundColor,
-        borderTopStyle: 'none',
-        borderBottomStyle: 'none',
-        borderLeftStyle: 'none',
+        borderTop: 'none',
+        borderBottom: 'none',
+        borderLeft: 'none',
         // do not render a border on cells in the right-most column
-        borderRightStyle:
-          columnIndex === data.columns.length - 1
-            ? 'none'
-            : theme.borders.border200.borderStyle,
+        borderRight: columnIndex === data.columns.length - 1 ? 'none' : null,
         boxSizing: 'border-box',
       })}
       style={style}
@@ -471,8 +468,8 @@ function Headers(props: {||}) {
                 className={css({
                   ...theme.borders.border200,
                   backgroundColor: theme.colors.backgroundPrimary,
-                  borderTopStyle: 'none',
-                  borderLeftStyle: 'none',
+                  borderTop: 'none',
+                  borderLeft: 'none',
                   borderRight:
                     columnIndex === ctx.columns.length - 1 ? 'none' : null,
                   boxSizing: 'border-box',
@@ -971,10 +968,7 @@ export function Unstable_DataTable(props: DataTablePropsT) {
               onScroll={handleScroll}
               style={{
                 ...theme.borders.border200,
-                borderLeftColor: theme.colors.borderOpaque,
-                borderRightColor: theme.colors.borderOpaque,
-                borderTopColor: theme.colors.borderOpaque,
-                borderBottomColor: theme.colors.borderOpaque,
+                borderColor: theme.colors.borderOpaque,
               }}
               direction={theme.direction === 'rtl' ? 'rtl' : 'ltr'}
             >

--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -16,7 +16,7 @@ import {
   SIZE as BUTTON_SIZES,
   KIND as BUTTON_KINDS,
 } from '../button/index.js';
-import {useStyletron, expandBorderStyles} from '../styles/index.js';
+import {useStyletron} from '../styles/index.js';
 import {Tooltip, PLACEMENT} from '../tooltip/index.js';
 
 import {COLUMNS, SORT_DIRECTIONS} from './constants.js';
@@ -113,7 +113,7 @@ function CellPlacement({columnIndex, rowIndex, data, style}) {
   return (
     <div
       className={css({
-        ...expandBorderStyles(theme.borders.border200),
+        ...theme.borders.border200,
         backgroundColor,
         borderTopStyle: 'none',
         borderBottomStyle: 'none',
@@ -469,7 +469,7 @@ function Headers(props: {||}) {
             >
               <div
                 className={css({
-                  ...expandBorderStyles(theme.borders.border200),
+                  ...theme.borders.border200,
                   backgroundColor: theme.colors.backgroundPrimary,
                   borderTopStyle: 'none',
                   borderLeftStyle: 'none',
@@ -970,7 +970,7 @@ export function Unstable_DataTable(props: DataTablePropsT) {
               itemData={itemData}
               onScroll={handleScroll}
               style={{
-                ...expandBorderStyles(theme.borders.border200),
+                ...theme.borders.border200,
                 borderLeftColor: theme.colors.borderOpaque,
                 borderRightColor: theme.colors.borderOpaque,
                 borderTopColor: theme.colors.borderOpaque,


### PR DESCRIPTION
Fixes: https://github.com/uber/baseweb/issues/3247

#### Description

The `expandBorderStyles` is useful on components that accept overrides, but it's not necessary in `data-table` components.

#### Scope

- [x] Patch: Bug Fix
