### PR TITLE
feat(app-nav-bar): let browser decide whether a scrollbar is needed is needed

### DIFF
--- a/src/app-nav-bar/styled-components.js
+++ b/src/app-nav-bar/styled-components.js
@@ -155,7 +155,7 @@ export const StyledSecondaryMenuContainer = styled<{}>('div', ({$theme}) => {
     flexWrap: 'nowrap',
     justifyContent: 'flex-start',
     alignItems: 'stretch',
-    overflow: 'scroll',
+    overflow: 'auto',
   };
 });
 


### PR DESCRIPTION
#### Description
This PR lets the browser decide whether scrollbars are needed when using a secondary app-nav-bar menu.

#### Scope
Minor: New Feature