### PR TITLE
fix(deploy): proper error handling

### DIFF
--- a/scripts/publish-to-npm.js
+++ b/scripts/publish-to-npm.js
@@ -55,7 +55,7 @@ function publishBaseui(tag) {
   console.log('--- Publishing baseui to NPM');
   spawnSync('yarn', ['build'], {stdio: 'inherit', cwd: ROOT_DIR});
   spawnSync('npm', ['publish', 'dist', '--tag', tag], {
-    stdio: 'inherit',
+    stdio: ['inherit', 'inherit', 'pipe'],
     cwd: ROOT_DIR,
   });
 }
@@ -66,7 +66,7 @@ function publishEslintPlugin(tag) {
     path.resolve(ESLINT_PLUGIN_DIR, 'package.json'),
   );
   spawnSync('npm', ['publish', '--tag', tag], {
-    stdio: 'inherit',
+    stdio: ['inherit', 'inherit', 'pipe'],
     cwd: ESLINT_PLUGIN_DIR,
   });
 }


### PR DESCRIPTION
More on the solution here https://nodejs.org/api/child_process.html#child_process_options_stdio


This is where the error is visible, but silent: https://buildkite.com/uberopensource/baseweb/builds/17176#30617f3f-944b-4b85-9a8c-1e13235704f8

Ideally , we want to fail the builds