### PR TITLE
fix(app-nav-bar): pass missing props to MenuItem

### DIFF
--- a/src/app-nav-bar/app-nav-bar.js
+++ b/src/app-nav-bar/app-nav-bar.js
@@ -64,7 +64,7 @@ export default function AppNavBar(props: AppNavBarPropsT) {
   });
 
   return (
-    <StyledRoot>
+    <StyledRoot data-baseweb="app-nav-bar">
       {/* Mobile Nav Experience */}
       <div
         className={css({

--- a/src/app-nav-bar/app-nav-bar.js
+++ b/src/app-nav-bar/app-nav-bar.js
@@ -56,13 +56,15 @@ export default function AppNavBar(props: AppNavBarPropsT) {
         active={active}
         item={item}
         key={index}
+        onClick={props.onNavItemClick}
+        onKeyDown={props.onNavItemKeyDown}
         onSelect={onNavItemSelect}
       />
     );
   });
 
   return (
-    <StyledRoot data-baseweb="app-nav-bar">
+    <StyledRoot>
       {/* Mobile Nav Experience */}
       <div
         className={css({
@@ -85,6 +87,8 @@ export default function AppNavBar(props: AppNavBarPropsT) {
           <SecondaryMenu
             nav={secondaryMenu}
             isNavItemActive={isNavItemActive}
+            onClick={props.onNavItemClick}
+            onKeyDown={props.onNavItemKeyDown}
             onNavItemSelect={onNavItemSelect}
           />
         ) : null}
@@ -131,6 +135,8 @@ export default function AppNavBar(props: AppNavBarPropsT) {
           <SecondaryMenu
             nav={secondaryMenu}
             isNavItemActive={isNavItemActive}
+            onClick={props.onNavItemClick}
+            onKeyDown={props.onNavItemKeyDown}
             onNavItemSelect={onNavItemSelect}
           />
         ) : null}

--- a/src/app-nav-bar/secondary-menu.js
+++ b/src/app-nav-bar/secondary-menu.js
@@ -37,6 +37,8 @@ export default function AppNavBar(props: SecondaryMenuT) {
                 item={item}
                 kind={KIND.secondary}
                 key={index}
+                onClick={props.onNavItemClick}
+                onKeyDown={props.onNavItemKeyDown}
                 onSelect={onNavItemSelect}
               />
             ))}

--- a/src/app-nav-bar/types.js
+++ b/src/app-nav-bar/types.js
@@ -14,6 +14,8 @@ type ItemT = any;
 type isNavItemActiveT = (params: {
   item: MainNavItemT | UserNavItemT,
 }) => boolean;
+type onNavItemClickT = (e: Event) => mixed;
+type onNavItemKeyDownT = (e: KeyboardEvent) => mixed;
 type onNavItemSelectT = (params: {item: MainNavItemT | UserNavItemT}) => mixed;
 
 export type MainNavItemT = {|
@@ -53,14 +55,19 @@ export type AppNavBarPropsT = {|
   appDisplayName?: React.Node,
   mainNav?: MainNavItemT[],
   isNavItemActive?: isNavItemActiveT,
+  onNavItemClick?: onNavItemClickT,
+  onNavItemKeyDown?: onNavItemKeyDownT,
   onNavItemSelect: onNavItemSelectT,
   userNav?: UserNavItemT[],
   username?: string,
   usernameSubtitle?: React.Node,
   userImgUrl?: string,
 |};
+
 export type SecondaryMenuT = {|
   nav?: MainNavItemT[],
   isNavItemActive?: isNavItemActiveT,
+  onNavItemClick?: onNavItemClickT,
+  onNavItemKeyDown?: onNavItemKeyDownT,
   onNavItemSelect: onNavItemSelectT,
 |};


### PR DESCRIPTION
adds the possibility to pass props to MenuItem that previously couldn't be. this would allow custom middle click handlers (mouse3 aka mousewheel click). this is useful when a user wants to open more pages at once.

#### Description
added appropriate static types.
every new prop is optional, so it doesn't break anything.

one thing to consider: what should be done with UserMenu? the new props aren't passed to UserMenu since StatefulMenu (to which props are further passed) doesn't support them. shouldn't be an issue for now.

#### Scope
Minor: New Feature
