### PR TITLE
Adds maxLength prop to TextareaProps

### DIFF
--- a/src/textarea/index.d.ts
+++ b/src/textarea/index.d.ts
@@ -10,6 +10,7 @@ import {
 
 export interface TextareaProps extends BaseInputProps<HTMLTextAreaElement> {
   rows?: number;
+  maxLength?: number;
 }
 
 export interface ADJOINED {

--- a/src/textarea/types.js
+++ b/src/textarea/types.js
@@ -28,6 +28,7 @@ export type TextareaPropsT = {
   /** Sets the size and number of visible text lines
    of the textarea element. */
   rows?: number,
+  maxLength?: number,
 };
 
 export type StatefulContainerPropsT = {


### PR DESCRIPTION
#### Description

Adds `maxLength` prop which exists in the documentation but is missing from the flow and ts types

#### Scope
Patch: Bug Fix