### PR TITLE
fix(data-table): reflect applied filters correctly in datetime filter

### DIFF
--- a/src/data-table/column-datetime.js
+++ b/src/data-table/column-datetime.js
@@ -171,7 +171,7 @@ function filterParamsToInitialState(input) {
 
   if (input) {
     const op = input.operation;
-    if (input.range) {
+    if (input.range && input.range.length) {
       if (op === DATETIME_OPERATIONS.RANGE_DATETIME) {
         output.rangeDates = input.range;
         output.rangeOperator = RANGE_OPERATIONS[0];
@@ -182,7 +182,7 @@ function filterParamsToInitialState(input) {
         output.rangeDates = input.range;
         output.rangeOperator = RANGE_OPERATIONS[2];
       }
-    } else if (input.selection) {
+    } else if (input.selection && input.selection.length) {
       output.comparatorIndex = 1;
       if (op === DATETIME_OPERATIONS.YEAR) {
         output.years = input.selection;


### PR DESCRIPTION
#### Description

Fixes datetime column's filter not showing applied categorical filters. The problem was with `if (input.range)` condition which always evaluated to `true` - In case when categorical filter was applied, `input.range` was an empty array which still evaluates to `true`.

#### Scope
Patch: Bug Fix
