### PR TITLE
feat(combobox): add change_source to change handler

### DIFF
--- a/src/combobox/combobox.js
+++ b/src/combobox/combobox.js
@@ -14,6 +14,7 @@ import {getOverrides} from '../helpers/overrides.js';
 import {Popover, PLACEMENT} from '../popover/index.js';
 import getBuiId from '../utils/get-bui-id.js';
 
+import {CHANGE_SOURCE} from './constants.js';
 import {
   StyledRoot,
   StyledInputContainer,
@@ -125,7 +126,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
     if (event.keyCode === ENTER) {
       setIsOpen(false);
       setSelectionIndex(-1);
-      onChange(tempValue);
+      onChange(tempValue, CHANGE_SOURCE.option);
     }
     if (event.keyCode === ESCAPE) {
       // NOTE(chase): aria 1.2 spec outlines a pattern where when escape is
@@ -159,7 +160,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
   function handleInputChange(event) {
     handleOpen();
     setSelectionIndex(-1);
-    onChange(event.target.value);
+    onChange(event.target.value, CHANGE_SOURCE.input);
     setTempValue(event.target.value);
   }
 
@@ -169,7 +170,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
       const stringified = mapOptionToString(clickedOption);
       setIsOpen(false);
       setSelectionIndex(index);
-      onChange(stringified);
+      onChange(stringified, CHANGE_SOURCE.option);
       setTempValue(stringified);
 
       if (inputRef.current) {

--- a/src/combobox/constants.js
+++ b/src/combobox/constants.js
@@ -1,0 +1,12 @@
+/*
+Copyright (c) 2018-2020 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+export const CHANGE_SOURCE = Object.freeze({
+  input: 'input',
+  option: 'option',
+});

--- a/src/combobox/index.d.ts
+++ b/src/combobox/index.d.ts
@@ -8,10 +8,10 @@ export interface SIZE {
   mini: 'mini';
 }
 
-export interface ChangeSourceT = {
-  input: 'input',
-  option: 'option',
-};
+export interface ChangeSourceT {
+  input: 'input';
+  option: 'option';
+}
 
 export type PropsT<OptionT = unknown> = {
   disabled?: boolean;

--- a/src/combobox/index.d.ts
+++ b/src/combobox/index.d.ts
@@ -8,6 +8,11 @@ export interface SIZE {
   mini: 'mini';
 }
 
+export interface ChangeSourceT = {
+  input: 'input',
+  option: 'option',
+};
+
 export type PropsT<OptionT = unknown> = {
   disabled?: boolean;
   mapOptionToNode?: ({isSelected: boolean, option: OptionT}) => React.ReactNode;

--- a/src/combobox/index.js
+++ b/src/combobox/index.js
@@ -9,6 +9,7 @@ LICENSE file in the root directory of this source tree.
 export {SIZE} from '../input/constants.js';
 
 export {default as Combobox} from './combobox.js';
+export {CHANGE_SOURCE} from './constants.js';
 export {
   StyledRoot,
   StyledInputContainer,

--- a/src/combobox/types.js
+++ b/src/combobox/types.js
@@ -8,10 +8,12 @@ LICENSE file in the root directory of this source tree.
 
 import * as React from 'react';
 
+import {CHANGE_SOURCE} from './constants.js';
+
 import type {OverrideT} from '../helpers/overrides.js';
 import {SIZE} from '../input/index.js';
-// import type {InputPropsT} from '../input/index.js';
-// import type {PopoverPropsT} from '../popover/index.js';
+
+export type ChangeSourceT = $Keys<typeof CHANGE_SOURCE>;
 
 export type PropsT<OptionT = mixed> = {|
   // Disallows text input and listbox opening.
@@ -27,7 +29,7 @@ export type PropsT<OptionT = mixed> = {|
   // map whatever value the client gets into a visible string in the list item.
   mapOptionToString: OptionT => string,
   // Called when input value changes or option is selected.
-  onChange: string => mixed,
+  onChange: (string, ChangeSourceT) => mixed,
   // Data to populate list items in the dropdown menu.
   options: OptionT[],
   overrides?: {|


### PR DESCRIPTION
### Description

In some situations, it's useful to know whether a combobox change came from user-keyboard-input vs user-selection. This pr adds an enum to the change handler.

#### Scope
Minor: New Feature