### PR TITLE
fix(button-group): remove duplicate SHAPE definition

### DIFF
--- a/src/button-group/index.d.ts
+++ b/src/button-group/index.d.ts
@@ -3,18 +3,11 @@ import {StyledFn, StyletronComponent} from 'styletron-react';
 import {SHAPE, SIZE, KIND} from '../button';
 import {Override} from '../overrides';
 
-export {SIZE};
+export {SHAPE, SIZE};
 
 export interface MODE {
   checkbox: 'checkbox';
   radio: 'radio';
-}
-
-export interface SHAPE {
-  default: 'default';
-  pill: 'pill';
-  round: 'round';
-  square: 'square';
 }
 
 export interface STATE_CHANGE_TYPE {
@@ -70,5 +63,4 @@ export class StatefulContainer extends React.Component<
 }
 
 export const MODE: MODE;
-export const SHAPE: SHAPE;
 export const STATE_CHANGE_TYPE: STATE_CHANGE_TYPE;


### PR DESCRIPTION
#### Description
Fixes `node_modules/baseui/button-group/index.d.ts(3,9): error TS2440: Import declaration conflicts with local declaration of 'SHAPE'.` by removing duplicate `SHAPE` definition. [The definitions](https://github.com/uber/baseweb/blob/master/src/button/index.d.ts#L23-L28) are exactly the same, so no breaking changes.

#### Scope
Patch: Bug Fix