### PR TITLE
fix(build): correct eslint publish command

### DIFF
--- a/scripts/alpha-test-web-code.js
+++ b/scripts/alpha-test-web-code.js
@@ -65,6 +65,8 @@ async function getBuild(token, number) {
 }
 
 async function main() {
+  console.log('--- Starting web-code alpha-test');
+
   const buildkiteToken = process.env.BUILDKITE_API_TOKEN;
 
   if (!buildkiteToken) {

--- a/scripts/publish-to-npm.js
+++ b/scripts/publish-to-npm.js
@@ -65,7 +65,7 @@ function publishEslintPlugin(tag) {
   copyPackageJSONVersionFromRoot(
     path.resolve(ESLINT_PLUGIN_DIR, 'package.json'),
   );
-  spawnSync('npm', ['publish', '--tag', tag, 'dist'], {
+  spawnSync('npm', ['publish', 'dist', '--tag', tag], {
     stdio: 'inherit',
     cwd: ESLINT_PLUGIN_DIR,
   });


### PR DESCRIPTION
corrects the order of args and flags in the npm publish command for eslint plugin
