### PR TITLE
fix(tabs-motion): handle conditional tabs

### DIFF
--- a/src/tabs-motion/__tests__/tabs-motion-conditional.scenario.js
+++ b/src/tabs-motion/__tests__/tabs-motion-conditional.scenario.js
@@ -13,30 +13,51 @@ import * as React from 'react';
 import {Tab, Tabs} from '../index.js';
 import {Button, KIND} from '../../button/index.js';
 
+class ErrorBoundary extends React.Component {
+  static getDerivedStateFromError(error) {
+    return {hasError: true};
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {hasError: false};
+  }
+
+  componentDidCatch(error) {
+    // console.log(error);
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
 export default function Scenario() {
-  const [activeKey, setActiveKey] = React.useState(0);
+  const [activeKey, setActiveKey] = React.useState('monster');
   const [show, setShow] = React.useState(false);
   return (
     <React.Fragment>
-      <button type="button" onClick={() => setShow(true)}>
-        Show Robot Tab
+      <button type="button" onClick={() => setShow(s => !s)}>
+        Toggle Robot Tab
       </button>
-      <Tabs
-        activeKey={activeKey}
-        onChange={({activeKey}) => setActiveKey(activeKey)}
-      >
-        {show && (
-          <Tab title="Robot">
-            <Button kind={KIND.secondary}>🤖</Button>
+      <ErrorBoundary>
+        <Tabs
+          activeKey={activeKey}
+          onChange={({activeKey}) => setActiveKey(activeKey)}
+        >
+          {show && (
+            <Tab title="Robot" key="robot">
+              <Button kind={KIND.secondary}>🤖</Button>
+            </Tab>
+          )}
+          <Tab title="Monster" key="monster">
+            <Button kind={KIND.secondary}>👺</Button>
           </Tab>
-        )}
-        <Tab title="Monster">
-          <Button kind={KIND.secondary}>👺</Button>
-        </Tab>
-        <Tab title="Watermelon">
-          <Button kind={KIND.secondary}>🍉</Button>
-        </Tab>
-      </Tabs>
+          <Tab title="Watermelon" key="watermelon">
+            <Button kind={KIND.secondary}>🍉</Button>
+          </Tab>
+        </Tabs>
+      </ErrorBoundary>
     </React.Fragment>
   );
 }

--- a/src/tabs-motion/__tests__/tabs-motion-conditional.scenario.js
+++ b/src/tabs-motion/__tests__/tabs-motion-conditional.scenario.js
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2018-2020 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+// @flow
+
+/* eslint-disable jsx-a11y/accessible-emoji */
+
+import * as React from 'react';
+import {Tab, Tabs} from '../index.js';
+import {Button, KIND} from '../../button/index.js';
+
+export default function Scenario() {
+  const [activeKey, setActiveKey] = React.useState(0);
+  const [show, setShow] = React.useState(false);
+  return (
+    <React.Fragment>
+      <button type="button" onClick={() => setShow(true)}>
+        Show Robot Tab
+      </button>
+      <Tabs
+        activeKey={activeKey}
+        onChange={({activeKey}) => setActiveKey(activeKey)}
+      >
+        {show && (
+          <Tab title="Robot">
+            <Button kind={KIND.secondary}>🤖</Button>
+          </Tab>
+        )}
+        <Tab title="Monster">
+          <Button kind={KIND.secondary}>👺</Button>
+        </Tab>
+        <Tab title="Watermelon">
+          <Button kind={KIND.secondary}>🍉</Button>
+        </Tab>
+      </Tabs>
+    </React.Fragment>
+  );
+}

--- a/src/tabs-motion/__tests__/tabs-motion-conditional.scenario.js
+++ b/src/tabs-motion/__tests__/tabs-motion-conditional.scenario.js
@@ -14,7 +14,10 @@ import * as React from 'react';
 import {Tab, Tabs} from '../index.js';
 import {Button, KIND} from '../../button/index.js';
 
-class ErrorBoundary extends React.Component {
+class ErrorBoundary extends React.Component<
+  {children: React.Node},
+  {hasError: boolean},
+> {
   static getDerivedStateFromError(error) {
     return {hasError: true};
   }

--- a/src/tabs-motion/__tests__/tabs-motion-conditional.scenario.js
+++ b/src/tabs-motion/__tests__/tabs-motion-conditional.scenario.js
@@ -7,6 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 // @flow
 
+/* global window */
 /* eslint-disable jsx-a11y/accessible-emoji */
 
 import * as React from 'react';
@@ -23,8 +24,12 @@ class ErrorBoundary extends React.Component {
     this.state = {hasError: false};
   }
 
+  componentDidMount() {
+    window.__e2e__error = false;
+  }
+
   componentDidCatch(error) {
-    // console.log(error);
+    window.__e2e__error = true;
   }
 
   render() {
@@ -37,7 +42,11 @@ export default function Scenario() {
   const [show, setShow] = React.useState(false);
   return (
     <React.Fragment>
-      <button type="button" onClick={() => setShow(s => !s)}>
+      <button
+        type="button"
+        onClick={() => setShow(s => !s)}
+        id="toggle-robot-tab"
+      >
         Toggle Robot Tab
       </button>
       <ErrorBoundary>

--- a/src/tabs-motion/__tests__/tabs-motion.e2e.js
+++ b/src/tabs-motion/__tests__/tabs-motion.e2e.js
@@ -88,6 +88,17 @@ describe('tabs', () => {
     expect(await page.evaluate(`window.__e2e__mounted`)).toBe(true);
   });
 
+  it('{regression} conditional tab does not throw error', async () => {
+    await mount(page, 'tabs-motion-conditional');
+    const button = await page.$('#toggle-robot-tab');
+    let firstTab = await page.$('#tabs-1-tab-robot');
+    expect(firstTab).toBeFalsy();
+    await button.click();
+    firstTab = await page.$('#tabs-1-tab-robot');
+    expect(firstTab).toBeTruthy();
+    expect(await page.evaluate(`window.__e2e__error`)).toBe(false);
+  });
+
   it('*tab* moves focus to active tab', async () => {
     await mount(page, 'tabs-motion-focus');
     const firstFocusElement = await page.$('#first-focus');

--- a/src/tabs-motion/tabs.js
+++ b/src/tabs-motion/tabs.js
@@ -123,7 +123,7 @@ export function Tabs({
         getHighlightLayoutParams(activeTabRef.current, orientation),
       );
     }
-  }, [activeKey, orientation]);
+  }, [activeKey, orientation, children]);
 
   // Create a shared, memoized, debounced callback for tabs to call on resize.
   const updateHighlight = React.useCallback(
@@ -223,146 +223,22 @@ export function Tabs({
       >
         {React.Children.map(children, (child, index) => {
           if (!child) return;
-          const key = child.key || index;
-          const isActive = key == activeKey;
-          const {
-            artwork: Artwork,
-            overrides = {},
-            tabRef,
-            onClick,
-            ...restProps
-          } = child.props;
-
-          // A way to share our internal activeTabRef via the "tabRef" prop.
-          const ref = React.useRef();
-          React.useImperativeHandle(tabRef, () => {
-            return isActive ? activeTabRef.current : ref.current;
-          });
-
-          React.useEffect(() => {
-            if (window.ResizeObserver) {
-              // We need to update the active tab highlight when the width or
-              // placement changes so we listen for resize updates in each tab.
-              const observer = new window.ResizeObserver(updateHighlight);
-              observer.observe(isActive ? activeTabRef.current : ref.current);
-              return () => {
-                observer.disconnect();
-              };
-            }
-          }, [activeKey, orientation]);
-
-          // Collect overrides
-          const {
-            Tab: TabOverrides,
-            ArtworkContainer: ArtworkContainerOverrides,
-          } = overrides;
-          const [Tab, TabProps] = getOverrides(TabOverrides, StyledTab);
-          const [ArtworkContainer, ArtworkContainerProps] = getOverrides(
-            ArtworkContainerOverrides,
-            StyledArtworkContainer,
-          );
-
-          // Keyboard focus styling
-          const [focusVisible, setFocusVisible] = React.useState(false);
-          const handleFocus = React.useCallback((event: SyntheticEvent<>) => {
-            if (isFocusVisible(event)) {
-              setFocusVisible(true);
-            }
-          }, []);
-          const handleBlur = React.useCallback(
-            (event: SyntheticEvent<>) => {
-              if (focusVisible !== false) {
-                setFocusVisible(false);
-              }
-            },
-            [focusVisible],
-          );
-
-          // Keyboard focus management
-          const handleKeyDown = React.useCallback(event => {
-            // WAI-ARIA 1.1
-            // https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel
-            // We use directional keys to iterate focus through Tabs.
-
-            // Find all tabs eligible for focus
-            const availableTabs = [
-              ...event.target.parentNode.childNodes,
-            ].filter(
-              node => !node.disabled && node.getAttribute('role') === 'tab',
-            );
-
-            // Exit early if there are no other tabs available
-            if (availableTabs.length === 1) return;
-
-            // Find tab to focus, looping to start/end of list if necessary
-            const currentTabIndex = availableTabs.indexOf(event.target);
-            const action = parseKeyDown(event);
-            if (action) {
-              let nextTab: ?HTMLButtonElement;
-              if (action === KEYBOARD_ACTION.previous) {
-                if (availableTabs[currentTabIndex - 1]) {
-                  nextTab = availableTabs[currentTabIndex - 1];
-                } else {
-                  nextTab = availableTabs[availableTabs.length - 1];
-                }
-              } else if (action === KEYBOARD_ACTION.next) {
-                if (availableTabs[currentTabIndex + 1]) {
-                  nextTab = availableTabs[currentTabIndex + 1];
-                } else {
-                  nextTab = availableTabs[0];
-                }
-              }
-              if (nextTab) {
-                // Focus the tab
-                nextTab.focus();
-
-                // Optionally activate the tab
-                if (activateOnFocus) {
-                  nextTab.click();
-                }
-              }
-              // Prevent default page scroll when in vertical orientation
-              if (isVertical(orientation)) {
-                event.preventDefault();
-              }
-            }
-          });
-
           return (
-            <Tab
-              data-baseweb="tab"
-              key={key}
-              id={getTabId(uid, key)}
-              role="tab"
-              onKeyDown={handleKeyDown}
-              aria-selected={isActive}
-              aria-controls={getTabPanelId(uid, key)}
-              tabIndex={isActive ? '0' : '-1'}
-              ref={isActive ? activeTabRef : ref}
-              disabled={!isActive && disabled}
-              type="button" // so it doesn't trigger a submit when used inside forms
-              $focusVisible={focusVisible}
-              {...sharedStylingProps}
-              {...restProps}
-              {...TabProps}
-              onClick={event => {
-                if (typeof onChange === 'function') onChange({activeKey: key});
-                if (typeof onClick === 'function') onClick(event);
-              }}
-              onFocus={forkFocus({...restProps, ...TabProps}, handleFocus)}
-              onBlur={forkBlur({...restProps, ...TabProps}, handleBlur)}
-            >
-              {Artwork ? (
-                <ArtworkContainer
-                  data-baseweb="artwork-container"
-                  {...sharedStylingProps}
-                  {...ArtworkContainerProps}
-                >
-                  <Artwork size={20} color="contentPrimary" />
-                </ArtworkContainer>
-              ) : null}
-              {child.props.title ? child.props.title : key}
-            </Tab>
+            <InternalTab
+              childKey={child.key}
+              childIndex={index}
+              activeKey={activeKey}
+              orientation={orientation}
+              activeTabRef={activeTabRef}
+              updateHighlight={updateHighlight}
+              parseKeyDown={parseKeyDown}
+              activateOnFocus={activateOnFocus}
+              uid={uid}
+              disabled={disabled}
+              sharedStylingProps={sharedStylingProps}
+              onChange={onChange}
+              {...child.props}
+            />
           );
         })}
         <TabHighlight
@@ -386,49 +262,228 @@ export function Tabs({
       />
       {React.Children.map(children, (child, index) => {
         if (!child) return;
-        const key = child.key || index;
-        const isActive = key == activeKey;
-        const {overrides = {}, children} = child.props;
-        const {TabPanel: TabPanelOverrides} = overrides;
-        const [TabPanel, TabPanelProps] = getOverrides(
-          TabPanelOverrides,
-          StyledTabPanel,
-        );
-        // Keyboard focus styling
-        const [focusVisible, setFocusVisible] = React.useState(false);
-        const handleFocus = React.useCallback((event: SyntheticEvent<>) => {
-          if (isFocusVisible(event)) {
-            setFocusVisible(true);
-          }
-        }, []);
-        const handleBlur = React.useCallback(
-          (event: SyntheticEvent<>) => {
-            if (focusVisible !== false) {
-              setFocusVisible(false);
-            }
-          },
-          [focusVisible],
-        );
         return (
-          <TabPanel
-            data-baseweb="tab-panel"
-            key={key}
-            role="tabpanel"
-            id={getTabPanelId(uid, key)}
-            aria-labelledby={getTabId(uid, key)}
-            tabIndex={isActive ? '0' : null}
-            aria-expanded={isActive}
-            hidden={!isActive}
-            $focusVisible={focusVisible}
-            {...sharedStylingProps}
-            {...TabPanelProps}
-            onFocus={forkFocus(TabPanelProps, handleFocus)}
-            onBlur={forkBlur(TabPanelProps, handleBlur)}
-          >
-            {isActive || renderAll ? children : null}
-          </TabPanel>
+          <InternalTabPanel
+            childKey={child.key}
+            childIndex={index}
+            activeKey={activeKey}
+            uid={uid}
+            sharedStylingProps={sharedStylingProps}
+            renderAll={renderAll}
+            {...child.props}
+          />
         );
       })}
     </Root>
+  );
+}
+
+function InternalTab({
+  childKey,
+  childIndex,
+  activeKey,
+  orientation,
+  activeTabRef,
+  updateHighlight,
+  parseKeyDown,
+  activateOnFocus,
+  uid,
+  disabled,
+  sharedStylingProps,
+  onChange,
+  ...props
+}) {
+  const key = childKey || childIndex;
+  const isActive = key == activeKey;
+  const {
+    artwork: Artwork,
+    overrides = {},
+    tabRef,
+    onClick,
+    title,
+    ...restProps
+  } = props;
+
+  // A way to share our internal activeTabRef via the "tabRef" prop.
+  const ref = React.useRef();
+  React.useImperativeHandle(tabRef, () => {
+    return isActive ? activeTabRef.current : ref.current;
+  });
+
+  React.useEffect(() => {
+    if (window.ResizeObserver) {
+      // We need to update the active tab highlight when the width or
+      // placement changes so we listen for resize updates in each tab.
+      const observer = new window.ResizeObserver(updateHighlight);
+      observer.observe(isActive ? activeTabRef.current : ref.current);
+      return () => {
+        observer.disconnect();
+      };
+    }
+  }, [activeKey, orientation]);
+
+  // Collect overrides
+  const {
+    Tab: TabOverrides,
+    ArtworkContainer: ArtworkContainerOverrides,
+  } = overrides;
+  const [Tab, TabProps] = getOverrides(TabOverrides, StyledTab);
+  const [ArtworkContainer, ArtworkContainerProps] = getOverrides(
+    ArtworkContainerOverrides,
+    StyledArtworkContainer,
+  );
+
+  // Keyboard focus styling
+  const [focusVisible, setFocusVisible] = React.useState(false);
+  const handleFocus = React.useCallback((event: SyntheticEvent<>) => {
+    if (isFocusVisible(event)) {
+      setFocusVisible(true);
+    }
+  }, []);
+  const handleBlur = React.useCallback(
+    (event: SyntheticEvent<>) => {
+      if (focusVisible !== false) {
+        setFocusVisible(false);
+      }
+    },
+    [focusVisible],
+  );
+
+  // Keyboard focus management
+  const handleKeyDown = React.useCallback(event => {
+    // WAI-ARIA 1.1
+    // https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel
+    // We use directional keys to iterate focus through Tabs.
+
+    // Find all tabs eligible for focus
+    const availableTabs = [...event.target.parentNode.childNodes].filter(
+      node => !node.disabled && node.getAttribute('role') === 'tab',
+    );
+
+    // Exit early if there are no other tabs available
+    if (availableTabs.length === 1) return;
+
+    // Find tab to focus, looping to start/end of list if necessary
+    const currentTabIndex = availableTabs.indexOf(event.target);
+    const action = parseKeyDown(event);
+    if (action) {
+      let nextTab: ?HTMLButtonElement;
+      if (action === KEYBOARD_ACTION.previous) {
+        if (availableTabs[currentTabIndex - 1]) {
+          nextTab = availableTabs[currentTabIndex - 1];
+        } else {
+          nextTab = availableTabs[availableTabs.length - 1];
+        }
+      } else if (action === KEYBOARD_ACTION.next) {
+        if (availableTabs[currentTabIndex + 1]) {
+          nextTab = availableTabs[currentTabIndex + 1];
+        } else {
+          nextTab = availableTabs[0];
+        }
+      }
+      if (nextTab) {
+        // Focus the tab
+        nextTab.focus();
+
+        // Optionally activate the tab
+        if (activateOnFocus) {
+          nextTab.click();
+        }
+      }
+      // Prevent default page scroll when in vertical orientation
+      if (isVertical(orientation)) {
+        event.preventDefault();
+      }
+    }
+  });
+
+  return (
+    <Tab
+      data-baseweb="tab"
+      key={key}
+      id={getTabId(uid, key)}
+      role="tab"
+      onKeyDown={handleKeyDown}
+      aria-selected={isActive}
+      aria-controls={getTabPanelId(uid, key)}
+      tabIndex={isActive ? '0' : '-1'}
+      ref={isActive ? activeTabRef : ref}
+      disabled={!isActive && disabled}
+      type="button" // so it doesn't trigger a submit when used inside forms
+      $focusVisible={focusVisible}
+      {...sharedStylingProps}
+      {...restProps}
+      {...TabProps}
+      onClick={event => {
+        if (typeof onChange === 'function') onChange({activeKey: key});
+        if (typeof onClick === 'function') onClick(event);
+      }}
+      onFocus={forkFocus({...restProps, ...TabProps}, handleFocus)}
+      onBlur={forkBlur({...restProps, ...TabProps}, handleBlur)}
+    >
+      {Artwork ? (
+        <ArtworkContainer
+          data-baseweb="artwork-container"
+          {...sharedStylingProps}
+          {...ArtworkContainerProps}
+        >
+          <Artwork size={20} color="contentPrimary" />
+        </ArtworkContainer>
+      ) : null}
+      {title ? title : key}
+    </Tab>
+  );
+}
+
+function InternalTabPanel({
+  childKey,
+  childIndex,
+  activeKey,
+  uid,
+  sharedStylingProps,
+  renderAll,
+  ...props
+}) {
+  const key = childKey || childIndex;
+  const isActive = key == activeKey;
+  const {overrides = {}, children} = props;
+  const {TabPanel: TabPanelOverrides} = overrides;
+  const [TabPanel, TabPanelProps] = getOverrides(
+    TabPanelOverrides,
+    StyledTabPanel,
+  );
+  // Keyboard focus styling
+  const [focusVisible, setFocusVisible] = React.useState(false);
+  const handleFocus = React.useCallback((event: SyntheticEvent<>) => {
+    if (isFocusVisible(event)) {
+      setFocusVisible(true);
+    }
+  }, []);
+  const handleBlur = React.useCallback(
+    (event: SyntheticEvent<>) => {
+      if (focusVisible !== false) {
+        setFocusVisible(false);
+      }
+    },
+    [focusVisible],
+  );
+  return (
+    <TabPanel
+      data-baseweb="tab-panel"
+      key={key}
+      role="tabpanel"
+      id={getTabPanelId(uid, key)}
+      aria-labelledby={getTabId(uid, key)}
+      tabIndex={isActive ? '0' : null}
+      aria-expanded={isActive}
+      hidden={!isActive}
+      $focusVisible={focusVisible}
+      {...sharedStylingProps}
+      {...TabPanelProps}
+      onFocus={forkFocus(TabPanelProps, handleFocus)}
+      onBlur={forkBlur(TabPanelProps, handleBlur)}
+    >
+      {isActive || renderAll ? children : null}
+    </TabPanel>
   );
 }

--- a/vrt/config.js
+++ b/vrt/config.js
@@ -413,6 +413,9 @@ const config = {
       },
     ],
   },
+  'tabs-motion-conditional': {
+    skip: true,
+  },
   'tabs-motion-focus': {
     skip: true,
   },


### PR DESCRIPTION
Fixes an issue where conditionally rendering a `Tab` can cause hook mismatches between renders. The fix is to move the inlined `React.Children.map` "components" into actual components and move the early return condition out.