### PR TITLE
fix: call focus on treeItemRefs if ref is not null

### DIFF
--- a/src/tree-view/tree-view.js
+++ b/src/tree-view/tree-view.js
@@ -48,7 +48,9 @@ export default function TreeView(props: TreeViewPropsT) {
   const focusTreeItem = (id: TreeNodeIdT | null) => {
     if (!id) return;
     setSelectedNodeId(id);
-    treeItemRefs.current[id].current.focus();
+
+    const node = treeItemRefs.current[id].current;
+    if (node) node.focus();
   };
 
   const onKeyDown = (e: KeyboardEvent, node: TreeNodeT<>) => {


### PR DESCRIPTION
#### Description
Fixes the error where a ref may be null, but still be fired.
![image](https://user-images.githubusercontent.com/7949047/81845044-9f9c0e80-956d-11ea-98c4-62c433897d15.png)

It could be that I'm using the component wrong, maybe I'm not forwarding a ref, but this check should still be in place.

#### Scope
Patch: Bug Fix
