### PR TITLE
feat(combobox): add `onFocus` prop to combobox

### DIFF
--- a/documentation-site/components/yard/config/combobox.ts
+++ b/documentation-site/components/yard/config/combobox.ts
@@ -43,10 +43,6 @@ const ComboboxConfig: TConfig = {
       value: 'nextValue => setValue(nextValue)',
       type: PropTypes.Function,
       description: 'Callback for when input focus changes.',
-      propHook: {
-        what: 'nextValue',
-        into: 'value',
-      },
     },
     size: {
       value: 'SIZE.default',

--- a/documentation-site/components/yard/config/combobox.ts
+++ b/documentation-site/components/yard/config/combobox.ts
@@ -25,10 +25,6 @@ const ComboboxConfig: TConfig = {
       value: 'nextValue => setValue(nextValue)',
       type: PropTypes.Function,
       description: 'Callback for when input focus changes.',
-      propHook: {
-        what: 'nextValue',
-        into: 'value',
-      },
     },
     onChange: {
       value: 'nextValue => setValue(nextValue)',

--- a/documentation-site/components/yard/config/combobox.ts
+++ b/documentation-site/components/yard/config/combobox.ts
@@ -39,6 +39,15 @@ const ComboboxConfig: TConfig = {
         into: 'value',
       },
     },
+    onFocus: {
+      value: 'nextValue => setValue(nextValue)',
+      type: PropTypes.Function,
+      description: 'Callback for when input focus changes.',
+      propHook: {
+        what: 'nextValue',
+        into: 'value',
+      },
+    },
     size: {
       value: 'SIZE.default',
       defaultValue: 'SIZE.default',

--- a/src/combobox/__tests__/combobox.test.js
+++ b/src/combobox/__tests__/combobox.test.js
@@ -53,6 +53,25 @@ describe('combobox', () => {
     expect(handleBlur.mock.calls.length).toBe(1);
   });
 
+  it('calls onFocus when input enters focus', () => {
+    const handleFocus = jest.fn();
+    const {container} = render(
+      <Combobox
+        mapOptionToString={o => o}
+        onChange={() => {}}
+        onFocus={handleFocus}
+        options={options}
+        value={''}
+      />,
+      {container: document.body},
+    );
+    const input = container.querySelector('input');
+    fireEvent.change(input, {target: {value: 'x'}});
+    fireEvent.focus(input);
+
+    expect(handleFocus.mock.calls.length).toBe(1);
+  });
+
   it('opens listbox when text is entered', () => {
     const {container} = render(
       <Combobox

--- a/src/combobox/combobox.js
+++ b/src/combobox/combobox.js
@@ -157,10 +157,11 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
     }
   }
 
-  function handleFocus() {
+  function handleFocus(event) {
     if (!isOpen && options.length) {
       handleOpen();
     }
+    if (onFocus) onFocus(event);
   }
 
   function handleBlur(event) {
@@ -179,7 +180,6 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
     setSelectionIndex(-1);
     setTempValue(value);
     if (onBlur) onBlur(event);
-    if (onFocus) onFocus(event);
   }
 
   function handleInputChange(event) {

--- a/src/combobox/combobox.js
+++ b/src/combobox/combobox.js
@@ -36,6 +36,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
     error = false,
     onBlur,
     onChange,
+    onFocus,
     onSubmit,
     mapOptionToNode,
     mapOptionToString,
@@ -178,6 +179,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
     setSelectionIndex(-1);
     setTempValue(value);
     if (onBlur) onBlur(event);
+    if (onFocus) onFocus(event);
   }
 
   function handleInputChange(event) {

--- a/src/combobox/index.d.ts
+++ b/src/combobox/index.d.ts
@@ -17,6 +17,7 @@ export type PropsT<OptionT = unknown> = {
   name?: string;
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => any;
   onChange?: (value: string, option: OptionT | null) => any;
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => any;
   onSubmit?: (params: {closeListbox: () => void; value: string}) => any;
   options: OptionT;
   overrides?: {

--- a/src/combobox/types.js
+++ b/src/combobox/types.js
@@ -35,6 +35,8 @@ export type PropsT<OptionT = mixed> = {|
   // Otherwise the second parameter will be null.
   // TODO(v11): consider consolidating function params into a single object bag.
   onChange: (string, OptionT | null) => mixed,
+  // Called when input enters focus.
+  onFocus?: (SyntheticInputEvent<HTMLInputElement>) => mixed,
   // Called when no option is selected and the enter key is pressed. An argument to this
   // function is another function to close the listbox if needed.
   onSubmit?: ({closeListbox: () => void, value: string}) => mixed,


### PR DESCRIPTION
This PR adds an `onFocus` prop to the combobox which returns the current input value, similar to the `onBlur` behavior.

This is useful when trying to manipulate app state outside of the component based on focus/blur behavior