### PR TITLE
Add a controlRef prop to <Select/>

### DIFF
--- a/documentation-site/examples/select/focus.js
+++ b/documentation-site/examples/select/focus.js
@@ -1,0 +1,45 @@
+// @flow
+import * as React from 'react';
+import {useStyletron} from 'baseui';
+import {Select} from 'baseui/select';
+import {Button} from 'baseui/button';
+
+export default () => {
+  const [css, theme] = useStyletron();
+  const [value, setValue] = React.useState([]);
+  const controlRef = React.useRef(null);
+  return (
+    <div className={css({display: 'flex'})}>
+      <Select
+        controlRef={controlRef}
+        creatable
+        options={[
+          {id: 'Portland', label: 'Portland'},
+          {id: 'NYC', label: 'New York City'},
+          {id: 'LosAngeles', label: 'Los Angeles'},
+          {id: 'Boston', label: 'Boston'},
+          {id: 'Atlanta', label: 'Atlanta'},
+          {id: 'SanFrancisco', label: 'San Francisco'},
+        ]}
+        labelKey="label"
+        valueKey="id"
+        onChange={({value}) => setValue(value)}
+        value={value}
+        overrides={{
+          Root: {
+            style: {
+              marginRight: theme.sizing.scale600,
+            },
+          },
+        }}
+      />
+      <Button
+        onClick={() =>
+          controlRef.current && controlRef.current.focus()
+        }
+      >
+        Click to focus
+      </Button>
+    </div>
+  );
+};

--- a/documentation-site/examples/select/focus.tsx
+++ b/documentation-site/examples/select/focus.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {useStyletron} from 'baseui';
+import {Select, Value} from 'baseui/select';
+import {Button} from 'baseui/button';
+
+export default () => {
+  const [css, theme] = useStyletron();
+  const [value, setValue] = React.useState<Value>([]);
+  const controlRef = React.useRef<
+    HTMLInputElement | HTMLDivElement
+  >(null);
+  return (
+    <div className={css({display: 'flex'})}>
+      <Select
+        controlRef={controlRef}
+        creatable
+        options={[
+          {id: 'Portland', label: 'Portland'},
+          {id: 'NYC', label: 'New York City'},
+          {id: 'LosAngeles', label: 'Los Angeles'},
+          {id: 'Boston', label: 'Boston'},
+          {id: 'Atlanta', label: 'Atlanta'},
+          {id: 'SanFrancisco', label: 'San Francisco'},
+        ]}
+        labelKey="label"
+        valueKey="id"
+        onChange={({value}) => setValue(value)}
+        value={value}
+        overrides={{
+          Root: {
+            style: {
+              marginRight: theme.sizing.scale600,
+            },
+          },
+        }}
+      />
+      <Button
+        onClick={() =>
+          controlRef.current && controlRef.current.focus()
+        }
+      >
+        Click to focus
+      </Button>
+    </div>
+  );
+};

--- a/documentation-site/pages/components/select.mdx
+++ b/documentation-site/pages/components/select.mdx
@@ -24,6 +24,7 @@ import SelectCreatableMulti from 'examples/select/creatable-multi.js';
 import SelectOverriddenDropdown from 'examples/select/overridden-dropdown.js';
 import SelectGrouped from 'examples/select/grouped.js';
 import SelectAsyncOptions from 'examples/select/async-options.js';
+import SelectFocus from 'examples/select/focus.js';
 
 import {StatefulSelect, TYPE} from 'baseui/select';
 import * as SelectExports from 'baseui/select';
@@ -97,6 +98,10 @@ existing options.
 
 <Example title="Select similar to native select" path="select/native.js">
   <SelectNative />
+</Example>
+
+<Example title="Focus and ref" path="select/focus.js">
+  <SelectFocus />
 </Example>
 
 <Example title="Select uncontrolled example" path="select/uncontrolled.js">

--- a/src/select/__tests__/select.test.js
+++ b/src/select/__tests__/select.test.js
@@ -4,6 +4,7 @@ Copyright (c) 2018-2020 Uber Technologies, Inc.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
+/* global document */
 // @flow
 import * as React from 'react';
 import {mount} from 'enzyme';
@@ -97,6 +98,17 @@ describe('Select component', function() {
         multi
         valueKey="color"
       />,
+    );
+  });
+
+  test('sets controlRef from props', () => {
+    const ref = React.createRef();
+    wrapper = mount(<Select {...props} controlRef={ref} />);
+    expect(ref.current).toBeDefined();
+    // $FlowFixMe
+    ref.current.focus();
+    expect(wrapper.find('input').getDOMNode() === document.activeElement).toBe(
+      true,
     );
   });
 });

--- a/src/select/index.d.ts
+++ b/src/select/index.d.ts
@@ -102,6 +102,7 @@ export interface SelectProps {
   }) => React.ReactNode;
   getValueLabel?: (args: {option: Option}) => React.ReactNode;
   id?: string;
+  controlRef?: React.Ref<HTMLInputElement | HTMLDivElement>;
   isLoading?: boolean;
   labelKey?: string;
   startOpen?: boolean;

--- a/src/select/select-component.js
+++ b/src/select/select-component.js
@@ -485,6 +485,17 @@ class Select extends React.Component<PropsT, SelectStateT> {
     }
   };
 
+  handleInputRef = (input: React.ElementRef<*>) => {
+    this.input = input;
+    if (this.props.controlRef) {
+      if (typeof this.props.controlRef === 'function') {
+        this.props.controlRef(input);
+      } else {
+        this.props.controlRef.current = input;
+      }
+    }
+  };
+
   selectValue = ({item}: {item: OptionT}) => {
     if (item.disabled) {
       return;
@@ -692,7 +703,7 @@ class Select extends React.Component<PropsT, SelectStateT> {
           aria-owns={this.state.isOpen ? this.listboxId : null}
           aria-required={this.props.required || null}
           onFocus={this.handleInputFocus}
-          ref={ref => (this.input = ref)}
+          ref={this.handleInputRef}
           tabIndex={0}
           {...sharedProps}
           {...inputContainerProps}
@@ -716,7 +727,7 @@ class Select extends React.Component<PropsT, SelectStateT> {
           aria-required={this.props.required || null}
           disabled={this.props.disabled || null}
           id={this.props.id || null}
-          inputRef={ref => (this.input = ref)}
+          inputRef={this.handleInputRef}
           onChange={this.handleInputChange}
           onFocus={this.handleInputFocus}
           overrides={{Input: overrides.Input}}

--- a/src/select/types.js
+++ b/src/select/types.js
@@ -119,6 +119,8 @@ export type PropsT = {
   getValueLabel: ?({option: OptionT}) => React.Node,
   /** Sets the id attribute of the internal input element. Allows for usage with labels. */
   id?: string,
+  /** A ref to access the input element powering the select if it's a search select, or the container div if it isn't. */
+  controlRef?: React.ElementRef<*>,
   /** Defines if the select is in a loading (async) state. */
   isLoading: boolean,
   /** Defines an option key for a default label value. */


### PR DESCRIPTION
#### Description

Similar to `<Input/>`, it's useful to be able to get a ref to the inner element so developers can imperatively do stuff to it, like focus it. This adds a `controlRef` prop to `<Select/>` so you can do just that!

It's called `controlRef` and not `inputRef`, which is different than `<Input/>`, but on purpose, because if the Select isn't searchable, then there isn't actually an `<input>` created, just a `<div>` as a container. The Flow and TypeScript types reflect this, but I thought it might be good to make the name and docs clear that it won't always be an input.

Added a test and an example in the docs.

Fixes #3398

#### Scope

Minor: New Feature
