### PR TITLE
fix(alpha-publish): correct root_dir in publish script

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,154 +8,151 @@ steps:
         env: DOCKER_BUILDKIT=1
     agents:
       queue: builders
-  - name: ':docker: :package: e2e'
-    plugins:
-      'docker-compose#v3.0.3':
-        build:
-          - e2e-test
-          - e2e-server
-          - e2e-server-healthy
-        image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
-        env: DOCKER_BUILDKIT=1
-    agents:
-      queue: builders
+
+  # - name: ':docker: :package: e2e'
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       build:
+  #         - e2e-test
+  #         - e2e-server
+  #         - e2e-server-healthy
+  #       image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
+  #       env: DOCKER_BUILDKIT=1
+  #   agents:
+  #     queue: builders
+
   # Wait until all images are built.
   # This way we can download the built image from a registry instead of building each for each test task.
   - wait
+
   # All of the commands after the wait are run in parallel.
-  - name: validate-examples
-    command: yarn validate:examples
-    plugins:
-      'docker-compose#v3.0.3':
-        run: baseui
-    agents:
-      queue: workers
+  # - name: validate-examples
+  #   command: yarn validate:examples
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: baseui
+  #   agents:
+  #     queue: workers
 
-  - name: ':typescript:'
-    command: yarn tsc
-    plugins:
-      'docker-compose#v3.0.3':
-        run: baseui
-    agents:
-      queue: workers
+  # - name: ':typescript:'
+  #   command: yarn tsc
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: baseui
+  #   agents:
+  #     queue: workers
 
-  - name: ':eslint:'
-    command: yarn lint
-    plugins:
-      'docker-compose#v3.0.3':
-        run: baseui
-    agents:
-      queue: workers
+  # - name: ':eslint:'
+  #   command: yarn lint
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: baseui
+  #   agents:
+  #     queue: workers
 
-  - name: ':flowtype:'
-    command: yarn flow check
-    plugins:
-      'docker-compose#v3.0.3':
-        run: baseui
-    agents:
-      queue: workers
+  # - name: ':flowtype:'
+  #   command: yarn flow check
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: baseui
+  #   agents:
+  #     queue: workers
 
-  - name: ':jest:'
-    command: yarn unit-test
-    plugins:
-      'docker-compose#v3.0.3':
-        run: baseui
-    agents:
-      queue: workers
+  # - name: ':jest:'
+  #   command: yarn unit-test
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: baseui
+  #   agents:
+  #     queue: workers
 
-  - name: fossa
-    command: 'curl https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash && fossa'
-    plugins:
-      'docker-compose#v3.0.3':
-        run: baseui
-    agents:
-      queue: workers
+  # - name: fossa
+  #   command: 'curl https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash && fossa'
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: baseui
+  #   agents:
+  #     queue: workers
 
-  - name: deploy-npm-latest
-    command: 'TAG=latest node scripts/publish-to-npm.js'
-    if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
-    plugins:
-      'docker-compose#v3.0.3':
-        run: baseui
-    agents:
-      queue: workers
+  # - name: deploy-npm-latest
+  #   command: 'TAG=latest node scripts/publish-to-npm.js'
+  #   if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: baseui
+  #   agents:
+  #     queue: workers
 
   - name: deploy-npm-alpha
     command: 'GIT_COMMIT=$BUILDKITE_COMMIT TAG=alpha node scripts/publish-to-npm.js'
-    if: build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
+    # commenting out for testing purposes
+    # if: build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
     plugins:
       'docker-compose#v3.0.3':
         run: baseui
     agents:
       queue: workers
-
-  - name: deploy-vscode
-    command: './deploy-vscode.sh'
-    if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
-    plugins:
-      'docker-compose#v3.0.3':
-        run: baseui
-    agents:
-      queue: workers
-
-  - name: deploy-versioned-docs
-    command: './deploy-versioned-docs.sh'
-    if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
-    plugins:
-      'docker-compose#v3.0.3':
-        run: baseui
-    agents:
-      queue: workers
-
-  - name: create-github-release
-    command: './scripts/github-release.js'
-    if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
-    plugins:
-      'docker-compose#v3.0.3':
-        run: baseui
-    agents:
-      queue: workers
-
-  - name: guard-component-sizes
-    command: './scripts/component-sizes.js'
-    plugins:
-      'docker-compose#v3.0.3':
-        run: baseui
-    agents:
-      queue: workers
-
-  - name: e2e
-    # we have to install puppeteer here to trigger the install.js script
-    # and also to make sure we do not add this to the released build artifact
-    command: yarn add puppeteer && yarn e2e:test:ci
-    artifact_paths:
-      - '__artifacts__/*.png'
-    plugins:
-      'docker-compose#v3.0.3':
-        run: e2e-test
-        pull:
-          - e2e-server
-          - e2e-server-healthy
-    agents:
-      queue: workers
-
-  - name: vrt
-    command: yarn vrt:ci
-    artifact_paths:
-      - '__artifacts__/*.png'
-    plugins:
-      'docker-compose#v3.0.3':
-        run: e2e-test
-        pull:
-          - e2e-server
-          - e2e-server-healthy
-    agents:
-      queue: workers
-
-  - name: flow-check-build
-    command: ./scripts/flow-check-build.js
-    plugins:
-      'docker-compose#v3.0.3':
-        run: baseui
-    agents:
-      queue: workers
+  # - name: deploy-vscode
+  #   command: './deploy-vscode.sh'
+  #   if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: baseui
+  #   agents:
+  #     queue: workers
+  # - name: deploy-versioned-docs
+  #   command: './deploy-versioned-docs.sh'
+  #   if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: baseui
+  #   agents:
+  #     queue: workers
+  # - name: create-github-release
+  #   command: './scripts/github-release.js'
+  #   if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: baseui
+  #   agents:
+  #     queue: workers
+  # - name: guard-component-sizes
+  #   command: './scripts/component-sizes.js'
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: baseui
+  #   agents:
+  #     queue: workers
+  # - name: e2e
+  #   # we have to install puppeteer here to trigger the install.js script
+  #   # and also to make sure we do not add this to the released build artifact
+  #   command: yarn add puppeteer && yarn e2e:test:ci
+  #   artifact_paths:
+  #     - '__artifacts__/*.png'
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: e2e-test
+  #       pull:
+  #         - e2e-server
+  #         - e2e-server-healthy
+  #   agents:
+  #     queue: workers
+  # - name: vrt
+  #   command: yarn vrt:ci
+  #   artifact_paths:
+  #     - '__artifacts__/*.png'
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: e2e-test
+  #       pull:
+  #         - e2e-server
+  #         - e2e-server-healthy
+  #   agents:
+  #     queue: workers
+  # - name: flow-check-build
+  #   command: ./scripts/flow-check-build.js
+  #   plugins:
+  #     'docker-compose#v3.0.3':
+  #       run: baseui
+  #   agents:
+  #     queue: workers

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,151 +8,154 @@ steps:
         env: DOCKER_BUILDKIT=1
     agents:
       queue: builders
-
-  # - name: ':docker: :package: e2e'
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       build:
-  #         - e2e-test
-  #         - e2e-server
-  #         - e2e-server-healthy
-  #       image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
-  #       env: DOCKER_BUILDKIT=1
-  #   agents:
-  #     queue: builders
-
+  - name: ':docker: :package: e2e'
+    plugins:
+      'docker-compose#v3.0.3':
+        build:
+          - e2e-test
+          - e2e-server
+          - e2e-server-healthy
+        image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
+        env: DOCKER_BUILDKIT=1
+    agents:
+      queue: builders
   # Wait until all images are built.
   # This way we can download the built image from a registry instead of building each for each test task.
   - wait
-
   # All of the commands after the wait are run in parallel.
-  # - name: validate-examples
-  #   command: yarn validate:examples
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: baseui
-  #   agents:
-  #     queue: workers
-
-  # - name: ':typescript:'
-  #   command: yarn tsc
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: baseui
-  #   agents:
-  #     queue: workers
-
-  # - name: ':eslint:'
-  #   command: yarn lint
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: baseui
-  #   agents:
-  #     queue: workers
-
-  # - name: ':flowtype:'
-  #   command: yarn flow check
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: baseui
-  #   agents:
-  #     queue: workers
-
-  # - name: ':jest:'
-  #   command: yarn unit-test
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: baseui
-  #   agents:
-  #     queue: workers
-
-  # - name: fossa
-  #   command: 'curl https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash && fossa'
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: baseui
-  #   agents:
-  #     queue: workers
-
-  # - name: deploy-npm-latest
-  #   command: 'TAG=latest node scripts/publish-to-npm.js'
-  #   if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: baseui
-  #   agents:
-  #     queue: workers
-
-  - name: deploy-npm-alpha
-    command: 'GIT_COMMIT=$BUILDKITE_COMMIT TAG=alpha node scripts/publish-to-npm.js'
-    # commenting out for testing purposes
-    # if: build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
+  - name: validate-examples
+    command: yarn validate:examples
     plugins:
       'docker-compose#v3.0.3':
         run: baseui
     agents:
       queue: workers
-  # - name: deploy-vscode
-  #   command: './deploy-vscode.sh'
-  #   if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: baseui
-  #   agents:
-  #     queue: workers
-  # - name: deploy-versioned-docs
-  #   command: './deploy-versioned-docs.sh'
-  #   if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: baseui
-  #   agents:
-  #     queue: workers
-  # - name: create-github-release
-  #   command: './scripts/github-release.js'
-  #   if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: baseui
-  #   agents:
-  #     queue: workers
-  # - name: guard-component-sizes
-  #   command: './scripts/component-sizes.js'
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: baseui
-  #   agents:
-  #     queue: workers
-  # - name: e2e
-  #   # we have to install puppeteer here to trigger the install.js script
-  #   # and also to make sure we do not add this to the released build artifact
-  #   command: yarn add puppeteer && yarn e2e:test:ci
-  #   artifact_paths:
-  #     - '__artifacts__/*.png'
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: e2e-test
-  #       pull:
-  #         - e2e-server
-  #         - e2e-server-healthy
-  #   agents:
-  #     queue: workers
-  # - name: vrt
-  #   command: yarn vrt:ci
-  #   artifact_paths:
-  #     - '__artifacts__/*.png'
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: e2e-test
-  #       pull:
-  #         - e2e-server
-  #         - e2e-server-healthy
-  #   agents:
-  #     queue: workers
-  # - name: flow-check-build
-  #   command: ./scripts/flow-check-build.js
-  #   plugins:
-  #     'docker-compose#v3.0.3':
-  #       run: baseui
-  #   agents:
-  #     queue: workers
+
+  - name: ':typescript:'
+    command: yarn tsc
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers
+
+  - name: ':eslint:'
+    command: yarn lint
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers
+
+  - name: ':flowtype:'
+    command: yarn flow check
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers
+
+  - name: ':jest:'
+    command: yarn unit-test
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers
+
+  - name: fossa
+    command: 'curl https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash && fossa'
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers
+
+  - name: deploy-npm-latest
+    command: 'TAG=latest node scripts/publish-to-npm.js'
+    if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers
+
+  - name: deploy-npm-alpha
+    command: 'GIT_COMMIT=$BUILDKITE_COMMIT TAG=alpha node scripts/publish-to-npm.js'
+    if: build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers
+
+  - name: deploy-vscode
+    command: './deploy-vscode.sh'
+    if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers
+
+  - name: deploy-versioned-docs
+    command: './deploy-versioned-docs.sh'
+    if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers
+
+  - name: create-github-release
+    command: './scripts/github-release.js'
+    if: build.branch == "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers
+
+  - name: guard-component-sizes
+    command: './scripts/component-sizes.js'
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers
+
+  - name: e2e
+    # we have to install puppeteer here to trigger the install.js script
+    # and also to make sure we do not add this to the released build artifact
+    command: yarn add puppeteer && yarn e2e:test:ci
+    artifact_paths:
+      - '__artifacts__/*.png'
+    plugins:
+      'docker-compose#v3.0.3':
+        run: e2e-test
+        pull:
+          - e2e-server
+          - e2e-server-healthy
+    agents:
+      queue: workers
+
+  - name: vrt
+    command: yarn vrt:ci
+    artifact_paths:
+      - '__artifacts__/*.png'
+    plugins:
+      'docker-compose#v3.0.3':
+        run: e2e-test
+        pull:
+          - e2e-server
+          - e2e-server-healthy
+    agents:
+      queue: workers
+
+  - name: flow-check-build
+    command: ./scripts/flow-check-build.js
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
+    agents:
+      queue: workers

--- a/scripts/publish-to-npm.js
+++ b/scripts/publish-to-npm.js
@@ -85,6 +85,9 @@ function main() {
     );
   }
 
+  console.log('*********');
+  console.log(__dirname, process.cwd());
+
   if (tag === ALPHA_TAG) {
     console.log('--- Updating package.json version to alpha.');
     const commitHash = process.env.GIT_COMMIT;

--- a/scripts/publish-to-npm.js
+++ b/scripts/publish-to-npm.js
@@ -14,7 +14,7 @@ const fs = require('fs');
 const path = require('path');
 const {spawnSync} = require('child_process');
 
-const ROOT_DIR = path.resolve(__dirname, '..', '..');
+const ROOT_DIR = path.resolve(__dirname, '..');
 const ESLINT_PLUGIN_DIR = path.resolve(
   ROOT_DIR,
   'packages',
@@ -35,6 +35,7 @@ function writeNpmTokenFromEnv() {
 }
 
 function readJSONFile(filepath) {
+  console.log('provided to readjsonfile fn', filepath);
   const contents = fs.readFileSync(filepath, 'utf8');
   return JSON.parse(contents);
 }
@@ -95,6 +96,7 @@ function main() {
       throw new Error('No GIT_COMMIT environment variable set.');
     }
     const packageJSONPath = path.resolve(ROOT_DIR, 'package.json');
+    console.log('path', packageJSONPath);
     const packageJSON = readJSONFile(packageJSONPath);
     const shortHash = commitHash.slice(-7);
     packageJSON.version = `0.0.0-alpha-${shortHash}`;

--- a/scripts/publish-to-npm.js
+++ b/scripts/publish-to-npm.js
@@ -35,7 +35,6 @@ function writeNpmTokenFromEnv() {
 }
 
 function readJSONFile(filepath) {
-  console.log('provided to readjsonfile fn', filepath);
   const contents = fs.readFileSync(filepath, 'utf8');
   return JSON.parse(contents);
 }
@@ -86,9 +85,6 @@ function main() {
     );
   }
 
-  console.log('*********');
-  console.log(__dirname, process.cwd());
-
   if (tag === ALPHA_TAG) {
     console.log('--- Updating package.json version to alpha.');
     const commitHash = process.env.GIT_COMMIT;
@@ -96,7 +92,6 @@ function main() {
       throw new Error('No GIT_COMMIT environment variable set.');
     }
     const packageJSONPath = path.resolve(ROOT_DIR, 'package.json');
-    console.log('path', packageJSONPath);
     const packageJSON = readJSONFile(packageJSONPath);
     const shortHash = commitHash.slice(-7);
     packageJSON.version = `0.0.0-alpha-${shortHash}`;

--- a/scripts/sync-package-versions.js
+++ b/scripts/sync-package-versions.js
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2018-2020 Uber Technologies, Inc.
+
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */

--- a/scripts/sync-package-versions.js
+++ b/scripts/sync-package-versions.js
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2018-2020 Uber Technologies, Inc.
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+// Sets local package.json to current baseui version.
+
+/* eslint-env node */
+// @flow
+
+const fs = require('fs');
+const baseuiVersion = require('../package.json').version;
+
+const packageJsonToUpdate = process.argv[2];
+
+const packageJSON = fs.readFileSync(packageJsonToUpdate, 'utf-8');
+const packageJSONBumped = packageJSON.replace(
+  '"version": "0.0.0"',
+  `"version": "${baseuiVersion}"`,
+);
+fs.writeFileSync(packageJsonToUpdate, packageJSONBumped, 'utf-8');


### PR DESCRIPTION
I moved some files around before putting up the last pr and broke the script. This PR also restores the package.json sync file that's used in the vs-code extension release process