### PR TITLE
Add missing `clearOnEscape` prop to input.BaseInputProps TS definition

### DIFF
--- a/src/input/index.d.ts
+++ b/src/input/index.d.ts
@@ -43,6 +43,7 @@ export interface BaseInputProps<T> {
   autoComplete?: string;
   autoFocus?: boolean;
   clearable?: boolean;
+  clearOnEscape?: boolean;
   disabled?: boolean;
   error?: boolean;
   positive?: boolean;


### PR DESCRIPTION
Fixes #3740

#### Scope
Patch: Bug Fix
