### PR TITLE
docs(typo): fix link to styletron's styled api

### DIFF
--- a/documentation-site/pages/components/styled.mdx
+++ b/documentation-site/pages/components/styled.mdx
@@ -23,7 +23,7 @@ export default Layout;
   the 'useStyletron' page for additional styletron-related information.
 </Notification>
 
-Base Web exports a modified version of [Styletron's](https://www.styletron.org/api/#styled) `styled` function.
+Base Web exports a modified version of [Styletron's](https://www.styletron.org/api-reference#styled) `styled` function.
 This modified version has access to [theme variables](/guides/theming/#theme-properties):
 
 ## Examples


### PR DESCRIPTION
#### Description

Noticed broken link to Styletron's `styled` function in [Styled](https://baseweb.design/components/styled/) docs:

❌ https://www.styletron.org/api/#styled
✅ https://www.styletron.org/api-reference#styled

#### Scope

- [x] Patch: Bug Fix


