### PR TITLE
test: fix possible e2e screenshot issue

### DIFF
--- a/jest.e2e.setup.js
+++ b/jest.e2e.setup.js
@@ -18,7 +18,15 @@ global.it = async function(name, func, timeout) {
         await func();
       } catch (e) {
         mkdirp.sync('__artifacts__');
-        await page.screenshot({path: `__artifacts__/${name}.png`});
+        try {
+          await page.screenshot({
+            type: 'png',
+            path: `__artifacts__/${name}.png`,
+          });
+        } catch (er) {
+          console.log('There was an issue taking a test failure screenshot.');
+          console.log(er);
+        }
         if (process.env.CI) {
           console.log(
             `\u001B]1338;url="artifact://__artifacts__/${name}.png";alt="Screenshot"\u0007`,


### PR DESCRIPTION
If the screenshot errors it hides the true error in the test. This PR adds a try/catch to make sure the real error gets out. Also adds `type: 'png'` to avoid mime type lookups. For some reason this can fail so let's just avoid that situation.