### PR TITLE
fix(tree-view): ensure nothing is rendered in treeview if data is empty

### DIFF
--- a/src/tree-view/tree-view.js
+++ b/src/tree-view/tree-view.js
@@ -128,32 +128,36 @@ export default function TreeView(props: TreeViewPropsT) {
 
   return (
     <Root role="tree" {...getOverrideProps(RootOverride)}>
-      {data.length &&
-        data.map(node => (
-          <TreeNode
-            indentGuides={indentGuides}
-            key={getId(node)}
-            node={node}
-            getId={getId}
-            onToggle={node => {
-              onToggle && onToggle(node);
-              focusTreeItem(getId(node));
-            }}
-            overrides={overrides}
-            renderAll={renderAll}
-            selectedNodeId={selectedNodeId}
-            onKeyDown={onKeyDown}
-            onFocus={onFocus}
-            onBlur={onBlur}
-            addRef={(id: TreeNodeIdT, ref: React.ElementRef<HTMLLIElement>) => {
-              treeItemRefs.current[id] = ref;
-            }}
-            removeRef={(id: TreeNodeIdT) => {
-              delete treeItemRefs.current[id];
-            }}
-            isFocusVisible={focusVisible}
-          />
-        ))}
+      {data.length
+        ? data.map(node => (
+            <TreeNode
+              indentGuides={indentGuides}
+              key={getId(node)}
+              node={node}
+              getId={getId}
+              onToggle={node => {
+                onToggle && onToggle(node);
+                focusTreeItem(getId(node));
+              }}
+              overrides={overrides}
+              renderAll={renderAll}
+              selectedNodeId={selectedNodeId}
+              onKeyDown={onKeyDown}
+              onFocus={onFocus}
+              onBlur={onBlur}
+              addRef={(
+                id: TreeNodeIdT,
+                ref: React.ElementRef<HTMLLIElement>,
+              ) => {
+                treeItemRefs.current[id] = ref;
+              }}
+              removeRef={(id: TreeNodeIdT) => {
+                delete treeItemRefs.current[id];
+              }}
+              isFocusVisible={focusVisible}
+            />
+          ))
+        : null}
     </Root>
   );
 }

--- a/src/tree-view/tree-view.js
+++ b/src/tree-view/tree-view.js
@@ -128,36 +128,31 @@ export default function TreeView(props: TreeViewPropsT) {
 
   return (
     <Root role="tree" {...getOverrideProps(RootOverride)}>
-      {data.length
-        ? data.map(node => (
-            <TreeNode
-              indentGuides={indentGuides}
-              key={getId(node)}
-              node={node}
-              getId={getId}
-              onToggle={node => {
-                onToggle && onToggle(node);
-                focusTreeItem(getId(node));
-              }}
-              overrides={overrides}
-              renderAll={renderAll}
-              selectedNodeId={selectedNodeId}
-              onKeyDown={onKeyDown}
-              onFocus={onFocus}
-              onBlur={onBlur}
-              addRef={(
-                id: TreeNodeIdT,
-                ref: React.ElementRef<HTMLLIElement>,
-              ) => {
-                treeItemRefs.current[id] = ref;
-              }}
-              removeRef={(id: TreeNodeIdT) => {
-                delete treeItemRefs.current[id];
-              }}
-              isFocusVisible={focusVisible}
-            />
-          ))
-        : null}
+      {data.map(node => (
+        <TreeNode
+          indentGuides={indentGuides}
+          key={getId(node)}
+          node={node}
+          getId={getId}
+          onToggle={node => {
+            onToggle && onToggle(node);
+            focusTreeItem(getId(node));
+          }}
+          overrides={overrides}
+          renderAll={renderAll}
+          selectedNodeId={selectedNodeId}
+          onKeyDown={onKeyDown}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          addRef={(id: TreeNodeIdT, ref: React.ElementRef<HTMLLIElement>) => {
+            treeItemRefs.current[id] = ref;
+          }}
+          removeRef={(id: TreeNodeIdT) => {
+            delete treeItemRefs.current[id];
+          }}
+          isFocusVisible={focusVisible}
+        />
+      ))}
     </Root>
   );
 }


### PR DESCRIPTION
#### Description

When `data.length` is 0, it renders `0` in the children.
This PR returns null if `data.length` is 0.

![image](https://user-images.githubusercontent.com/7949047/82866412-794f7900-9f46-11ea-9ff6-8d7762128d98.png)


#### Scope

Patch: Bug Fix
