### PR TITLE
fix(link): avoid passing in animateUnderline as attribute

### DIFF
--- a/src/link/index.js
+++ b/src/link/index.js
@@ -29,17 +29,17 @@ function LinkFocus(props) {
 export const StyledLink = withWrapper(
   Link,
   Styled =>
-    function StyledLink(props) {
+    function StyledLink({animateUnderline, ...restProps}) {
       return (
         <LinkFocus>
           {focusProps => (
             <Styled
               data-baseweb="link"
-              $isAnimateUnderline={props.animateUnderline}
+              $isAnimateUnderline={animateUnderline}
               $isFocusVisible={focusProps.focusVisible}
-              onFocus={forkFocus(props, focusProps.handleFocus)}
-              onBlur={forkBlur(props, focusProps.handleBlur)}
-              {...props}
+              onFocus={forkFocus(restProps, focusProps.handleFocus)}
+              onBlur={forkBlur(restProps, focusProps.handleBlur)}
+              {...restProps}
             />
           )}
         </LinkFocus>


### PR DESCRIPTION
Avoid passing in animateUnderline as attribute. Otherwise results in warning:
```
Warning: React does not recognize the `animateUnderline` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `animateunderline` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

Test Plan: Create a Link with animateUnderline prop and no longer see the warning.