### PR TITLE
fix(textarea): removes ADJOINED enum

### DIFF
--- a/documentation-site/components/yard/config/textarea.ts
+++ b/documentation-site/components/yard/config/textarea.ts
@@ -1,5 +1,5 @@
 import omit from 'just-omit';
-import {Textarea, SIZE, ADJOINED} from 'baseui/textarea';
+import {Textarea, SIZE} from 'baseui/textarea';
 import {PropTypes} from 'react-view';
 import {TConfig} from '../types';
 import {theme, inputProps} from './input';
@@ -14,11 +14,11 @@ const TextareaConfig: TConfig = {
   scope: {
     Textarea,
     SIZE,
-    ADJOINED,
   },
   theme,
   props: {
     ...omit(inputProps, [
+      'adjoined',
       'type',
       'startEnhancer',
       'endEnhancer',


### PR DESCRIPTION
Fixes #3660

Description
Exported ADJOINED constant from textarea/index.js similar to STATE_CHANGE_TYPE & SIZE which were internally fetched from input/constants.js

Reproduced Error : [Video](https://www.loom.com/share/81078fd4eee4433382c675d5fe5d20a9)

Working Fix: [Video](https://www.loom.com/share/651213ac54854d47a3e3fea7f9a7b02e)

Scope
Patch: Bug Fix