### PR TITLE
feat(button): add Root alias for BaseButton

### DIFF
--- a/documentation-site/components/header-navigation.js
+++ b/documentation-site/components/header-navigation.js
@@ -108,7 +108,7 @@ export default function HeaderNavigation({
             size={SIZE.compact}
             kind={KIND.minimal}
             overrides={{
-              BaseButton: {
+              Root: {
                 style: {
                   display: 'none',
                   [mq(875)]: {
@@ -129,7 +129,7 @@ export default function HeaderNavigation({
             size={SIZE.compact}
             kind={KIND.minimal}
             overrides={{
-              BaseButton: {
+              Root: {
                 style: {
                   display: 'none',
                   [mq(1000)]: {
@@ -186,7 +186,7 @@ export default function HeaderNavigation({
           shape={SHAPE.square}
           title="Join our Slack channel"
           overrides={{
-            BaseButton: {
+            Root: {
               style: {
                 display: 'none',
                 [mq(500)]: {
@@ -210,7 +210,7 @@ export default function HeaderNavigation({
           shape={SHAPE.square}
           title="Open GitHub repository"
           overrides={{
-            BaseButton: {
+            Root: {
               style: {
                 display: 'none',
                 [mq(400)]: {
@@ -231,7 +231,7 @@ export default function HeaderNavigation({
           shape={SHAPE.square}
           title="Toggle direction"
           overrides={{
-            BaseButton: {
+            Root: {
               style: {
                 display: 'none',
                 [mq(450)]: {
@@ -256,7 +256,7 @@ export default function HeaderNavigation({
           shape={SHAPE.square}
           title="Toggle theme"
           overrides={{
-            BaseButton: {
+            Root: {
               style: {
                 display: 'flex',
               },
@@ -274,7 +274,7 @@ export default function HeaderNavigation({
           shape={SHAPE.square}
           title="Toggle navigation"
           overrides={{
-            BaseButton: {
+            Root: {
               style: {
                 display: 'flex',
                 [theme.mediaQuery.medium]: {

--- a/documentation-site/components/posts.js
+++ b/documentation-site/components/posts.js
@@ -79,7 +79,7 @@ const Index = () => {
                     rel="noreferrer noopener"
                     href={p.path}
                     overrides={{
-                      BaseButton: {
+                      Root: {
                         style: {boxSizing: 'border-box', width: '100%'},
                       },
                     }}

--- a/documentation-site/components/yard/action-buttons.tsx
+++ b/documentation-site/components/yard/action-buttons.tsx
@@ -66,7 +66,7 @@ const ActionButtons: React.FC<{
         </Button>
         <Button
           overrides={{
-            BaseButton: {
+            Root: {
               props: {
                 $as: 'a',
               },

--- a/documentation-site/components/yard/config/button.ts
+++ b/documentation-site/components/yard/config/button.ts
@@ -119,7 +119,7 @@ const ButtonConfig: TConfig = {
       description: 'Lets you customize all aspects of the component.',
       custom: {
         names: [
-          'BaseButton',
+          'Root',
           'EndEnhancer',
           'LoadingSpinner',
           'LoadingSpinnerContainer',

--- a/documentation-site/components/yard/config/card.ts
+++ b/documentation-site/components/yard/config/card.ts
@@ -27,7 +27,7 @@ const CardConfig: TConfig = {
   ornare faucibus ex, non facilisis nisl.
 </StyledBody>
 <StyledAction>
-<Button overrides={{BaseButton: {style: {width: '100%'}}}}>
+<Button overrides={{Root: {style: {width: '100%'}}}}>
   Button Label
 </Button>
 </StyledAction>`,

--- a/documentation-site/examples/aspect-ratio-box/calendar.js
+++ b/documentation-site/examples/aspect-ratio-box/calendar.js
@@ -11,7 +11,7 @@ const CalendarButton = props => (
   <Button
     kind={KIND.minimal}
     overrides={{
-      BaseButton: {
+      Root: {
         style: {
           paddingTop: 0,
           paddingRight: 0,

--- a/documentation-site/examples/aspect-ratio-box/calendar.tsx
+++ b/documentation-site/examples/aspect-ratio-box/calendar.tsx
@@ -10,7 +10,7 @@ const CalendarButton = (props: {children: React.ReactNode}) => (
   <Button
     kind={KIND.minimal}
     overrides={{
-      BaseButton: {
+      Root: {
         style: {
           paddingTop: 0,
           paddingRight: 0,

--- a/documentation-site/examples/card/image-cta.js
+++ b/documentation-site/examples/card/image-cta.js
@@ -14,7 +14,7 @@ export default () => (
       ornare faucibus ex, non facilisis nisl.
     </StyledBody>
     <StyledAction>
-      <Button overrides={{BaseButton: {style: {width: '100%'}}}}>
+      <Button overrides={{Root: {style: {width: '100%'}}}}>
         Button Label
       </Button>
     </StyledAction>

--- a/documentation-site/examples/card/image-cta.tsx
+++ b/documentation-site/examples/card/image-cta.tsx
@@ -13,7 +13,7 @@ export default () => (
       ornare faucibus ex, non facilisis nisl.
     </StyledBody>
     <StyledAction>
-      <Button overrides={{BaseButton: {style: {width: '100%'}}}}>
+      <Button overrides={{Root: {style: {width: '100%'}}}}>
         Button Label
       </Button>
     </StyledAction>

--- a/documentation-site/examples/card/thumbnail-cta.js
+++ b/documentation-site/examples/card/thumbnail-cta.js
@@ -21,7 +21,7 @@ export default () => (
       ornare faucibus ex, non facilisis nisl.
     </StyledBody>
     <StyledAction>
-      <Button overrides={{BaseButton: {style: {width: '100%'}}}}>
+      <Button overrides={{Root: {style: {width: '100%'}}}}>
         Button Label
       </Button>
     </StyledAction>

--- a/documentation-site/examples/card/thumbnail-cta.tsx
+++ b/documentation-site/examples/card/thumbnail-cta.tsx
@@ -20,7 +20,7 @@ export default () => (
       ornare faucibus ex, non facilisis nisl.
     </StyledBody>
     <StyledAction>
-      <Button overrides={{BaseButton: {style: {width: '100%'}}}}>
+      <Button overrides={{Root: {style: {width: '100%'}}}}>
         Button Label
       </Button>
     </StyledAction>

--- a/documentation-site/examples/drawer/anchors.js
+++ b/documentation-site/examples/drawer/anchors.js
@@ -23,7 +23,7 @@ export default () => {
               setIsOpen({...isOpen, [eachAnchor]: true})
             }
             overrides={{
-              BaseButton: {
+              Root: {
                 style: {
                   marginTop: '12px',
                   marginBottom: '12px',

--- a/documentation-site/examples/drawer/anchors.tsx
+++ b/documentation-site/examples/drawer/anchors.tsx
@@ -22,7 +22,7 @@ export default () => {
               setIsOpen({...isOpen, [eachAnchor]: true})
             }
             overrides={{
-              BaseButton: {
+              Root: {
                 style: {
                   marginTop: '12px',
                   marginBottom: '12px',

--- a/documentation-site/examples/drawer/sizes.js
+++ b/documentation-site/examples/drawer/sizes.js
@@ -21,7 +21,7 @@ export default () => {
           <Button
             onClick={() => setIsOpen({...isOpen, [eachSize]: true})}
             overrides={{
-              BaseButton: {
+              Root: {
                 style: {
                   marginTop: '12px',
                   marginBottom: '12px',

--- a/documentation-site/examples/drawer/sizes.tsx
+++ b/documentation-site/examples/drawer/sizes.tsx
@@ -20,7 +20,7 @@ export default () => {
           <Button
             onClick={() => setIsOpen({...isOpen, [eachSize]: true})}
             overrides={{
-              BaseButton: {
+              Root: {
                 style: {
                   marginTop: '12px',
                   marginBottom: '12px',

--- a/documentation-site/examples/overrides/component.js
+++ b/documentation-site/examples/overrides/component.js
@@ -9,7 +9,7 @@ function customButton(props) {
 export default () => (
   <Button
     overrides={{
-      BaseButton: customButton,
+      Root: customButton,
     }}
   >
     Submit

--- a/documentation-site/examples/overrides/component.tsx
+++ b/documentation-site/examples/overrides/component.tsx
@@ -4,7 +4,7 @@ import {Button} from 'baseui/button';
 export default () => (
   <Button
     overrides={{
-      BaseButton: props => <button>{props.children}</button>,
+      Root: props => <button>{props.children}</button>,
     }}
   >
     Submit

--- a/documentation-site/examples/overrides/props.js
+++ b/documentation-site/examples/overrides/props.js
@@ -5,7 +5,7 @@ import {Button} from 'baseui/button';
 export default () => (
   <Button
     overrides={{
-      BaseButton: {
+      Root: {
         props: {
           'data-test': 'action-button',
         },

--- a/documentation-site/examples/overrides/props.tsx
+++ b/documentation-site/examples/overrides/props.tsx
@@ -4,7 +4,7 @@ import {Button} from 'baseui/button';
 export default () => (
   <Button
     overrides={{
-      BaseButton: {
+      Root: {
         props: {
           'data-test': 'action-button',
         },

--- a/documentation-site/examples/overrides/style-with-theme.js
+++ b/documentation-site/examples/overrides/style-with-theme.js
@@ -5,7 +5,7 @@ import {Button} from 'baseui/button';
 export default () => (
   <Button
     overrides={{
-      BaseButton: {
+      Root: {
         style: ({$theme}) => ({
           backgroundColor: $theme.colors.warning,
         }),

--- a/documentation-site/examples/overrides/style-with-theme.tsx
+++ b/documentation-site/examples/overrides/style-with-theme.tsx
@@ -4,7 +4,7 @@ import {Button} from 'baseui/button';
 export default () => (
   <Button
     overrides={{
-      BaseButton: {
+      Root: {
         style: ({$theme}) => ({
           backgroundColor: $theme.colors.warning,
         }),

--- a/documentation-site/examples/overrides/style.js
+++ b/documentation-site/examples/overrides/style.js
@@ -5,7 +5,7 @@ import {Button} from 'baseui/button';
 export default () => (
   <Button
     overrides={{
-      BaseButton: {
+      Root: {
         style: {
           backgroundColor: 'red',
         },

--- a/documentation-site/examples/overrides/style.tsx
+++ b/documentation-site/examples/overrides/style.tsx
@@ -4,7 +4,7 @@ import {Button} from 'baseui/button';
 export default () => (
   <Button
     overrides={{
-      BaseButton: {
+      Root: {
         style: {
           backgroundColor: 'red',
         },

--- a/documentation-site/examples/progress-steps/dotted.js
+++ b/documentation-site/examples/progress-steps/dotted.js
@@ -10,7 +10,7 @@ function SpacedButton(props) {
     <Button
       {...props}
       overrides={{
-        BaseButton: {
+        Root: {
           style: ({$theme}) => ({
             marginLeft: $theme.sizing.scale200,
             marginRight: $theme.sizing.scale200,

--- a/documentation-site/examples/progress-steps/dotted.tsx
+++ b/documentation-site/examples/progress-steps/dotted.tsx
@@ -9,7 +9,7 @@ function SpacedButton(props: ButtonProps) {
     <Button
       {...props}
       overrides={{
-        BaseButton: {
+        Root: {
           style: ({$theme}) => ({
             marginLeft: $theme.sizing.scale200,
             marginRight: $theme.sizing.scale200,

--- a/documentation-site/examples/progress-steps/numbered.js
+++ b/documentation-site/examples/progress-steps/numbered.js
@@ -9,7 +9,7 @@ function SpacedButton(props) {
     <Button
       {...props}
       overrides={{
-        BaseButton: {
+        Root: {
           style: ({$theme}) => ({
             marginLeft: $theme.sizing.scale200,
             marginRight: $theme.sizing.scale200,

--- a/documentation-site/examples/progress-steps/numbered.tsx
+++ b/documentation-site/examples/progress-steps/numbered.tsx
@@ -8,7 +8,7 @@ function SpacedButton(props: ButtonProps) {
     <Button
       {...props}
       overrides={{
-        BaseButton: {
+        Root: {
           style: ({$theme}) => ({
             marginLeft: $theme.sizing.scale200,
             marginRight: $theme.sizing.scale200,

--- a/documentation-site/examples/use-styletron/overrides.js
+++ b/documentation-site/examples/use-styletron/overrides.js
@@ -9,7 +9,7 @@ export default () => {
     <Button
       disabled
       overrides={{
-        BaseButton: props => {
+        Root: props => {
           return (
             <button
               disabled={props.disabled}

--- a/documentation-site/examples/use-styletron/overrides.tsx
+++ b/documentation-site/examples/use-styletron/overrides.tsx
@@ -8,7 +8,7 @@ export default () => {
     <Button
       disabled
       overrides={{
-        BaseButton: props => {
+        Root: props => {
           return (
             <button
               disabled={props.disabled}

--- a/documentation-site/pages/index.js
+++ b/documentation-site/pages/index.js
@@ -138,7 +138,7 @@ const Index = (props: {
           $as="a"
           href="/getting-started/setup"
           overrides={{
-            BaseButton: {
+            Root: {
               style: ({$theme}) => ({
                 boxSizing: 'border-box',
                 width: '100%',
@@ -160,7 +160,7 @@ const Index = (props: {
           $as="a"
           href="/getting-started/learn"
           overrides={{
-            BaseButton: {
+            Root: {
               style: ({$theme}) => ({
                 boxSizing: 'border-box',
                 width: '100%',

--- a/packages/baseui-codemods/src/v9-theme-scale.test.js
+++ b/packages/baseui-codemods/src/v9-theme-scale.test.js
@@ -123,9 +123,9 @@ describe('shift theme usage for fonts', () => {
     });
 
     it('override style function', async () => {
-      const content = `const Foo = <Button overrides={{ BaseButton: { style: ({$theme}) => ({ ...$theme.typography.font200 })}}}>Foo</Button>`;
+      const content = `const Foo = <Button overrides={{ Root: { style: ({$theme}) => ({ ...$theme.typography.font200 })}}}>Foo</Button>`;
       expect(await transform(content)).toMatchInlineSnapshot(
-        `"const Foo = <Button overrides={{ BaseButton: { style: ({$theme}) => ({ ...$theme.typography.font100 })}}}>Foo</Button>"`,
+        `"const Foo = <Button overrides={{ Root: { style: ({$theme}) => ({ ...$theme.typography.font100 })}}}>Foo</Button>"`,
       );
     });
 

--- a/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
+++ b/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
@@ -275,12 +275,12 @@ const tests = {
     // Button is aliased
     {
       code: `
-        import { Button as BaseButton } from "baseui/button"
+        import { Button as Root } from "baseui/button"
         export default () => {
           return (
-            <BaseButton kind="minimal">
+            <Root kind="minimal">
               Hello
-            </BaseButton>
+            </Root>
           )
         }
       `,

--- a/src/app-nav-bar/mobile-menu/mobile-nav.js
+++ b/src/app-nav-bar/mobile-menu/mobile-nav.js
@@ -24,7 +24,7 @@ export default function MobileNav(props: AppNavBarPropsT) {
   return (
     <>
       <Button
-        overrides={{BaseButton: {component: StyledSideMenuButton}}}
+        overrides={{Root: {component: StyledSideMenuButton}}}
         onClick={toggleMenu}
       >
         <MenuIcon size={'24px'} />

--- a/src/app-nav-bar/user-menu/user-menu.js
+++ b/src/app-nav-bar/user-menu/user-menu.js
@@ -34,7 +34,7 @@ export default function UserMenu(props: AppNavBarPropsT) {
       popperOptions={{modifiers: {flip: {enabled: false}}}}
       triggerType={TRIGGER_TYPE.click}
     >
-      <Button overrides={{BaseButton: {component: StyledUserMenuButton}}}>
+      <Button overrides={{Root: {component: StyledUserMenuButton}}}>
         <Avatar name={username || ''} src={userImgUrl} size={'32px'} />
         {isOpen ? (
           <ChevronUpSmallFilled

--- a/src/button-group/__tests__/button-group-overrides.scenario.js
+++ b/src/button-group/__tests__/button-group-overrides.scenario.js
@@ -12,7 +12,7 @@ import {Button} from '../../button/index.js';
 import {StatefulButtonGroup, MODE} from '../index.js';
 
 const buttonOverrides = {
-  BaseButton: {
+  Root: {
     style: ({$isSelected}) => {
       if ($isSelected)
         return {

--- a/src/button-group/button-group.js
+++ b/src/button-group/button-group.js
@@ -114,7 +114,7 @@ export class ButtonGroupRoot extends React.Component<{|
             shape,
             size,
             overrides: {
-              BaseButton: {
+              Root: {
                 style: () => {
                   // Even though baseui's buttons have square corners, some applications override to
                   // rounded. Maintaining corner radius in this circumstance is ideal to avoid further

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -64,8 +64,8 @@ class Button extends React.Component<
       ...restProps
     } = this.props;
     // Get overrides
-    const [BaseButton, baseButtonProps] = getOverrides(
-      overrides.BaseButton,
+    const [Root, rootProps] = getOverrides(
+      overrides.BaseButton || overrides.Root,
       StyledBaseButton,
     );
     const [LoadingSpinner, loadingSpinnerProps] = getOverrides(
@@ -84,7 +84,7 @@ class Button extends React.Component<
       $isFocusVisible: this.state.isFocusVisible,
     };
     return (
-      <BaseButton
+      <Root
         ref={forwardedRef}
         data-baseweb="button"
         {...(isLoading
@@ -101,14 +101,11 @@ class Button extends React.Component<
           : {})}
         {...sharedProps}
         {...restProps}
-        {...baseButtonProps}
+        {...rootProps}
         // Applies last to override passed in onClick
         onClick={this.internalOnClick}
-        onFocus={forkFocus(
-          {...restProps, ...baseButtonProps},
-          this.handleFocus,
-        )}
-        onBlur={forkBlur({...restProps, ...baseButtonProps}, this.handleBlur)}
+        onFocus={forkFocus({...restProps, ...rootProps}, this.handleFocus)}
+        onBlur={forkBlur({...restProps, ...rootProps}, this.handleBlur)}
       >
         {isLoading ? (
           <React.Fragment>
@@ -126,7 +123,7 @@ class Button extends React.Component<
         ) : (
           <ButtonInternals {...this.props} />
         )}
-      </BaseButton>
+      </Root>
     );
   }
 }

--- a/src/button/index.d.ts
+++ b/src/button/index.d.ts
@@ -28,6 +28,7 @@ export interface SHAPE {
 }
 
 export interface ButtonOverrides {
+  Root?: Override<any>;
   BaseButton?: Override<any>;
   StartEnhancer?: Override<any>;
   EndEnhancer?: Override<any>;
@@ -53,6 +54,7 @@ export interface ButtonProps
   type?: 'submit' | 'reset' | 'button';
 }
 
+export const StyledRoot: StyletronComponent<any>;
 export const StyledBaseButton: StyletronComponent<any>;
 export const StyledStartEnhancer: StyletronComponent<any>;
 export const StyledEndEnhancer: StyletronComponent<any>;

--- a/src/button/index.js
+++ b/src/button/index.js
@@ -10,6 +10,7 @@ export {default as Button} from './button.js';
 export {KIND, SIZE, SHAPE} from './constants.js';
 // Styled elements
 export {
+  BaseButton as StyledRoot,
   BaseButton as StyledBaseButton,
   StartEnhancer as StyledStartEnhancer,
   EndEnhancer as StyledEndEnhancer,

--- a/src/button/types.js
+++ b/src/button/types.js
@@ -11,6 +11,7 @@ import {KIND, SIZE, SHAPE} from './constants.js';
 import type {OverrideT} from '../helpers/overrides.js';
 
 export type OverridesT = {
+  Root?: OverrideT,
   BaseButton?: OverrideT,
   StartEnhancer?: OverrideT,
   EndEnhancer?: OverrideT,

--- a/src/data-table/column-datetime.js
+++ b/src/data-table/column-datetime.js
@@ -319,16 +319,10 @@ function DatetimeFilter(props) {
             },
           }}
         >
-          <Button
-            type="button"
-            overrides={{BaseButton: {style: {width: '100%'}}}}
-          >
+          <Button type="button" overrides={{Root: {style: {width: '100%'}}}}>
             Range
           </Button>
-          <Button
-            type="button"
-            overrides={{BaseButton: {style: {width: '100%'}}}}
-          >
+          <Button type="button" overrides={{Root: {style: {width: '100%'}}}}>
             Categorical
           </Button>
         </ButtonGroup>

--- a/src/data-table/column-numerical.js
+++ b/src/data-table/column-numerical.js
@@ -325,16 +325,10 @@ function NumericalFilter(props) {
           },
         }}
       >
-        <Button
-          type="button"
-          overrides={{BaseButton: {style: {width: '100%'}}}}
-        >
+        <Button type="button" overrides={{Root: {style: {width: '100%'}}}}>
           Range
         </Button>
-        <Button
-          type="button"
-          overrides={{BaseButton: {style: {width: '100%'}}}}
-        >
+        <Button type="button" overrides={{Root: {style: {width: '100%'}}}}>
           Single Value
         </Button>
       </ButtonGroup>
@@ -351,34 +345,19 @@ function NumericalFilter(props) {
             },
           }}
         >
-          <Button
-            type="button"
-            overrides={{BaseButton: {style: {width: '100%'}}}}
-          >
+          <Button type="button" overrides={{Root: {style: {width: '100%'}}}}>
             &#60;
           </Button>
-          <Button
-            type="button"
-            overrides={{BaseButton: {style: {width: '100%'}}}}
-          >
+          <Button type="button" overrides={{Root: {style: {width: '100%'}}}}>
             &#62;
           </Button>
-          <Button
-            type="button"
-            overrides={{BaseButton: {style: {width: '100%'}}}}
-          >
+          <Button type="button" overrides={{Root: {style: {width: '100%'}}}}>
             &#8804;
           </Button>
-          <Button
-            type="button"
-            overrides={{BaseButton: {style: {width: '100%'}}}}
-          >
+          <Button type="button" overrides={{Root: {style: {width: '100%'}}}}>
             &#8805;
           </Button>
-          <Button
-            type="button"
-            overrides={{BaseButton: {style: {width: '100%'}}}}
-          >
+          <Button type="button" overrides={{Root: {style: {width: '100%'}}}}>
             &#61;
           </Button>
         </ButtonGroup>

--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -600,7 +600,7 @@ const InnerTableElement = React.forwardRef<
                   kind={BUTTON_KINDS.minimal}
                   shape={BUTTON_SHAPES.round}
                   overrides={{
-                    BaseButton: {
+                    Root: {
                       style: {marginLeft: theme.sizing.scale300},
                     },
                   }}

--- a/src/data-table/filter-menu.js
+++ b/src/data-table/filter-menu.js
@@ -311,7 +311,7 @@ function FilterMenu(props: PropsT) {
         shape={SHAPE.pill}
         size={SIZE.compact}
         overrides={{
-          BaseButton: {
+          Root: {
             style: {
               marginLeft: theme.sizing.scale500,
               marginBottom: theme.sizing.scale500,

--- a/src/data-table/stateful-data-table.js
+++ b/src/data-table/stateful-data-table.js
@@ -256,7 +256,7 @@ export function Unstable_StatefulDataTable(props: StatefulDataTablePropsT) {
                         <Button
                           key={action.label}
                           overrides={{
-                            BaseButton: {props: {'aria-label': action.label}},
+                            Root: {props: {'aria-label': action.label}},
                           }}
                           onClick={onClick}
                           kind={BUTTON_KINDS.tertiary}

--- a/src/drawer/__tests__/drawer-render-all.scenario.js
+++ b/src/drawer/__tests__/drawer-render-all.scenario.js
@@ -16,7 +16,7 @@ function Example() {
       <Button
         onClick={() => setIsOpen(true)}
         overrides={{
-          BaseButton: {
+          Root: {
             props: {
               'data-e2e': 'open-drawer-button',
             },

--- a/src/drawer/__tests__/drawer.scenario.js
+++ b/src/drawer/__tests__/drawer.scenario.js
@@ -16,7 +16,7 @@ function Example() {
       <Button
         onClick={() => setIsOpen(true)}
         overrides={{
-          BaseButton: {
+          Root: {
             props: {
               'data-e2e': 'open-drawer-button',
             },

--- a/src/file-uploader/file-uploader.js
+++ b/src/file-uploader/file-uploader.js
@@ -121,7 +121,7 @@ function FileUploader(props: PropsT) {
                         kind={KIND.minimal}
                         onClick={open}
                         overrides={{
-                          BaseButton: {
+                          Root: {
                             style: {fontWeight: 'normal'},
                           },
                         }}
@@ -186,7 +186,7 @@ function FileUploader(props: PropsT) {
                           aria-describedby={props['aria-describedby']}
                           aria-errormessage={props.errorMessage}
                           overrides={{
-                            BaseButton: {
+                            Root: {
                               style: {outline: null, fontWeight: 'normal'},
                             },
                           }}
@@ -201,7 +201,7 @@ function FileUploader(props: PropsT) {
                           }}
                           aria-describedby={props['aria-describedby']}
                           overrides={{
-                            BaseButton: {
+                            Root: {
                               style: {outline: null, fontWeight: 'normal'},
                             },
                           }}

--- a/src/modal/__tests__/modal-button.test.js
+++ b/src/modal/__tests__/modal-button.test.js
@@ -18,7 +18,7 @@ const mockTheme = createMockTheme(LightTheme);
 
 describe('ModalButton', () => {
   test('renders modal button with correct styles', () => {
-    const overrides = {BaseButton: {style: {color: 'red'}}};
+    const overrides = {Root: {style: {color: 'red'}}};
     const wrapper = shallow(
       <ModalButton kind={KIND.tertiary} overrides={overrides}>
         Hello World
@@ -30,7 +30,7 @@ describe('ModalButton', () => {
     expect(button).toHaveProp('kind', KIND.tertiary);
 
     const mergedOverrides = button.prop('overrides');
-    const result = mergedOverrides.BaseButton.style({$theme: mockTheme});
+    const result = mergedOverrides.Root.style({$theme: mockTheme});
     expect(result).toEqual({
       color: 'red',
       ':nth-last-child(n+2)': {

--- a/src/modal/modal-button.js
+++ b/src/modal/modal-button.js
@@ -13,7 +13,7 @@ import {mergeOverrides} from '../helpers/overrides.js';
 
 // ModalButtons should have some margin pre-applied
 const overrides = {
-  BaseButton: {
+  Root: {
     style: ({$theme}) => {
       const marginInlineEnd: string =
         $theme.direction !== 'rtl' ? 'marginRight' : 'marginLeft';

--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -144,7 +144,7 @@ export default class Pagination extends React.PureComponent<
                   }}
                   kind={KIND.tertiary}
                   overrides={{
-                    BaseButton: overrides.PrevButton,
+                    Root: overrides.PrevButton,
                   }}
                   size={size}
                 >
@@ -247,7 +247,7 @@ export default class Pagination extends React.PureComponent<
                   }}
                   kind={KIND.tertiary}
                   overrides={{
-                    BaseButton: overrides.NextButton,
+                    Root: overrides.NextButton,
                   }}
                   size={size}
                 >


### PR DESCRIPTION
All other components have a `Root` overrides - this PR ensures consistency across components