### PR TITLE
fix(tree-view): don't refer to non-existent typescript types

### DIFF
--- a/src/tree-view/index.d.ts
+++ b/src/tree-view/index.d.ts
@@ -76,6 +76,6 @@ type toggleIsExpandedT = (
 
 export const toggleIsExpanded: toggleIsExpandedT;
 export const TreeLabelInteractable: React.FC<{
-  overrides?: {LabelInteractable: OverrideT},
-  children?: React.ReactNode | React.ChildrenArray<void | null | boolean | string | number | React.Element<any>>
+  overrides?: {LabelInteractable: Override<any>};
+  children?: React.ReactNode;
 }>;


### PR DESCRIPTION
#### Description

The TreeView TypeScript types were accidentally referring to a Flow type variable `OverrideT` which should just be `Override` like the rest of the TypeScript types, as well as using an older and unnecessary style of expressing a `children` prop. The TypeScript `React.ReactNode` type includes arrays of `React.ReactNode` as well, so the extra stuff isn't necessary.

#### Scope

Patch: Bug Fix