### PR TITLE
fix(eslint-plugin-baseui): add baseui prefix for recommended config

### DIFF
--- a/packages/eslint-plugin-baseui/src/index.js
+++ b/packages/eslint-plugin-baseui/src/index.js
@@ -21,9 +21,9 @@ module.exports = {
     recommended: {
       plugins: ['baseui'],
       rules: {
-        'deprecated-theme-api': ['warn'],
-        'deprecated-component-api': ['warn'],
-        'no-deep-imports': ['warn'],
+        'baseui/deprecated-theme-api': ['warn'],
+        'baseui/deprecated-component-api': ['warn'],
+        'baseui/no-deep-imports': ['warn'],
       },
     },
   },


### PR DESCRIPTION
#### Description

Without this, you'll get the following when you try to use the recommended config from an external project:
```
  1:1  error  Definition for rule 'deprecated-theme-api' was not found      deprecated-theme-api
  1:1  error  Definition for rule 'deprecated-component-api' was not found  deprecated-component-api
  1:1  error  Definition for rule 'no-deep-imports' was not found           no-deep-imports
```
#### Scope
Patch: Bug Fix
