### PR TITLE
fix(menu): fix type checking MENUPROPS in menu

### DIFF
--- a/src/menu/index.d.ts
+++ b/src/menu/index.d.ts
@@ -36,6 +36,7 @@ export interface MenuProps extends BaseMenuPropsT {
     EmptyState?: Override<any>;
     List?: Override<any>;
     Option?: Override<any>;
+    ListItem?: Override<any>;
   };
 }
 

--- a/src/menu/types.js
+++ b/src/menu/types.js
@@ -140,6 +140,7 @@ export type MenuPropsT = {
     List?: OverrideT,
     Option?: OverrideT,
     OptgroupHeader?: OverrideT,
+    ListItem?: OverrideT,
   },
   /** Renders all menu content for SEO purposes regardless of menu  state */
   renderAll?: boolean,


### PR DESCRIPTION
#### Description
Fix type checking ListItem for type `MenuProps` for typescript and flow
#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
