### PR TITLE
feat(button): prevent form submit when button is loading

### DIFF
--- a/src/button/__tests__/button-in-form.test.js
+++ b/src/button/__tests__/button-in-form.test.js
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2018-2020 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+/* eslint-disable */
+import React from 'react';
+import {render, fireEvent} from '@testing-library/react';
+
+import Button from '../button.js';
+
+test('Clicking a button should work', () => {
+  const onClick = jest.fn();
+  const utils = render(
+    <Button data-testid="button" onClick={onClick}>
+      Submit
+    </Button>,
+  );
+  const button = utils.getByTestId('button');
+  fireEvent.click(button);
+  expect(onClick).toHaveBeenCalled();
+});
+
+test('Form should submit normally', () => {
+  const onSubmit = jest.fn();
+  const utils = render(
+    <form onSubmit={onSubmit}>
+      <Button data-testid="button">Submit</Button>
+    </form>,
+  );
+  const button = utils.getByTestId('button');
+  fireEvent.click(button);
+  expect(onSubmit).toHaveBeenCalled();
+});
+
+test('Form should not submit when button is loading', () => {
+  const onSubmit = jest.fn();
+  const utils = render(
+    <form onSubmit={onSubmit}>
+      <Button data-testid="button" isLoading>
+        Submit
+      </Button>
+    </form>,
+  );
+  const button = utils.getByTestId('button');
+  fireEvent.click(button);
+  expect(onSubmit).not.toHaveBeenCalled();
+});

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -30,6 +30,7 @@ class Button extends React.Component<
   internalOnClick = (...args: *) => {
     const {isLoading, onClick} = this.props;
     if (isLoading) {
+      args[0].preventDefault();
       return;
     }
     onClick && onClick(...args);


### PR DESCRIPTION
#### Description

Per off line discussion, enhancing the behavior of the Button component to prevent form submission when a button has `isLoading={true}`. The Button currently prevents the onClick handler from firing, so this is just an extension of the idea that the button "should not cause any action when it's in a loading state".

#### Scope
Patch: Bug Fix
