### PR TITLE
fix(toast): respect the css `transition-duration` for unmount

### DIFF
--- a/src/toast/__tests__/toast.test.js
+++ b/src/toast/__tests__/toast.test.js
@@ -242,11 +242,13 @@ describe('Toast', () => {
             },
           },
         }}
-      />,
+      >
+        Toast Content
+      </Toast>,
     );
 
     let getComputedStyleMock = jest
-      .spyOn(window, 'getComputedStyle')
+      .spyOn(global.window, 'getComputedStyle')
       .mockImplementationOnce(bodyNode => {
         expect(
           JSON.parse(bodyNode.getAttribute('test-style')).transitionDuration,

--- a/src/toast/__tests__/toast.test.js
+++ b/src/toast/__tests__/toast.test.js
@@ -5,6 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
+/* eslint-env browser */
 
 import * as React from 'react';
 import {render, getByTestId} from '@testing-library/react';
@@ -248,7 +249,7 @@ describe('Toast', () => {
     );
 
     let getComputedStyleMock = jest
-      .spyOn(global.window, 'getComputedStyle')
+      .spyOn(window, 'getComputedStyle')
       .mockImplementationOnce(bodyNode => {
         expect(
           JSON.parse(bodyNode.getAttribute('test-style')).transitionDuration,

--- a/src/toast/toast.js
+++ b/src/toast/toast.js
@@ -48,6 +48,7 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
   animateOutCompleteTimer: ?TimeoutID;
   closeRef: ?{current: ?mixed};
   previouslyFocusedElement: ?HTMLElement;
+  bodyRef: ?{current: ?mixed};
 
   state = {
     isVisible: false,
@@ -58,6 +59,7 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
   constructor(props: ToastPropsT) {
     super(props);
     this.closeRef = React.createRef();
+    this.bodyRef = React.createRef();
     this.previouslyFocusedElement = null;
   }
 
@@ -137,11 +139,23 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
 
   animateOut = (callback: () => mixed = () => {}) => {
     this.setState({isVisible: false});
+
+    let animationDuration =
+      (__BROWSER__ &&
+        this.bodyRef &&
+        this.bodyRef.current &&
+        Number(
+          getComputedStyle(this.bodyRef.current)
+            .getPropertyValue('transition-duration')
+            .replace('s', ''),
+        ) * 1000) ||
+      200; // default backup just in case
+
     // Remove the toast from the DOM after animation finishes
     this.animateOutCompleteTimer = setTimeout(() => {
       this.setState({isRendered: false});
       callback();
-    }, 600);
+    }, animationDuration);
   };
 
   dismiss = () => {
@@ -226,6 +240,7 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
             {...sharedProps}
             {...bodyProps}
             // the properties below have to go after overrides
+            ref={this.bodyRef}
             onBlur={this.onBlur}
             onFocus={this.onFocus}
             onMouseEnter={this.onMouseEnter}

--- a/src/toast/toast.js
+++ b/src/toast/toast.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-/* global document */
+/* global document, window */
 import * as React from 'react';
 import {getOverrides, mergeOverrides} from '../helpers/overrides.js';
 import DeleteIcon from '../icon/delete.js';
@@ -141,17 +141,15 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
     this.setState({isVisible: false});
 
     let animationDuration =
-      (__BROWSER__ &&
-        this.bodyRef &&
-        this.bodyRef.current &&
-        Number(
-          // $FlowFixMe: Body is typed as `mixed` but actually is Element so this isn't a problem
-          window
-            .getComputedStyle(this.bodyRef.current)
-            .getPropertyValue('transition-duration')
-            .replace('s', ''),
-        ) * 1000) ||
-      200; // default backup just in case
+      __BROWSER__ && this.bodyRef && this.bodyRef.current
+        ? Number(
+            // $FlowFixMe: Body is typed as `mixed` but actually is Element so this isn't a problem
+            window
+              .getComputedStyle(this.bodyRef.current)
+              .getPropertyValue('transition-duration')
+              .replace('s', ''),
+          ) * 1000
+        : 200; // default backup just in case
 
     // Remove the toast from the DOM after animation finishes
     this.animateOutCompleteTimer = setTimeout(() => {

--- a/src/toast/toast.js
+++ b/src/toast/toast.js
@@ -145,7 +145,9 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
         this.bodyRef &&
         this.bodyRef.current &&
         Number(
-          getComputedStyle(this.bodyRef.current)
+          // $FlowFixMe: Body is typed as `mixed` but actually is Element so this isn't a problem
+          window
+            .getComputedStyle(this.bodyRef.current)
             .getPropertyValue('transition-duration')
             .replace('s', ''),
         ) * 1000) ||


### PR DESCRIPTION
Fixes #3194

#### Description

Problem was the `setTimeout` was set for arbitrary 600ms (maybe it was the default for previous releases idk) and now the default transition duration is 200ms hence if you mouseover in those 400ms gap it doesn't unmount (as the gif in the issue shows).

Now using 200 instead of 600 is also not good enough because we could have overrides via prop or even directly (like outside of styletron and baseweb which we shouldn't bother about but okay) so we're using `getComputedStyle` to get the transition duration.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
