### PR TITLE
fix(skeleton): clear up warning

### DIFF
--- a/src/skeleton/styled-components.js
+++ b/src/skeleton/styled-components.js
@@ -57,10 +57,9 @@ export const StyledRoot = styled<{
   }
 
   return {
-    background: props.$animation
-      ? getAnimationColor(props)
-      : props.$theme.colors.backgroundTertiary,
-    ...(props.$animation ? animationStyle : {}),
+    ...(props.$animation
+      ? {...animationStyle, backgroundImage: getAnimationColor(props)}
+      : {backgroundColor: props.$theme.colors.backgroundTertiary}),
     height: props.$height,
     width: props.$width,
   };
@@ -70,10 +69,9 @@ export const StyledRow = styled<{$animation?: boolean, $isLastRow: boolean}>(
   'div',
   props => {
     return {
-      background: props.$animation
-        ? getAnimationColor(props)
-        : props.$theme.colors.backgroundTertiary,
-      ...(props.$animation ? animationStyle : {}),
+      ...(props.$animation
+        ? {...animationStyle, backgroundImage: getAnimationColor(props)}
+        : {backgroundColor: props.$theme.colors.backgroundTertiary}),
       width: '100%',
       height: '15px',
       marginBottom: props.$isLastRow ? '0px' : '10px',


### PR DESCRIPTION
Clears up a warning when using the styletron atomic engine and the animated skeleton component.