### PR TITLE
fix(datepicker): inputting a date into input field results in right date

### DIFF
--- a/src/datepicker/__tests__/datepicker.test.js
+++ b/src/datepicker/__tests__/datepicker.test.js
@@ -229,7 +229,7 @@ describe('Datepicker', () => {
     });
   });
 
-  test('fires the onchange only when date length is same as formatString with single date', () => {
+  test('does not fire the onchange when date length is less than passed formatString with single date', () => {
     const onChange = jest.fn();
     const format = 'dd.MM.yyyy';
     const date = new Date('2019 01 01');
@@ -258,6 +258,21 @@ describe('Datepicker', () => {
       date: parse(newDate, format, new Date()),
     });
     expect(onChange.mock.calls).toHaveLength(1);
+  });
+
+  // Issue #3230
+  test('does not fire the onchange when date length is less than default formatDate with single date when no formatString is passed', () => {
+    const onChange = jest.fn();
+    const component = mount(<Datepicker onChange={onChange} value={null} />);
+
+    // $FlowFixMe
+    component.instance().handleInputChange({
+      currentTarget: {
+        value: '1',
+      },
+    });
+
+    expect(onChange.mock.calls).toHaveLength(0);
   });
 
   test('returns an array of date objects on input change', () => {

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -35,6 +35,7 @@ export default class Datepicker extends React.Component<
   static defaultProps = {
     'aria-describedby': 'datepicker--screenreader--message--input',
     value: null,
+    formatString: 'yyyy/MM/dd',
   };
 
   calendar: ?HTMLElement;
@@ -112,7 +113,7 @@ export default class Datepicker extends React.Component<
   formatDisplayValue(date: ?Date | Array<Date>) {
     let formatDisplayValue = this.props.formatDisplayValue || this.formatDate;
     formatDisplayValue = formatDisplayValue.bind(this);
-    return formatDisplayValue(date, this.props.formatString || 'yyyy/MM/dd');
+    return formatDisplayValue(date, this.props.formatString);
   }
 
   open = () => {
@@ -221,7 +222,7 @@ export default class Datepicker extends React.Component<
     } else {
       const dateString = this.normalizeDashes(inputValue);
       let date = new Date(dateString);
-      const formatString = this.props.formatString || 'yyyy/MM/dd';
+      const formatString = this.props.formatString;
 
       // Prevent early parsing of value.
       // Eg 25.12.2 will be transformed to 25.12.0002 formatted from date to string

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -221,18 +221,17 @@ export default class Datepicker extends React.Component<
     } else {
       const dateString = this.normalizeDashes(inputValue);
       let date = new Date(dateString);
-      const formatString = this.props.formatString;
-      if (formatString) {
-        // Prevent early parsing of value.
-        // Eg 25.12.2 will be transformed to 25.12.0002 formatted from date to string
-        if (
-          dateString.replace(/(\s)*/g, '').length <
-          formatString.replace(/(\s)*/g, '').length
-        ) {
-          date = null;
-        } else {
-          date = parse(dateString, formatString, new Date());
-        }
+      const formatString = this.props.formatString || 'yyyy/MM/dd';
+
+      // Prevent early parsing of value.
+      // Eg 25.12.2 will be transformed to 25.12.0002 formatted from date to string
+      if (
+        dateString.replace(/(\s)*/g, '').length <
+        formatString.replace(/(\s)*/g, '').length
+      ) {
+        date = null;
+      } else {
+        date = parse(dateString, formatString, new Date());
       }
 
       isValid(date) &&

--- a/src/datepicker/types.js
+++ b/src/datepicker/types.js
@@ -191,7 +191,7 @@ export type DatepickerPropsT = CalendarPropsT & {
     date: ?Date | Array<Date>,
     formatString: string,
   ) => string,
-  formatString?: string,
+  formatString: string,
   /** Where to mount the popover */
   mountNode?: HTMLElement,
   /** Called when calendar is closed */


### PR DESCRIPTION
Fixes #3230

#### Description

The scenario in the issue is already taken care of, the author just forgot you'll always have a `formatString` if not the passed then the default

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change

<sup>Btw, I love baseweb! Especially the overrides pattern, it's stellar, like it embraces the fact that you'll always have to override something at some point so why not provide a way to do that in the first place. And not to mention it's not just trivial style overrides but [actual overrides in behavior and logic too](https://baseweb.design/guides/understanding-overrides/#override-the-entire-subcomponent) So thank you :)</sup>