### PR TITLE
fix(layout-grid): fix ALIGNMENT enum

### DIFF
--- a/src/layout-grid/index.d.ts
+++ b/src/layout-grid/index.d.ts
@@ -4,9 +4,9 @@ import {CSSLengthUnitT} from '../theme';
 import {Override} from '../overrides';
 
 export enum ALIGNMENT {
-  start = 'start',
+  start = 'flex-start',
   center = 'center',
-  end = 'end',
+  end = 'flex-end',
 }
 
 export enum BEHAVIOR {


### PR DESCRIPTION
#### Description

Fixes the ALIGNMENT enum to work with type checking + usage with the `align` prop when using typescript

[constants.js](https://github.com/uber/baseweb/blob/45e52ab24c18a8df7f6025cdb3f716030f8e5a1a/src/layout-grid/constants.js#L14-L18)

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
