### PR TITLE
docs(bedrock): remove references to bedrock from public documentation

### DIFF
--- a/documentation-site/pages/getting-started/setup.mdx
+++ b/documentation-site/pages/getting-started/setup.mdx
@@ -133,7 +133,6 @@ There are detailed guides for Styletron setup for the following frameworks:
 - [Next.js](https://www.styletron.org/getting-started/#with-nextjs)
 - [Gatsby](https://www.styletron.org/getting-started/#with-gatsby)
 - [Other React applications](https://www.styletron.org/getting-started/#with-react)
-- [Bedrock](http://t.uber.com/base-bedrock) (Uber only)
 
 When using **Gatsby** and `gatsby-plugin-styletron`, make sure to place `BaseProvider` into the root component of your application (typically `layout.js`) and not into `gatsby-client.js`. This will ensure the correct order of
 


### PR DESCRIPTION
It can be viewed on the public site and links to a google doc with comments from Uber employees. This feels inappropriate.