### PR TITLE
docs(progress-bar): remove infinite example

### DIFF
--- a/documentation-site/examples/progress-bar/infinite.js
+++ b/documentation-site/examples/progress-bar/infinite.js
@@ -1,7 +1,0 @@
-// @flow
-import * as React from 'react';
-import {ProgressBar} from 'baseui/progress-bar';
-
-export default () => {
-  return <ProgressBar infinite />;
-};

--- a/documentation-site/examples/progress-bar/infinite.tsx
+++ b/documentation-site/examples/progress-bar/infinite.tsx
@@ -1,6 +1,0 @@
-import * as React from 'react';
-import {ProgressBar} from 'baseui/progress-bar';
-
-export default () => {
-  return <ProgressBar infinite />;
-};

--- a/documentation-site/pages/components/progress-bar.mdx
+++ b/documentation-site/pages/components/progress-bar.mdx
@@ -12,7 +12,6 @@ import Exports from '../../components/exports';
 import Basic from 'examples/progress-bar/basic.js';
 import Negative from 'examples/progress-bar/negative.js';
 import WithLabel from 'examples/progress-bar/with-label.js';
-import Infinite from 'examples/progress-bar/infinite.js';
 import CustomLabel from 'examples/progress-bar/custom-label.js';
 import Customization from 'examples/progress-bar/overrides.js';
 
@@ -59,13 +58,6 @@ Indicates a wait time for actions - either within an experience flow or loading 
   path="progress-bar/with-label.js"
 >
   <WithLabel />
-</Example>
-
-<Example
-  title="Progress bar with Infinite progress"
-  path="progress-bar/infinite.js"
->
-  <Infinite />
 </Example>
 
 <Example


### PR DESCRIPTION
Yard provides the same functionality, and this has a bug in it, so 🔥 