### PR TITLE
fix(form-control): don't pass non-DOM props to DOM children

### DIFF
--- a/src/form-control/form-control.js
+++ b/src/form-control/form-control.js
@@ -40,8 +40,6 @@ export default class FormControl extends React.Component<
     overrides: {},
     label: null,
     caption: null,
-    error: false,
-    positive: false,
     disabled: false,
   };
   state = {captionId: getBuiId()};

--- a/src/form-control/types.js
+++ b/src/form-control/types.js
@@ -29,9 +29,9 @@ export type FormControlPropsT = {
   /** Displays label in light gray color if true */
   disabled?: boolean,
   /** Error state of the input. If an error prop passed it will be rendered in place of caption as an error message. */
-  error: React.Node | ((props: {}) => React.Node),
+  error?: React.Node | ((props: {}) => React.Node),
   /** Positive state of the input. If an error prop passed it will be rendered in place of positive as an error message. */
-  positive: React.Node | ((props: {}) => React.Node),
+  positive?: React.Node | ((props: {}) => React.Node),
   children: React.Node,
 };
 


### PR DESCRIPTION
#### Description

FormControls can be passed a single child of any type to contain the actual controls. The `error` and `positive` props are passed down to that single child, which is useful when it's an `<Input/>` or what have you. If it's a `<div/>` or something like that however, React logs a warning (I think only in Strict mode) about passing the non-DOM props `error` and `positive` to a div. You can ideally avoid this warning by not using FormControl's `error` or `positive` functionality at all when using non-baseweb children, but prior to this change the warning would still be logged even when not using those props.

This changes `<FormControl/>` to not pass an `error` or `positive` prop to it's single child unless those props are actually set to something. No more warnings!

#### Scope

Patch: Bug Fix