### PR TITLE
docs: update examples with prefilled arrays

### DIFF
--- a/documentation-site/examples/list/menu-adapter.js
+++ b/documentation-site/examples/list/menu-adapter.js
@@ -11,7 +11,7 @@ import {
   ARTWORK_SIZES,
 } from 'baseui/list';
 
-const ITEMS = [...new Array(10)].map(() => ({
+const ITEMS = Array.from({length: 10}, () => ({
   title: 'Jane Smith',
   subtitle: 'Senior Engineering Manager',
   icon: Search,

--- a/documentation-site/examples/list/menu-adapter.tsx
+++ b/documentation-site/examples/list/menu-adapter.tsx
@@ -8,7 +8,7 @@ import {
   ARTWORK_SIZES,
 } from 'baseui/list';
 
-const ITEMS = [...new Array(10)].map(() => ({
+const ITEMS = Array.from({length: 10}, () => ({
   title: 'Jane Smith',
   subtitle: 'Senior Engineering Manager',
   icon: Search,

--- a/documentation-site/examples/menu/profile.js
+++ b/documentation-site/examples/menu/profile.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import {StatefulMenu, OptionProfile} from 'baseui/menu';
 
-const ITEMS = [...new Array(4)].map(() => ({
+const ITEMS = Array.from({length: 4}, () => ({
   title: 'David Smith',
   subtitle: 'Senior Engineering Manager',
   body: 'Uber Everything',

--- a/documentation-site/examples/menu/profile.tsx
+++ b/documentation-site/examples/menu/profile.tsx
@@ -8,7 +8,7 @@ interface IItem {
   imgUrl: string;
 }
 
-const ITEMS = [...new Array(4)].map(() => ({
+const ITEMS = Array.from({length: 4}, () => ({
   title: 'David Smith',
   subtitle: 'Senior Engineering Manager',
   body: 'Uber Everything',

--- a/documentation-site/examples/menu/virtual-list.js
+++ b/documentation-site/examples/menu/virtual-list.js
@@ -5,7 +5,7 @@ import {StatefulMenu, OptionList, StyledList} from 'baseui/menu';
 import List from 'react-virtualized/dist/commonjs/List';
 import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
 
-const ITEMS = [...new Array(1500)].map((_, index) => ({
+const ITEMS = Array.from({length: 1500}, (_, index) => ({
   label: `item number: ${index + 1}`,
 }));
 

--- a/documentation-site/examples/menu/virtual-list.tsx
+++ b/documentation-site/examples/menu/virtual-list.tsx
@@ -3,7 +3,7 @@ import {withStyle} from 'baseui';
 import {StatefulMenu, OptionList, StyledList} from 'baseui/menu';
 import {List, AutoSizer} from 'react-virtualized';
 
-const ITEMS = [...new Array(1500)].map((_, index) => ({
+const ITEMS = Array.from({length: 1500}, (_, index) => ({
   label: `item number: ${index + 1}`,
 }));
 

--- a/documentation-site/examples/table/filter.js
+++ b/documentation-site/examples/table/filter.js
@@ -38,7 +38,7 @@ class FilterTable extends React.Component<
     filters: [],
   };
 
-  FILTER_FUNCTIONS = [...new Array(10)].map((_, i) => row =>
+  FILTER_FUNCTIONS = Array.from({length: 10}, (_, i) => row =>
     row[0] % (i + 1) === 0,
   );
 
@@ -106,7 +106,7 @@ class FilterTable extends React.Component<
 
 export default () => {
   const [css] = useStyletron();
-  const FILTER_DATA = [...new Array(100)].map((_, i) => [
+  const FILTER_DATA = Array.from({length: 100}, (_, i) => [
     i,
     'row title',
   ]);

--- a/documentation-site/examples/table/filter.tsx
+++ b/documentation-site/examples/table/filter.tsx
@@ -34,8 +34,9 @@ class FilterTable extends React.Component<any> {
     filters: [],
   };
 
-  FILTER_FUNCTIONS = Array.from({length: 10}, (_, i) => row =>
-    row[0] % (i + 1) === 0,
+  FILTER_FUNCTIONS = Array.from(
+    {length: 10},
+    (_, i) => (row: any) => row[0] % (i + 1) === 0,
   );
 
   onFilter = (index: number) => {

--- a/documentation-site/examples/table/filter.tsx
+++ b/documentation-site/examples/table/filter.tsx
@@ -34,7 +34,7 @@ class FilterTable extends React.Component<any> {
     filters: [],
   };
 
-  FILTER_FUNCTIONS = [...new Array(10)].map((_, i) => (row: any) =>
+  FILTER_FUNCTIONS = Array.from({length: 10}, (_, i) => row =>
     row[0] % (i + 1) === 0,
   );
 
@@ -102,7 +102,7 @@ class FilterTable extends React.Component<any> {
 
 export default () => {
   const [css] = useStyletron();
-  const FILTER_DATA = [...new Array(100)].map((_, i) => [
+  const FILTER_DATA = Array.from({length: 100}, (_, i) => [
     i,
     'row title',
   ]);

--- a/documentation-site/examples/table/pagination.js
+++ b/documentation-site/examples/table/pagination.js
@@ -78,7 +78,7 @@ function PaginatedTable(props: {data: any[], columns: any[]}) {
         <StatefulPopover
           content={({close}) => (
             <StatefulMenu
-              items={[...new Array(100)].map((_, i) => ({
+              items={Array.from({length: 100}, (_, i) => ({
                 label: i + 1,
               }))}
               onItemSelect={({item}) => {
@@ -109,9 +109,9 @@ function PaginatedTable(props: {data: any[], columns: any[]}) {
   );
 }
 
-const COLUMNS = [...new Array(5)].map(() => 'Label');
-const DATA = [...new Array(45)].map((_, i) =>
-  [...new Array(5)].map(() => `row: ${i + 1}`),
+const COLUMNS = Array.from({length: 5}, () => 'Label');
+const DATA = Array.from({length: 45}, (_, i) =>
+  Array.from({length: 5}, () => `row: ${i + 1}`),
 );
 
 export default () => (

--- a/documentation-site/examples/table/pagination.tsx
+++ b/documentation-site/examples/table/pagination.tsx
@@ -85,7 +85,7 @@ function PaginatedTable(props: {data: any[]; columns: any[]}) {
         <StatefulPopover
           content={({close}) => (
             <StatefulMenu
-              items={[...new Array(100)].map((_, i) => ({
+              items={Array.from({length: 100}, (_, i) => ({
                 label: i + 1,
               }))}
               onItemSelect={({item}) => {
@@ -116,9 +116,9 @@ function PaginatedTable(props: {data: any[]; columns: any[]}) {
   );
 }
 
-const COLUMNS = [...new Array(5)].map(() => 'Label');
-const DATA = [...new Array(45)].map((_, i) =>
-  [...new Array(5)].map(() => `row: ${i + 1}`),
+const COLUMNS = Array.from({length: 5}, () => 'Label');
+const DATA = Array.from({length: 45}, (_, i) =>
+  Array.from({length: 5}, () => `row: ${i + 1}`),
 );
 
 export default () => (


### PR DESCRIPTION
Noticed that StackBlitz compiles `new Array` a bit strangely and so subsequent `map` calls don't work correctly. https://github.com/stackblitz/core/issues/546

Seems that if you construct an array any other way it works fine. In this PR I've switched to `Array.from` as recommended in the linked issue.