### PR TITLE
fix(input): add step property to ts defintions

### DIFF
--- a/src/input/index.d.ts
+++ b/src/input/index.d.ts
@@ -62,6 +62,7 @@ export interface BaseInputProps<T> {
   placeholder?: string;
   required?: boolean;
   size?: SIZE[keyof SIZE];
+  step?: string;
   type?: string;
   value?: string | number;
   rows?: number;


### PR DESCRIPTION
I added step support for Input

Fixes #1

#### Description

I try to use the Input component with type number and step property but I got the typescript error for props. I added optional props.

#### Scope
Patch: Bug Fix