### PR TITLE
Adds autoFocus prop to Toast ts defintion.

### DIFF
--- a/src/toast/index.d.ts
+++ b/src/toast/index.d.ts
@@ -97,6 +97,7 @@ export interface ToastOverrides {
 }
 export interface ToastProps {
   autoHideDuration?: number;
+  autoFocus?: Boolean;
   children?:
     | ((args: {dismiss: () => void}) => React.ReactNode)
     | React.ReactNode;


### PR DESCRIPTION
Fixes #3681 - Add autoFocus prop to typescript ToastProps defintion

#### Description

Update the typescript definition file for the Toast element. Added the `autoFocus` prop to the types defintion file.

#### Scope
**Patch: Bug Fix**
Minor: New Feature
Major: Breaking change
