### PR TITLE
feat(combobox): adds support for id attribute

### DIFF
--- a/documentation-site/components/yard/config/combobox.ts
+++ b/documentation-site/components/yard/config/combobox.ts
@@ -77,6 +77,18 @@ const ComboboxConfig: TConfig = {
       type: PropTypes.Boolean,
       description: 'Renders component in disabled state.',
     },
+    id: {
+      value: undefined,
+      type: PropTypes.String,
+      description: 'Id attribute.',
+      hidden: true,
+    },
+    name: {
+      value: undefined,
+      type: PropTypes.String,
+      description: 'Name attribute.',
+      hidden: true,
+    },
 
     overrides: {
       value: undefined,

--- a/src/combobox/__tests__/combobox-form-control.scenario.js
+++ b/src/combobox/__tests__/combobox-form-control.scenario.js
@@ -29,6 +29,7 @@ function Example() {
     <div className={css({width: '375px', padding: '12px 48px'})}>
       <FormControl label="label" caption="caption">
         <Combobox
+          id="combo"
           value={value}
           onChange={nextValue => setValue(nextValue)}
           mapOptionToString={o => o.label}

--- a/src/combobox/combobox.js
+++ b/src/combobox/combobox.js
@@ -38,6 +38,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
     onSubmit,
     mapOptionToNode,
     mapOptionToString,
+    id,
     name,
     options,
     overrides = {},
@@ -297,6 +298,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
             disabled={disabled}
             error={error}
             name={name}
+            id={id}
             onBlur={handleBlur}
             onChange={handleInputChange}
             onFocus={handleFocus}

--- a/src/combobox/index.d.ts
+++ b/src/combobox/index.d.ts
@@ -13,6 +13,7 @@ export type PropsT<OptionT = unknown> = {
   disabled?: boolean;
   mapOptionToNode?: ({isSelected: boolean, option: OptionT}) => React.ReactNode;
   mapOptionToString: (OptionT) => string;
+  id?: string;
   name?: string;
   onChange?: (value: string, option: OptionT | null) => any;
   onSubmit?: (params: {closeListbox: () => void; value: string}) => any;

--- a/src/combobox/types.js
+++ b/src/combobox/types.js
@@ -26,6 +26,7 @@ export type PropsT<OptionT = mixed> = {|
   // Options are often fetched from remote server, provides a simple way to
   // map whatever value the client gets into a visible string in the list item.
   mapOptionToString: OptionT => string,
+  id?: string,
   name?: string,
   // Called when input value changes or option is selected. If user selects a
   // suggested option, that option will be provided as the second function parameter.


### PR DESCRIPTION
#### Description

Add support for setting the `id` attribute of the rendered `<input>`.

#### Scope

Minor
