### PR TITLE
feat(app-nav-bar): add MenuItem event handlers

### DIFF
--- a/src/app-nav-bar/app-nav-bar.js
+++ b/src/app-nav-bar/app-nav-bar.js
@@ -56,6 +56,9 @@ export default function AppNavBar(props: AppNavBarPropsT) {
         active={active}
         item={item}
         key={index}
+        onClick={props.onNavItemClick}
+        onAuxClick={props.onNavItemAuxClick}
+        onKeyDown={props.onNavItemKeyDown}
         onSelect={onNavItemSelect}
       />
     );
@@ -85,6 +88,9 @@ export default function AppNavBar(props: AppNavBarPropsT) {
           <SecondaryMenu
             nav={secondaryMenu}
             isNavItemActive={isNavItemActive}
+            onNavItemClick={props.onNavItemClick}
+            onNavItemAuxClick={props.onNavItemAuxClick}
+            onNavItemKeyDown={props.onNavItemKeyDown}
             onNavItemSelect={onNavItemSelect}
           />
         ) : null}
@@ -131,6 +137,9 @@ export default function AppNavBar(props: AppNavBarPropsT) {
           <SecondaryMenu
             nav={secondaryMenu}
             isNavItemActive={isNavItemActive}
+            onNavItemClick={props.onNavItemClick}
+            onNavItemAuxClick={props.onNavItemAuxClick}
+            onNavItemKeyDown={props.onNavItemKeyDown}
             onNavItemSelect={onNavItemSelect}
           />
         ) : null}

--- a/src/app-nav-bar/index.d.ts
+++ b/src/app-nav-bar/index.d.ts
@@ -4,6 +4,15 @@ type ItemT = any;
 type mapItemToNode = (item: ItemT) => React.ReactNode;
 type mapItemToString = (item: ItemT) => string;
 
+type isNavItemActiveT = (params: {
+  item: MainNavItemT | UserNavItemT,
+}) => boolean;
+
+type onNavItemClickT = (params: {item: MainNavItemT | UserNavItemT, event: Event}) => any;
+type onNavItemAuxClickT = (params: {item: MainNavItemT | UserNavItemT, event: Event}) => any;
+type onNavItemKeyDownT = (params: {item: MainNavItemT | UserNavItemT, event: KeyboardEvent}) => any;
+type onNavItemSelectT = (params: {item: MainNavItemT | UserNavItemT}) => any;
+
 export type MainNavItemT = {
   active?: boolean;
   icon?: React.ComponentType<any>;
@@ -12,6 +21,10 @@ export type MainNavItemT = {
   mapItemToString: mapItemToString;
   nav?: MainNavItemT[];
   navExitIcon?: React.ComponentType<any>;
+  navPosition?: {
+    desktop?: POSITION[keyof POSITION];
+    mobile?: POSITION[keyof POSITION];
+  };
 };
 
 export type UserNavItemT = {
@@ -20,18 +33,31 @@ export type UserNavItemT = {
   item: ItemT;
   mapItemToNode?: mapItemToNode;
   mapItemToString: mapItemToString;
+  nav?: UserNavItemT[];
 };
 
 export interface AppNavBarPropsT {
   appDisplayName?: React.ReactNode;
   // eslint-disable-next-line flowtype/no-weak-type;
   mainNav?: MainNavItemT[];
-  isNavItemActive: (params: {item: MainNavItemT | UserNavItemT}) => boolean;
-  onNavItemSelect: (params: {item: MainNavItemT | UserNavItemT}) => any;
+  isNavItemActive: isNavItemActiveT;
+  onNavItemClick?: onNavItemClickT;
+  onNavItemAuxClick?: onNavItemAuxClickT;
+  onNavItemKeyDown?: onNavItemKeyDownT;
+  onNavItemSelect: onNavItemSelectT;
   userNav?: UserNavItemT[];
   username?: string;
   usernameSubtitle?: React.ReactNode;
   userImgUrl?: string;
+}
+
+export interface SecondaryMenuT {
+  nav?: MainNavItemT[];
+  isNavItemActive?: isNavItemActiveT;
+  onNavItemClick?: onNavItemClickT;
+  onNavItemAuxClick?: onNavItemAuxClickT;
+  onNavItemKeyDown?: onNavItemKeyDownT;
+  onNavItemSelect: onNavItemSelectT;
 }
 
 export interface POSITION {

--- a/src/app-nav-bar/main-menu-item.js
+++ b/src/app-nav-bar/main-menu-item.js
@@ -10,16 +10,24 @@ import * as React from 'react';
 import {KIND} from './constants.js';
 import {StyledMainMenuItem} from './styled-components.js';
 import {isFocusVisible} from '../utils/focusVisible.js';
-import type {MainNavItemT, UserNavItemT} from './types.js';
+import type {
+  MainNavItemT,
+  UserNavItemT,
+  onNavItemClickT,
+  onNavItemAuxClickT,
+  onNavItemKeyDownT,
+  onNavItemSelectT
+} from './types.js';
 
 export default class MenuItem extends React.Component<
   {
     item: MainNavItemT | UserNavItemT,
     active?: boolean,
     kind?: $Values<typeof KIND>,
-    onClick?: (e: Event) => mixed,
-    onKeyDown?: (e: KeyboardEvent) => mixed,
-    onSelect: ({item: MainNavItemT | UserNavItemT}) => mixed,
+    onClick?: onNavItemClickT,
+    onAuxClick?: onNavItemAuxClickT,
+    onKeyDown?: onNavItemKeyDownT,
+    onSelect: onNavItemSelectT,
   },
   {hasFocusVisible: boolean},
 > {
@@ -43,14 +51,21 @@ export default class MenuItem extends React.Component<
 
   onClick = (e: Event) => {
     const {onClick, onSelect} = this.props;
-    typeof onClick === 'function' && onClick(e);
+    typeof onClick === 'function' && onClick({item: this.props.item, event: e});
     typeof onSelect === 'function' && onSelect({item: this.props.item});
+    return;
+  };
+
+  onAuxClick = (e: Event) => {
+    const {onAuxClick} = this.props;
+    typeof onAuxClick === 'function' && onAuxClick({item: this.props.item, event: e});
+    // don't call onSelect here
     return;
   };
 
   onKeyDown = (e: KeyboardEvent) => {
     const {onKeyDown, onSelect} = this.props;
-    typeof onKeyDown === 'function' && onKeyDown(e);
+    typeof onKeyDown === 'function' && onKeyDown({item: this.props.item, event: e});
     if (e.key === 'Enter') {
       typeof onSelect === 'function' && onSelect({item: this.props.item});
     }
@@ -69,6 +84,7 @@ export default class MenuItem extends React.Component<
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
         onClick={this.onClick}
+        onAuxClick={this.onAuxClick}
         onKeyDown={this.onKeyDown}
       >
         {typeof item.mapItemToNode === 'function'

--- a/src/app-nav-bar/secondary-menu.js
+++ b/src/app-nav-bar/secondary-menu.js
@@ -37,6 +37,9 @@ export default function AppNavBar(props: SecondaryMenuT) {
                 item={item}
                 kind={KIND.secondary}
                 key={index}
+                onClick={props.onNavItemClick}
+                onAuxClick={props.onNavItemAuxClick}
+                onKeyDown={props.onNavItemKeyDown}
                 onSelect={onNavItemSelect}
               />
             ))}

--- a/src/app-nav-bar/types.js
+++ b/src/app-nav-bar/types.js
@@ -14,6 +14,10 @@ type ItemT = any;
 type isNavItemActiveT = (params: {
   item: MainNavItemT | UserNavItemT,
 }) => boolean;
+
+type onNavItemClickT = (params: {item: MainNavItemT | UserNavItemT, event: Event}) => mixed;
+type onNavItemAuxClickT = (params: {item: MainNavItemT | UserNavItemT, event: Event}) => mixed;
+type onNavItemKeyDownT = (params: {item: MainNavItemT | UserNavItemT, event: KeyboardEvent}) => mixed;
 type onNavItemSelectT = (params: {item: MainNavItemT | UserNavItemT}) => mixed;
 
 export type MainNavItemT = {|
@@ -53,14 +57,21 @@ export type AppNavBarPropsT = {|
   appDisplayName?: React.Node,
   mainNav?: MainNavItemT[],
   isNavItemActive?: isNavItemActiveT,
+  onNavItemClick?: onNavItemClickT,
+  onNavItemAuxClick?: onNavItemAuxClickT,
+  onNavItemKeyDown?: onNavItemKeyDownT,
   onNavItemSelect: onNavItemSelectT,
   userNav?: UserNavItemT[],
   username?: string,
   usernameSubtitle?: React.Node,
   userImgUrl?: string,
 |};
+
 export type SecondaryMenuT = {|
   nav?: MainNavItemT[],
   isNavItemActive?: isNavItemActiveT,
+  onNavItemClick?: onNavItemClickT,
+  onNavItemAuxClick?: onNavItemAuxClickT,
+  onNavItemKeyDown?: onNavItemKeyDownT,
   onNavItemSelect: onNavItemSelectT,
 |};


### PR DESCRIPTION
adds the possibility to pass onNavItemClick, onNavItemAuxClick, onNavItemKeyDown props to MenuItem which previously couldn't be. for example, onNavItemAuxClick is particularly useful when a middle mouse click occurs, for example, a new tab can be opened, etc.

#### Description
added appropriate static types.
every new prop is optional, so it doesn't break anything.
changed old onClick and onKeyDown type definitions to also include the current item (and also event). [this doesn't break anything, since they weren't even passed to MenuItem before]

one thing to consider: what should be done with UserMenu? the new props aren't passed to UserMenu since StatefulMenu (to which props are further passed) doesn't support them. shouldn't be an issue for now. imo, it would be a very opinionated change. same goes for MobileNav.

one thing more to note is that, onNavItemAuxClick *doesnt* call onNavItemSelect, because it obviously shouldn't.

#### Scope
Minor: New Feature