### PR TITLE
fix(card): broken typescript defintions

### DIFF
--- a/src/card/index.d.ts
+++ b/src/card/index.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {StyletronComponent} from 'styletron-react';
-import {ImagePropsT} from './types.js';
 import {Override} from '../overrides';
 
 export interface CardOverrides {
@@ -16,7 +15,7 @@ export interface CardProps {
   readonly action?: React.ReactNode;
   readonly children?: React.ReactNode;
   readonly hasThumbnail?: (props: {readonly thumbnail?: string}) => boolean;
-  readonly headerImage?: string | ImagePropsT;
+  readonly headerImage?: string | React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>;
   readonly overrides?: CardOverrides;
   readonly thumbnail?: string;
   readonly title?: React.ReactNode;


### PR DESCRIPTION
#### Description

The index.d.ts for the Card component was importing types from a flow types file causing a typescript error when importing from `baseui/card`:

```
error TS7016: Could not find a declaration file for module './types.js'. '/Users/airhorns/Code/gadget/node_modules/baseui/card/types.js' implicitly has an 'any' type.

3 import {ImagePropsT} from './types.js';
```

The type for the `headerImage` prop is a string or all the props that an `<img>` can take, so this updates the TypeScript type to just use React's built in props list for images.

#### Scope

Patch: Bug Fix