### PR TITLE
fix: toast children flow type

### DIFF
--- a/src/toast/types.js
+++ b/src/toast/types.js
@@ -38,7 +38,7 @@ export type ComponentRenderPropT = (props: {dismiss: () => void}) => React.Node;
 
 export type ChildT = React.Node;
 
-export type ChildrenT = React.ChildrenArray<ChildT>;
+export type ChildrenT = React.Node;
 
 export type ToastPrivateStateT = {
   isFocusVisible: boolean,


### PR DESCRIPTION
Fixes #3303

#### Description
Use React.Node type for Toast Children

#### Scope

Patch: Bug Fix
