### PR TITLE
fix(popover): don't clone anchor with ref if it's not using forwardRef

### DIFF
--- a/src/layer/tether.js
+++ b/src/layer/tether.js
@@ -48,9 +48,9 @@ class Tether extends React.Component<TetherPropsT, TetherStateT> {
           if (__DEV__) {
             // eslint-disable-next-line no-console
             console.warn(
-              `[baseui][TetherBehavior] ref has not been passed to the Popper's anchor element.
-              See how to pass the ref to an anchor element in the Popover example
-              http://baseui.design/components/popover#anchor-ref-handling-example`,
+              `[baseui][TetherBehavior] ref has not been passed to the Popper's anchor element.\n` +
+                `See how to pass the ref to an anchor element in the Popover example\n` +
+                `http://baseui.design/components/popover#anchor-ref-handling-example`,
             );
           }
         } else {

--- a/src/layer/tether.js
+++ b/src/layer/tether.js
@@ -48,9 +48,9 @@ class Tether extends React.Component<TetherPropsT, TetherStateT> {
           if (__DEV__) {
             // eslint-disable-next-line no-console
             console.warn(
-              `[baseui][TetherBehavior] ref has not been passed to the Popper's anchor element.\n` +
-                `See how to pass the ref to an anchor element in the Popover example\n` +
-                `http://baseui.design/components/popover#anchor-ref-handling-example`,
+              '[baseui][TetherBehavior] ref has not been passed to the Popper's anchor element.\n' +
+                'See how to pass the ref to an anchor element in the Popover example\n' +
+                'http://baseui.design/components/popover#anchor-ref-handling-example',
             );
           }
         } else {

--- a/src/popover/__tests__/popover-unmocked.test.js
+++ b/src/popover/__tests__/popover-unmocked.test.js
@@ -13,7 +13,7 @@ import {Popover} from '../index.js';
 
 describe('Popover', () => {
   // Issue #3265
-  test.only('does not throw when anchor component is not refable', () => {
+  test('does not throw when anchor component is not refable', () => {
     const NonForwardRefFunctionalComponent = () => <>hello</>;
     const originalConsoleError = console.error;
     const originalConsoleWarn = console.warn;

--- a/src/popover/__tests__/popover-unmocked.test.js
+++ b/src/popover/__tests__/popover-unmocked.test.js
@@ -1,0 +1,41 @@
+/*
+Copyright (c) 2018-2020 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+/* eslint-env browser */
+
+import * as React from 'react';
+import ReactDOM from 'react-dom';
+import {mount} from 'enzyme';
+import {Popover} from '../index.js';
+
+describe('Popover', () => {
+  // Issue #3265
+  test.only('does not throw when anchor component is not refable', () => {
+    const NonForwardRefFunctionalComponent = () => <>hello</>;
+    const originalConsoleError = console.error;
+    const originalConsoleWarn = console.warn;
+
+    console.error = jest.fn(); // not using spy because it also calls the original console.error
+    console.warn = jest.fn();
+
+    mount(
+      <Popover isOpen content="foo">
+        <NonForwardRefFunctionalComponent />
+      </Popover>,
+    );
+
+    expect(console.error).toBeCalledTimes(0); // React doesn't throw, it logs
+    expect(console.warn).toBeCalledWith(
+      `[baseui][TetherBehavior] ref has not been passed to the Popper's anchor element.\n` +
+        `See how to pass the ref to an anchor element in the Popover example\n` +
+        `http://baseui.design/components/popover#anchor-ref-handling-example`,
+    );
+
+    console.error = originalConsoleError;
+    console.warn = originalConsoleWarn;
+  });
+});

--- a/src/popover/__tests__/popover-unmocked.test.js
+++ b/src/popover/__tests__/popover-unmocked.test.js
@@ -8,7 +8,6 @@ LICENSE file in the root directory of this source tree.
 /* eslint-env browser */
 
 import * as React from 'react';
-import ReactDOM from 'react-dom';
 import {mount} from 'enzyme';
 import {Popover} from '../index.js';
 
@@ -19,7 +18,9 @@ describe('Popover', () => {
     const originalConsoleError = console.error;
     const originalConsoleWarn = console.warn;
 
+    // $FlowFixMe (it's okay for this test)
     console.error = jest.fn(); // not using spy because it also calls the original console.error
+    // $FlowFixMe
     console.warn = jest.fn();
 
     mount(
@@ -35,7 +36,10 @@ describe('Popover', () => {
         `http://baseui.design/components/popover#anchor-ref-handling-example`,
     );
 
+    // $FlowFixMe
     console.error = originalConsoleError;
+
+    // $FlowFixMe
     console.warn = originalConsoleWarn;
   });
 });

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -361,10 +361,20 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
       return null;
     }
 
-    const isValidElement = React.isValidElement(anchor);
-    const anchorProps = this.getAnchorProps();
+    let anchorProps = this.getAnchorProps();
 
-    if (typeof anchor === 'object' && isValidElement) {
+    if (typeof anchor === 'object' && React.isValidElement(anchor)) {
+      if (typeof anchor.type === 'function') {
+        /* if is non-forwardRef functional component
+         * (if it's wrapped by forwardRef then the type is no longer a function)
+         * then remove ref because rendering non-forwardRef functional component throws
+         * an error and which makes tether unable to show the ref not set warning
+         * see: issue #3265
+         */
+
+        delete anchorProps.ref;
+      }
+
       return React.cloneElement(anchor, anchorProps);
     }
     return <span {...anchorProps}>{anchor}</span>;


### PR DESCRIPTION
Closes #3265

#### Description
We're already logging a warning if the anchor ref is not being set, but if it's a functional component without `forwardRef` React logs an error that you can't set ref and bails out thus our warning doesn't log. So the fix doesn't set the ref while cloning hence out warning would get logged.


#### Scope
Minor: New Feature
(going for a minor because it's also kinda a feature)
