### PR TITLE
fix(combobox): test name attr to remove credit card suggestion on docs site

### DIFF
--- a/documentation-site/examples/combobox/async-options.js
+++ b/documentation-site/examples/combobox/async-options.js
@@ -100,7 +100,7 @@ function Example() {
           onChange={handleChange}
           mapOptionToString={mapOptionToString}
           options={options}
-          name="color-selector"
+          name="async-options"
         />
       </FormControl>
     </div>

--- a/documentation-site/examples/combobox/async-options.js
+++ b/documentation-site/examples/combobox/async-options.js
@@ -100,6 +100,7 @@ function Example() {
           onChange={handleChange}
           mapOptionToString={mapOptionToString}
           options={options}
+          name="color-selector"
         />
       </FormControl>
     </div>

--- a/documentation-site/examples/combobox/async-options.tsx
+++ b/documentation-site/examples/combobox/async-options.tsx
@@ -98,6 +98,7 @@ function Example() {
           onChange={handleChange}
           mapOptionToString={mapOptionToString}
           options={options}
+          name="async-options"
         />
       </FormControl>
     </div>

--- a/documentation-site/examples/combobox/filtered-options.js
+++ b/documentation-site/examples/combobox/filtered-options.js
@@ -91,6 +91,7 @@ function Example() {
           onChange={setValue}
           mapOptionToString={mapOptionToString}
           options={filteredOptions}
+          name="filtered-options"
         />
       </FormControl>
     </div>

--- a/documentation-site/examples/combobox/filtered-options.tsx
+++ b/documentation-site/examples/combobox/filtered-options.tsx
@@ -89,6 +89,7 @@ function Example() {
           onChange={setValue}
           mapOptionToString={mapOptionToString}
           options={filteredOptions}
+          name="filtered-options"
         />
       </FormControl>
     </div>

--- a/documentation-site/examples/combobox/input-overrides.js
+++ b/documentation-site/examples/combobox/input-overrides.js
@@ -27,6 +27,7 @@ function Example() {
           onChange={setValue}
           mapOptionToString={o => o.label}
           options={options}
+          name="input-overrides"
           overrides={{
             Input: {
               props: {

--- a/documentation-site/examples/combobox/input-overrides.tsx
+++ b/documentation-site/examples/combobox/input-overrides.tsx
@@ -25,6 +25,7 @@ function Example() {
           onChange={setValue}
           mapOptionToString={o => o.label}
           options={options}
+          name="input-overrides"
           overrides={{
             Input: {
               props: {

--- a/documentation-site/examples/combobox/replacement-node.js
+++ b/documentation-site/examples/combobox/replacement-node.js
@@ -50,6 +50,7 @@ function Example() {
           onChange={setValue}
           mapOptionToString={o => o.label}
           mapOptionToNode={ReplacementNode}
+          name="replacement-node"
           options={options}
         />
       </FormControl>

--- a/documentation-site/examples/combobox/replacement-node.tsx
+++ b/documentation-site/examples/combobox/replacement-node.tsx
@@ -48,6 +48,7 @@ function Example() {
           onChange={setValue}
           mapOptionToString={o => o.label}
           mapOptionToNode={ReplacementNode}
+          name="replacement-node"
           options={options}
         />
       </FormControl>

--- a/src/combobox/combobox.js
+++ b/src/combobox/combobox.js
@@ -36,6 +36,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
     onChange,
     mapOptionToNode,
     mapOptionToString,
+    name,
     options,
     overrides = {},
     positive = false,
@@ -274,6 +275,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
             aria-controls={listboxId}
             disabled={disabled}
             error={error}
+            name={name}
             onBlur={handleBlur}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}

--- a/src/combobox/index.d.ts
+++ b/src/combobox/index.d.ts
@@ -12,6 +12,7 @@ export type PropsT<OptionT = unknown> = {
   disabled?: boolean;
   mapOptionToNode?: ({isSelected: boolean, option: OptionT}) => React.ReactNode;
   mapOptionToString: (OptionT) => string;
+  name?: string;
   onChange?: (string) => any;
   options: OptionT;
   overrides?: {

--- a/src/combobox/types.js
+++ b/src/combobox/types.js
@@ -26,6 +26,7 @@ export type PropsT<OptionT = mixed> = {|
   // Options are often fetched from remote server, provides a simple way to
   // map whatever value the client gets into a visible string in the list item.
   mapOptionToString: OptionT => string,
+  name?: string,
   // Called when input value changes or option is selected.
   onChange: string => mixed,
   // Data to populate list items in the dropdown menu.


### PR DESCRIPTION
#### Description

Chrome tries to autofill combobox example with stored credit card information. Adding a `name` attribute that's unrelated to payment removes the suggestion

#### Scope
Patch: Bug Fix
