### PR TITLE
fix(textarea): exports ADJOINED

### DIFF
--- a/documentation-site/components/yard/config/textarea.ts
+++ b/documentation-site/components/yard/config/textarea.ts
@@ -1,5 +1,5 @@
 import omit from 'just-omit';
-import {Textarea, SIZE, ADJOINED} from 'baseui/textarea';
+import {Textarea, SIZE} from 'baseui/textarea';
 import {PropTypes} from 'react-view';
 import {TConfig} from '../types';
 import {theme, inputProps} from './input';
@@ -14,11 +14,11 @@ const TextareaConfig: TConfig = {
   scope: {
     Textarea,
     SIZE,
-    ADJOINED,
   },
   theme,
   props: {
     ...omit(inputProps, [
+      'adjoined',
       'type',
       'startEnhancer',
       'endEnhancer',

--- a/src/textarea/index.js
+++ b/src/textarea/index.js
@@ -10,5 +10,5 @@ export {default as StatefulTextarea} from './stateful-textarea.js';
 export {default as StatefulContainer} from './stateful-container.js';
 // Styled elements
 export {StyledTextareaContainer, StyledTextarea} from './styled-components.js';
-export {ADJOINED, STATE_CHANGE_TYPE, SIZE} from './constants.js';
+export {STATE_CHANGE_TYPE, SIZE} from './constants.js';
 export type * from './types.js';

--- a/src/textarea/index.js
+++ b/src/textarea/index.js
@@ -10,5 +10,5 @@ export {default as StatefulTextarea} from './stateful-textarea.js';
 export {default as StatefulContainer} from './stateful-container.js';
 // Styled elements
 export {StyledTextareaContainer, StyledTextarea} from './styled-components.js';
-export {STATE_CHANGE_TYPE, SIZE} from './constants.js';
+export {ADJOINED, STATE_CHANGE_TYPE, SIZE} from './constants.js';
 export type * from './types.js';


### PR DESCRIPTION
Fixes #3660 

#### Description

Exported ADJOINED constant from textarea/index.js similar to STATE_CHANGE_TYPE & SIZE which were internally fetched from input/constants.js

Reproduced Error : [Video](https://www.loom.com/share/81078fd4eee4433382c675d5fe5d20a9)

Working Fix: [Video](https://www.loom.com/share/70dc89c5ac76466d8d22e4888f1f5662)

#### Scope
Patch: Bug Fix
