### PR TITLE
feat(select): add alias for tag override

### DIFF
--- a/documentation-site/components/yard/config/select.ts
+++ b/documentation-site/components/yard/config/select.ts
@@ -342,7 +342,7 @@ const SelectConfig: TConfig = {
           'Placeholder',
           'ValueContainer',
           'SingleValue',
-          'MultiValue',
+          'Tag',
           'InputContainer',
           'Input',
           'IconsContainer',

--- a/documentation-site/examples/select/overriden-tag.js
+++ b/documentation-site/examples/select/overriden-tag.js
@@ -10,7 +10,7 @@ export default () => {
   return (
     <Select
       overrides={{
-        MultiValue: {
+        Tag: {
           props: {
             overrides: {
               Root: {

--- a/documentation-site/examples/select/overriden-tag.tsx
+++ b/documentation-site/examples/select/overriden-tag.tsx
@@ -9,7 +9,7 @@ export default () => {
   return (
     <Select
       overrides={{
-        MultiValue: {
+        Tag: {
           props: {
             overrides: {
               Root: {

--- a/documentation-site/pages/guides/understanding-overrides.mdx
+++ b/documentation-site/pages/guides/understanding-overrides.mdx
@@ -233,9 +233,9 @@ Here is the default multi-select option for Base Web:
 
 Let's change the way the selected values appear.
 
-The first step is to identify _what_ we want to override. In this case, we want to change the selected values for a multi-select. Let's check out the [`overrides` inspector for Select](/components/select/#overrides). Looking through the list of possible overrides, we see there is a promising `MultiValue` property.
+The first step is to identify _what_ we want to override. In this case, we want to change the selected values for a multi-select. Let's check out the [`overrides` inspector for Select](/components/select/#overrides). Looking through the list of possible overrides, we see there is a promising `Tag` property.
 
-You might notice that the `MultiValue` component is just an instance of the `Tag` component. We can [reference the documentation for Tag](/components/tag/#overrides) to see what overrides are available.
+We can [reference the documentation for Tag](/components/tag/#overrides) to see what overrides are available.
 
 We have identified a nested Base Web component that is accessible via overrides. Now we can apply some nested overrides to customize things:
 
@@ -245,7 +245,7 @@ We have identified a nested Base Web component that is accessible via overrides.
 
 Notice the nested override pattern here:
 
-> StatefulSelect > overrides > MultiValue > props > overrides
+> StatefulSelect > overrides > Tag > props > overrides
 
 Once we have access to the nested `Tag`, we can override the styles for the `Root`, `Text`, `Action` & `ActionIcon`, changing the colors to a few lovely shades of purple.
 

--- a/src/select/__tests__/stateful-select.test.js
+++ b/src/select/__tests__/stateful-select.test.js
@@ -47,7 +47,7 @@ describe('Stateful select', function() {
         ValueContainer: StyledValueContainer,
         Placeholder: StyledPlaceholder,
         SingleValue: StyledSingleValue,
-        MultiValue: function MultiValueComponent({children}) {
+        Tag: function TagComponent({children}) {
           return <div>{children}</div>;
         },
         InputContainer: StyledInputContainer,

--- a/src/select/index.d.ts
+++ b/src/select/index.d.ts
@@ -54,6 +54,7 @@ export interface SelectOverrides {
   ValueContainer?: Override<any>;
   SingleValue?: Override<any>;
   MultiValue?: Override<any>;
+  Tag?: Override<any>;
   InputContainer?: Override<any>;
   Input?: Override<any>;
   IconsContainer?: Override<any>;

--- a/src/select/multi-value.js
+++ b/src/select/multi-value.js
@@ -12,7 +12,11 @@ import {Tag, VARIANT as TAG_VARIANT} from '../tag/index.js';
 // eslint-disable-next-line flowtype/no-weak-types
 export default function MultiValue(props: any) {
   const {overrides = {}, removeValue, ...restProps} = props;
-  const [MultiValue, multiValueProps] = getOverrides(overrides.MultiValue, Tag);
+  // todo(v10): remove the MultiValue override in favor of Tag
+  const [MultiValue, tagProps] = getOverrides(
+    overrides.Tag || overrides.MultiValue,
+    Tag,
+  );
   return (
     <MultiValue
       variant={TAG_VARIANT.solid}
@@ -28,7 +32,7 @@ export default function MultiValue(props: any) {
       }}
       onActionClick={removeValue}
       {...restProps}
-      {...multiValueProps}
+      {...tagProps}
     >
       {props.children}
     </MultiValue>

--- a/src/select/select-component.js
+++ b/src/select/select-component.js
@@ -656,7 +656,7 @@ class Select extends React.Component<PropsT, SelectStateT> {
             key={`value-${i}-${value[this.props.valueKey]}`}
             removeValue={() => this.removeValue(value)}
             disabled={disabled}
-            overrides={{MultiValue: overrides.MultiValue}}
+            overrides={{Tag: overrides.Tag, MultiValue: overrides.MultiValue}}
             {...sharedProps}
             $disabled={disabled}
           >

--- a/src/select/types.js
+++ b/src/select/types.js
@@ -44,6 +44,7 @@ export type OverridesT = {
   ValueContainer?: OverrideT,
   SingleValue?: OverrideT,
   MultiValue?: OverrideT,
+  Tag?: OverrideT,
   InputContainer?: OverrideT,
   Input?: OverrideT,
   IconsContainer?: OverrideT,


### PR DESCRIPTION
Historically, the name `MultiValue` seemed to confuse folks - `Tag` would be probably a better name, as it directly shows what underlying component is being overriden 