### PR TITLE
fix(menu):menu listens to list

### DIFF
--- a/src/menu/index.d.ts
+++ b/src/menu/index.d.ts
@@ -92,6 +92,7 @@ export interface StatefulContainerProps {
   onItemSelect?: OnItemSelect;
   rootRef?: React.Ref<any>;
   typeAhead?: boolean;
+  listenToDoc?: boolean;
   children?: (args: RenderProps) => React.ReactNode;
   addMenuToNesting?: (ref: React.Ref<HTMLElement>) => void;
   removeMenuFromNesting?: (ref: React.Ref<HTMLElement>) => void;

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -28,6 +28,7 @@ export default function Menu(props: StatelessMenuPropsT) {
     focusMenu = () => {},
     unfocusMenu = () => {},
     handleMouseLeave = () => {},
+    handleKeyDown = () => {},
     renderAll = false,
   } = props;
 
@@ -117,6 +118,11 @@ export default function Menu(props: StatelessMenuPropsT) {
           onMouseOver={focusMenu}
           onFocus={forkFocus({onFocus: focusMenu}, handleFocus)}
           onBlur={forkBlur({onBlur: unfocusMenu}, handleBlur)}
+          onKeyDown={event => {
+            if (props.isFocused) {
+              handleKeyDown(event);
+            }
+          }}
           tabIndex={0}
           data-baseweb="menu"
           $isFocusVisible={focusVisible}

--- a/src/menu/stateful-container.js
+++ b/src/menu/stateful-container.js
@@ -31,6 +31,7 @@ export default class MenuStatefulContainer extends React.Component<
       isFocused: false,
     },
     typeAhead: true,
+    listenToDoc: true,
     stateReducer: ((changeType, changes) => changes: StateReducerFnT),
     onItemSelect: () => {},
     getRequiredItemProps: () => ({}),
@@ -79,7 +80,7 @@ export default class MenuStatefulContainer extends React.Component<
         );
       }
 
-      if (this.state.isFocused) {
+      if (this.props.listenToDoc && this.state.isFocused) {
         document.addEventListener('keydown', this.onKeyDown);
       }
     }
@@ -90,7 +91,8 @@ export default class MenuStatefulContainer extends React.Component<
     const rootRef = this.props.rootRef ? this.props.rootRef : this.rootRef;
 
     if (__BROWSER__) {
-      document.removeEventListener('keydown', this.onKeyDown);
+      if (this.props.listenToDoc)
+        document.removeEventListener('keydown', this.onKeyDown);
     }
     this.props.removeMenuFromNesting &&
       this.props.removeMenuFromNesting(rootRef);
@@ -98,9 +100,17 @@ export default class MenuStatefulContainer extends React.Component<
 
   componentDidUpdate(_: mixed, prevState: StatefulContainerStateT) {
     if (__BROWSER__) {
-      if (!prevState.isFocused && this.state.isFocused) {
+      if (
+        this.props.listenToDoc &&
+        !prevState.isFocused &&
+        this.state.isFocused
+      ) {
         document.addEventListener('keydown', this.onKeyDown);
-      } else if (prevState.isFocused && !this.state.isFocused) {
+      } else if (
+        this.props.listenToDoc &&
+        prevState.isFocused &&
+        !this.state.isFocused
+      ) {
         document.removeEventListener('keydown', this.onKeyDown);
       }
     }
@@ -417,6 +427,7 @@ export default class MenuStatefulContainer extends React.Component<
         getRequiredItemProps: this.getRequiredItemProps,
         handleMouseLeave: this.handleMouseLeave,
         highlightedIndex: this.state.highlightedIndex,
+        handleKeyDown: this.props.listenToDoc ? event => {} : this.onKeyDown,
         isFocused: this.state.isFocused,
         focusMenu: this.focusMenu,
         unfocusMenu: this.unfocusMenu,

--- a/src/menu/types.js
+++ b/src/menu/types.js
@@ -124,6 +124,8 @@ export type StatefulContainerPropsT = {
   rootRef?: RootRefT,
   /** whether has keyboard type-ahead function */
   typeAhead: boolean,
+  /** whether has keyboard listens to document; if true, listens to document; if false, listens to itself; Default is true */
+  listenToDoc: boolean,
   /** Child as function pattern. */
   children: RenderPropsT => React.Node,
   addMenuToNesting?: (ref: {current: HTMLElement | null}) => void,


### PR DESCRIPTION
`Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->

#### Description

<!-- Describe your changes below in as much detail as possible -->
This is the continuous part of https://github.com/uber/baseweb/pull/3558.

In summary, for keyboard input `Menu` could listen to 

1. Document 

2. List Item (this only works when `Menu` is focused)

3. nothing

It's easy to let `Menu` listen to nothing because we could use `stopnavigation()` in its ancestor. Therefore, we should offer the choice for developer to have `Menu` listen to Document or List item. This is what `props.listenToDoc` does.


`Menu`  needs to listen to document in some cases. For example, component [Select](https://github.com/uber/baseweb/blob/master/src/select)  or [Timepicker](https://github.com/uber/baseweb/tree/master/src/timepicker) may need `Menu `to listen to keyboard all the time but they cannot have menu focused (they need to focus on the `Input`). So listening  to  document is the best way to maintain the keyboard navigation function of `Menu` here. 

The reason why we need `Menu` to listen to List Item is clearly expressed in this issue(https://github.com/uber/baseweb/issues/3557).  We offer this choice to avoid keyboard interruption between ancestor and children. More test for  this will come later .

#### Scope
<!-- Pick one:
Patch: Bug Fix
Minor: New Feature
Major: Breaking change
-->
