### PR TITLE
feat(combobox): include option in change handler params if suggestion is selected

### DIFF
--- a/src/combobox/__tests__/combobox.test.js
+++ b/src/combobox/__tests__/combobox.test.js
@@ -31,6 +31,7 @@ describe('combobox', () => {
 
     expect(handleChange.mock.calls.length).toBe(1);
     expect(handleChange.mock.calls[0][0]).toBe('x');
+    expect(handleChange.mock.calls[0][1]).toBe(null);
   });
 
   it('opens listbox when text is entered', () => {
@@ -110,6 +111,7 @@ describe('combobox', () => {
 
     expect(handleChange.mock.calls.length).toBe(1);
     expect(handleChange.mock.calls[0][0]).toBe(options[1]);
+    expect(handleChange.mock.calls[0][1]).toBe(options[1]);
   });
 
   it('calls onChange with selected value when option clicked', () => {
@@ -133,6 +135,7 @@ describe('combobox', () => {
 
     expect(handleChange.mock.calls.length).toBe(1);
     expect(handleChange.mock.calls[0][0]).toBe(options[2]);
+    expect(handleChange.mock.calls[0][1]).toBe(options[2]);
   });
 
   it('closes listbox on blur', () => {

--- a/src/combobox/combobox.js
+++ b/src/combobox/combobox.js
@@ -124,9 +124,12 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
       });
     }
     if (event.keyCode === ENTER) {
-      setIsOpen(false);
-      setSelectionIndex(-1);
-      onChange(tempValue);
+      let clickedOption = options[selectionIndex];
+      if (clickedOption) {
+        setIsOpen(false);
+        setSelectionIndex(-1);
+        onChange(mapOptionToString(clickedOption), clickedOption);
+      }
     }
     if (event.keyCode === ESCAPE) {
       // NOTE(chase): aria 1.2 spec outlines a pattern where when escape is
@@ -160,7 +163,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
   function handleInputChange(event) {
     handleOpen();
     setSelectionIndex(-1);
-    onChange(event.target.value);
+    onChange(event.target.value, null);
     setTempValue(event.target.value);
   }
 
@@ -170,7 +173,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
       const stringified = mapOptionToString(clickedOption);
       setIsOpen(false);
       setSelectionIndex(index);
-      onChange(stringified);
+      onChange(stringified, clickedOption);
       setTempValue(stringified);
 
       if (inputRef.current) {

--- a/src/combobox/index.d.ts
+++ b/src/combobox/index.d.ts
@@ -13,7 +13,7 @@ export type PropsT<OptionT = unknown> = {
   mapOptionToNode?: ({isSelected: boolean, option: OptionT}) => React.ReactNode;
   mapOptionToString: (OptionT) => string;
   name?: string;
-  onChange?: (string) => any;
+  onChange?: (value: string, option: OptionT | null) => any;
   options: OptionT;
   overrides?: {
     Root?: Override<any>;

--- a/src/combobox/types.js
+++ b/src/combobox/types.js
@@ -27,8 +27,10 @@ export type PropsT<OptionT = mixed> = {|
   // map whatever value the client gets into a visible string in the list item.
   mapOptionToString: OptionT => string,
   name?: string,
-  // Called when input value changes or option is selected.
-  onChange: string => mixed,
+  // Called when input value changes or option is selected. If user selects a
+  // suggested option, that option will be provided as the second function parameter.
+  // Otherwise the second parameter will be null.
+  onChange: (string, OptionT | null) => mixed,
   // Data to populate list items in the dropdown menu.
   options: OptionT[],
   overrides?: {|

--- a/src/combobox/types.js
+++ b/src/combobox/types.js
@@ -30,6 +30,7 @@ export type PropsT<OptionT = mixed> = {|
   // Called when input value changes or option is selected. If user selects a
   // suggested option, that option will be provided as the second function parameter.
   // Otherwise the second parameter will be null.
+  // TODO(v10): consider consolidating function params into a single object bag.
   onChange: (string, OptionT | null) => mixed,
   // Data to populate list items in the dropdown menu.
   options: OptionT[],


### PR DESCRIPTION
#### Description

In some situations, it's useful to know whether a combobox change came from user-keyboard-input vs user-selection. If a suggestion is selected, the option value will be provided to the change handler, otherwise null.

#### Scope
Minor: New Feature
