### PR TITLE
feat(layout grid): use Context in grid so React.Fragments can be used

### DIFF
--- a/src/layout-grid/__tests__/layout-grid.scenario.js
+++ b/src/layout-grid/__tests__/layout-grid.scenario.js
@@ -14,10 +14,12 @@ export default function Scenario() {
   return (
     <>
       <Grid>
-        <Cell span={12}>
-          <Inner>1</Inner>
-        </Cell>
-        {null}
+        <>
+          <Cell span={12}>
+            <Inner>1</Inner>
+          </Cell>
+          {null}
+        </>
       </Grid>
       <br />
       <Grid>

--- a/src/layout-grid/cell.js
+++ b/src/layout-grid/cell.js
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 import React from 'react';
 import {getOverrides} from '../helpers/overrides.js';
 import {StyledCell as DefaultStyledCell} from './styled-components.js';
-
+import {GridContext} from './grid.js';
 import type {CellPropsT} from './types.js';
 
 export default function Cell({
@@ -28,13 +28,14 @@ export default function Cell({
     overrides.Cell,
     DefaultStyledCell,
   );
+  const gridContext = React.useContext(GridContext);
   return (
     <StyledCell
       $align={align}
-      $gridColumns={gridColumns}
-      $gridGaps={gridGaps}
-      $gridGutters={gridGutters}
-      $gridUnit={gridUnit}
+      $gridColumns={gridColumns || gridContext.gridColumns}
+      $gridGaps={gridGaps || gridContext.gridGaps}
+      $gridGutters={gridGutters || gridContext.gridGutters}
+      $gridUnit={gridUnit || gridContext.gridUnit}
       $order={order}
       $skip={skip}
       $span={span}

--- a/src/layout-grid/cell.js
+++ b/src/layout-grid/cell.js
@@ -32,6 +32,7 @@ export default function Cell({
   return (
     <StyledCell
       $align={align}
+      // TODO(v10): Remove the four grid props, get them solely from GridContext
       $gridColumns={gridColumns || gridContext.gridColumns}
       $gridGaps={gridGaps || gridContext.gridGaps}
       $gridGutters={gridGutters || gridContext.gridGutters}

--- a/src/layout-grid/grid.js
+++ b/src/layout-grid/grid.js
@@ -5,13 +5,15 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-
-import React from 'react';
+import * as React from 'react';
 import {getOverrides} from '../helpers/overrides.js';
 import {StyledGrid as DefaultStyledGrid} from './styled-components.js';
-import Cell from './cell.js';
 
-import type {GridPropsT} from './types.js';
+import type {GridPropsT, SharedGridPropsT} from './types.js';
+
+export const GridContext: React.Context<SharedGridPropsT> = React.createContext(
+  {},
+);
 
 export default function Grid({
   align,
@@ -39,20 +41,11 @@ export default function Grid({
       $gridUnit={gridUnit}
       {...overrideProps}
     >
-      {React.Children.map(children, child => {
-        if (child) {
-          return (
-            <Cell
-              gridColumns={gridColumns}
-              gridGaps={gridGaps}
-              gridGutters={gridGutters}
-              gridUnit={gridUnit}
-              {...child.props}
-            />
-          );
-        }
-        return null;
-      })}
+      <GridContext.Provider
+        value={{gridColumns, gridGaps, gridGutters, gridUnit}}
+      >
+        {children}
+      </GridContext.Provider>
     </StyledGrid>
   );
 }

--- a/src/layout-grid/index.d.ts
+++ b/src/layout-grid/index.d.ts
@@ -19,7 +19,7 @@ export type Responsive<T> = T | T[];
 export interface GridProps {
   align?: Responsive<ALIGNMENT>;
   behavior?: BEHAVIOR;
-  children: React.ReactElement<CellProps> | React.ReactElement<CellProps>[];
+  children: React.ReactNode;
   gridColumns?: Responsive<number>;
   gridGaps?: Responsive<number>;
   gridGutters?: Responsive<number>;

--- a/src/layout-grid/types.js
+++ b/src/layout-grid/types.js
@@ -8,7 +8,6 @@ LICENSE file in the root directory of this source tree.
 
 import * as React from 'react';
 import {ALIGNMENT, BEHAVIOR} from './constants.js';
-import Cell from './cell.js';
 
 import type {OverrideT} from '../helpers/overrides.js';
 
@@ -39,25 +38,28 @@ export type CSSLengthUnitT =
   | 'vmax'
   | '%';
 
-export type GridPropsT = {
-  /** Control vertical alignment of cells at each breakpoint. */
-  align?: ResponsiveT<AlignmentT>,
-  /** Grid container behavior beyond max width. Fluid will continue to expand. Fixed will limit grid container to max width and center the container horizontally within parent element. */
-  behavior?: BehaviorT,
-  /** Children should be Cells. */
-  children: React.ChildrenArray<React.Element<typeof Cell> | null>,
+export type SharedGridPropsT = {
   /** Number of columns at each breakpoint. */
   gridColumns?: ResponsiveT<number>,
   /** Gap between rows at each breakpoint. */
   gridGaps?: ResponsiveT<number>,
   /** Gap between columns at each breakpoint. */
   gridGutters?: ResponsiveT<number>,
+  /** Modify the CSS length unit used to measure columns and rows. Defaults to theme value. */
+  gridUnit?: CSSLengthUnitT,
+};
+export type GridPropsT = {
+  ...SharedGridPropsT,
+  /** Control vertical alignment of cells at each breakpoint. */
+  align?: ResponsiveT<AlignmentT>,
+  /** Grid container behavior beyond max width. Fluid will continue to expand. Fixed will limit grid container to max width and center the container horizontally within parent element. */
+  behavior?: BehaviorT,
+  /** Children should be Cells. */
+  children: React.Node,
   /** Gap on either side of grid container at each breakpoint. */
   gridMargins?: ResponsiveT<number>,
   /** Maximum width of the grid container. Does not include Margins. Only applies when `behavior` is `fluid`. */
   gridMaxWidth?: number,
-  /** Modify the CSS length unit used to measure columns and rows. Defaults to theme value. */
-  gridUnit?: CSSLengthUnitT,
   /** Overrides for your grid. */
   overrides?: {
     Grid?: OverrideT,
@@ -80,18 +82,11 @@ export type StyledGridPropsT = {
 };
 
 export type CellPropsT = {
+  ...SharedGridPropsT,
   /** Control vertical alignment of individual cell at each breakpoint. Limited proxy for `align-self` CSS property. */
   align?: ResponsiveT<AlignmentT>,
   /** Content to be placed in Cell. */
   children?: React.Node,
-  /** Number of columns at each breakpoint. */
-  gridColumns?: ResponsiveT<number>,
-  /** Gap between rows at each breakpoint. */
-  gridGaps?: ResponsiveT<number>,
-  /** Gap between columns at each breakpoint. */
-  gridGutters?: ResponsiveT<number>,
-  /** Modify the CSS length unit used to measure columns and rows. Defaults to theme value. */
-  gridUnit?: CSSLengthUnitT,
   /** Control placement order of cell in flex row at each breakpoint. Proxy for `order` CSS property. */
   order?: ResponsiveT<number>,
   /** Control number of columns to offset cell at each breakpoint. */

--- a/src/layout-grid/types.js
+++ b/src/layout-grid/types.js
@@ -82,6 +82,7 @@ export type StyledGridPropsT = {
 };
 
 export type CellPropsT = {
+  // TODO(v10): Remove shared grid props from cell
   ...SharedGridPropsT,
   /** Control vertical alignment of individual cell at each breakpoint. Limited proxy for `align-self` CSS property. */
   align?: ResponsiveT<AlignmentT>,


### PR DESCRIPTION
Fixes #3263 

#### Description

Change grid to use context so that non-cell elements can be used as children to the grid. This will allow you to split up cells into subcomponents that have a react fragment wrapped around them, or be wrapped in HoCs/other wrapped components that still render Cells.

This change should be entirely backwards compatible with any existing code that uses Baseweb.

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
