### PR TITLE
fix(accordion): update typescript accordion overrides type

### DIFF
--- a/src/accordion/types.js
+++ b/src/accordion/types.js
@@ -33,7 +33,11 @@ export type PanelStateReducerT = (
 ) => PanelStateT;
 
 export type AccordionOverridesT = {
+  Content?: OverrideT,
+  Header?: OverrideT,
+  PanelContainer?: OverrideT,
   Root?: OverrideT,
+  ToggleIcon?: OverrideT,
 };
 
 export type PanelOverridesT = {


### PR DESCRIPTION
Fixes #3376

#### Description

Adds in the missing accordion overrides to the typescript type.

<!-- Describe your changes below in as much detail as possible -->

#### Scope
Patch: Bug Fix
