### PR TITLE
fix(button): prevent button height change when isLoading

### DIFF
--- a/src/button/styled-components.js
+++ b/src/button/styled-components.js
@@ -141,6 +141,7 @@ export const LoadingSpinner = styled<SharedStylePropsT>(
       borderLeftColor: background,
       borderBottomColor: background,
       borderRightColor: background,
+      boxSizing: 'content-box',
       display: 'inline-block',
       animationDuration: $theme.animation.timing700,
       animationTimingFunction: 'linear',


### PR DESCRIPTION
#### Description
The height of a button was changing when setting `isLoading` in some sites. The cause was tracked down to sites applying global styles like `* { box-sizing: border-box; }`. To ensure that all sites have a consistent button height regardless of these global styles we are setting the LoadingSpinner's `<span>` to have its `box-sizing` set to `content-box`.

#### Scope
Patch: Bug Fix
