### PR TITLE
fix(button): make .d.ts reflect that it's uses forwardRef

### DIFF
--- a/documentation-site/examples/pin-code/completion.tsx
+++ b/documentation-site/examples/pin-code/completion.tsx
@@ -6,7 +6,7 @@ import {PinCode} from 'baseui/pin-code';
 export default function() {
   const [css] = useStyletron();
   const [values, setValues] = React.useState(['', '', '', '']);
-  const buttonRef = React.useRef<Button>(null);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
   return (
     <div className={css({display: 'flex'})}>
       <PinCode

--- a/src/button/__tests__/button.test.js
+++ b/src/button/__tests__/button.test.js
@@ -66,7 +66,7 @@ describe('Button Component', () => {
     });
   });
 
-  test('internalOnClick prevents external onClick while loading', () => {
+  test("onClick doesn't fire while loading", () => {
     const props = {
       onClick: jest.fn(),
       isLoading: true,

--- a/src/button/index.d.ts
+++ b/src/button/index.d.ts
@@ -60,7 +60,7 @@ export const StyledLoadingSpinner: StyletronComponent<any>;
 export const StyledLoadingSpinnerContainer: StyletronComponent<any>;
 
 export const Button: React.ForwardRefExoticComponent<
-  React.PropsWithoutRef<ButtonProps> & React.RefObject<HTMLButtonElement>
+  React.PropsWithoutRef<ButtonProps> & React.RefAttributes<HTMLButtonElement>
 >;
 
 export const KIND: KIND;

--- a/src/button/index.d.ts
+++ b/src/button/index.d.ts
@@ -59,10 +59,9 @@ export const StyledEndEnhancer: StyletronComponent<any>;
 export const StyledLoadingSpinner: StyletronComponent<any>;
 export const StyledLoadingSpinnerContainer: StyletronComponent<any>;
 
-export class Button extends React.Component<ButtonProps> {
-  internalOnClick(...args: any): void;
-  focus(): void;
-}
+export const Button: React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<ButtonProps> & React.RefObject<HTMLButtonElement>
+>;
 
 export const KIND: KIND;
 export const SHAPE: SHAPE;


### PR DESCRIPTION
Fixed #2652

#### Description

`Button` is already forwarding the ref to html button element so there won't be any problems in runtime in code on the issue page, only the types weren't reflecting that. [Here's the test](https://codesandbox.io/s/summer-sun-ejnct?file=/example.tsx) for this PR. (there's no type testing strategy in the repo hence testing this way)

Also there are a lot of components that forward the ref but the types don't reflect that so can send a PR that fixes all those types?

#### Scope
Patch: Bug Fix
