### PR TITLE
chore(button): update ModalButton margin

### DIFF
--- a/src/modal/__tests__/modal-button.test.js
+++ b/src/modal/__tests__/modal-button.test.js
@@ -33,7 +33,7 @@ describe('ModalButton', () => {
     const result = mergedOverrides.BaseButton.style({$theme: mockTheme});
     expect(result).toEqual({
       color: 'red',
-      ':nth-last-child(n+2)': {
+      ':not(:last-child)': {
         marginRight: '$theme.sizing.scale500',
       },
     });

--- a/src/modal/modal-button.js
+++ b/src/modal/modal-button.js
@@ -18,7 +18,7 @@ const overrides = {
       const marginInlineEnd: string =
         $theme.direction !== 'rtl' ? 'marginRight' : 'marginLeft';
       return {
-        ':nth-last-child(n+2)': {
+        ':not(:last-child)': {
           [marginInlineEnd]: $theme.sizing.scale500,
         },
       };


### PR DESCRIPTION
Update ModalButton margin to use `:not(:last-child)`, which is slightly more semantic than `:nth-last-child(n+2)`. Should have the same specificity.
