### PR TITLE
docs(toast): adding new example for toast component

### DIFF
--- a/documentation-site/examples/toast/toast-close-from-outside.js
+++ b/documentation-site/examples/toast/toast-close-from-outside.js
@@ -1,25 +1,26 @@
+// @flow
 import * as React from 'react';
+
 import {toaster, ToasterContainer} from 'baseui/toast';
 import {Button} from 'baseui/button';
 
 export default () => {
   const [toastKey, setToastKey] = React.useState(null);
-  function showToast() {
-    const key = toaster.info('This is the message.');
-    setToastKey(key);
-  }
 
-  function closeToast() {
-    if (toastKey) {
-      toaster.clear(toastKey);
-      setToastKey(null);
-    }
-  }
+  const showToast = () =>
+    setToastKey(toaster.info('This is the message.'));
+
+  const closeToast = () => {
+    toaster.clear(toastKey);
+    setToastKey(null);
+  };
 
   return (
     <ToasterContainer>
       <Button onClick={showToast}>Show notification</Button>
-      <Button onClick={closeToast}>Close notification</Button>
+      <Button disabled={!toastKey} onClick={closeToast}>
+        Close notification
+      </Button>
     </ToasterContainer>
   );
 };

--- a/documentation-site/examples/toast/toast-close-from-outside.js
+++ b/documentation-site/examples/toast/toast-close-from-outside.js
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import {toaster, ToasterContainer} from 'baseui/toast';
+import {Button} from 'baseui/button';
+
+export default () => {
+  const [toastKey, setToastKey] = React.useState(null);
+  function showToast() {
+    const key = toaster.info('This is the message.');
+    setToastKey(key);
+  }
+
+  function closeToast() {
+    if (toastKey) {
+      toaster.clear(toastKey);
+      setToastKey(null);
+    }
+  }
+
+  return (
+    <ToasterContainer>
+      <Button onClick={showToast}>Show notification</Button>
+      <Button onClick={closeToast}>Close notification</Button>
+    </ToasterContainer>
+  );
+};

--- a/documentation-site/examples/toast/toast-close-from-outside.tsx
+++ b/documentation-site/examples/toast/toast-close-from-outside.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+
+import {toaster, ToasterContainer} from 'baseui/toast';
+import {Button} from 'baseui/button';
+
+type INullableReactText = React.ReactText | null;
+
+export default () => {
+  const [toastKey, setToastKey] = React.useState<
+    INullableReactText
+  >(null);
+
+  const showToast = () =>
+    setToastKey(toaster.info('This is the message.', {}));
+
+  const closeToast = () => {
+    if (toastKey) {
+      toaster.clear(toastKey);
+      setToastKey(null);
+    }
+  };
+
+  return (
+    <ToasterContainer>
+      <Button onClick={showToast}>Show notification</Button>
+      <Button disabled={!toastKey} onClick={closeToast}>
+        Close notification
+      </Button>
+    </ToasterContainer>
+  );
+};

--- a/documentation-site/pages/components/toast.mdx
+++ b/documentation-site/pages/components/toast.mdx
@@ -61,7 +61,7 @@ If a toast with an identical key already exists, that toast's contents will be u
 </Example>
 
 <Example
-  title="Toast been closed from outside"
+  title="Toast Being Closed From Outside"
   path="toast/toast-close-from-outside.js"
 >
   <ToastCloseFromOutside />

--- a/documentation-site/pages/components/toast.mdx
+++ b/documentation-site/pages/components/toast.mdx
@@ -12,6 +12,7 @@ import Exports from '../../components/exports';
 import ToastBasic from 'examples/toast/basic.js';
 import ToastNotification from 'examples/toast/toast-notification.js';
 import ToastSameKeyNotification from 'examples/toast/toast-same-key-notification.js';
+import ToastCloseFromOutside from 'examples/toast/toast-close-from-outside.js';
 
 import {Toast} from 'baseui/toast';
 import * as ToastExports from 'baseui/toast';
@@ -57,6 +58,13 @@ If a toast with an identical key already exists, that toast's contents will be u
   path="toast/toast-same-key-notification.js"
 >
   <ToastSameKeyNotification />
+</Example>
+
+<Example
+  title="Toast been closed from outside"
+  path="toast/toast-close-from-outside.js"
+>
+  <ToastCloseFromOutside />
 </Example>
 
 ## API


### PR DESCRIPTION
Closes #3188

#### Description

This PR improves the [toast documentation](https://baseweb.design/components/toast) by adding an example where you can close the toast from outside of it