### PR TITLE
fix(tabs-motion): use string key

### DIFF
--- a/src/tabs-motion/tabs.js
+++ b/src/tabs-motion/tabs.js
@@ -293,7 +293,7 @@ function InternalTab({
   onChange,
   ...props
 }) {
-  const key = childKey || childIndex;
+  const key = childKey || String(childIndex);
   const isActive = key == activeKey;
   const {
     artwork: Artwork,
@@ -445,7 +445,7 @@ function InternalTabPanel({
   renderAll,
   ...props
 }) {
-  const key = childKey || childIndex;
+  const key = childKey || String(childIndex);
   const isActive = key == activeKey;
   const {overrides = {}, children} = props;
   const {TabPanel: TabPanelOverrides} = overrides;


### PR DESCRIPTION
#### Description

I've noticed a bug in docs for [Tabs (Motion)](https://baseweb.design/components/tabs-motion/) example. 
The property `activeKey` isn't updating in yard when switching between the tabs:
<img src="https://user-images.githubusercontent.com/4865430/94558090-27a65a80-0268-11eb-9206-9c408e0448b9.gif" alt="tab motion issue demo" width="460" />

As I dug, it happens because the component returns the`activeKey` prop as a number, which causes this issue. 

This fix based on the code implementation from the similar Tab component, where it explicitly converts index to string: https://github.com/uber/baseweb/blob/b144ca682059421fe2fd9cfe0e45af62ad9c3beb/src/tabs/tabs.js#L44

#### Scope
Patch: Bug Fix