### PR TITLE
fix(menu): types

### DIFF
--- a/src/menu/index.d.ts
+++ b/src/menu/index.d.ts
@@ -39,6 +39,7 @@ export interface MenuProps extends BaseMenuPropsT {
     List?: Override<any>;
     Option?: Override<any>;
     ListItem?: Override<any>;
+    OptgroupHeader?: Override<any>;
   };
 }
 


### PR DESCRIPTION
Fixes #3746 

#### Description

Adds OptgroupHeader to Menu overrides type definitions.

#### Scope

- [X] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
