### PR TITLE
fix(app-nav-bar): add data-baseweb attr

### DIFF
--- a/src/app-nav-bar/app-nav-bar.js
+++ b/src/app-nav-bar/app-nav-bar.js
@@ -62,7 +62,7 @@ export default function AppNavBar(props: AppNavBarPropsT) {
   });
 
   return (
-    <StyledRoot>
+    <StyledRoot data-baseweb="app-nav-bar">
       {/* Mobile Nav Experience */}
       <div
         className={css({


### PR DESCRIPTION
Just noticed that the `data-baseweb` attr is missing from the app-nav-bar component
