### PR TITLE
fix(e2e): migrate from deprecated waitFor fn

### DIFF
--- a/documentation-site/pages/blog/visual-regression-testing/index.mdx
+++ b/documentation-site/pages/blog/visual-regression-testing/index.mdx
@@ -313,7 +313,8 @@ If you have any components that make use of transitions or animations you are go
 When testing components that require interactions, you often need to wait for the UI to change before you can proceed to the next step in the interaction. It might be tempting to simply pad steps with arbitrary wait times, but this is a sure way to add flakiness to your test.
 
 ```js
-await page.waitFor(250); // waits for 250ms before proceeding
+const {waitForTimeout} = require('../../../e2e/helpers/index.js');
+await waitForTimeout(250); // waits for 250ms before proceeding
 ```
 
 This should be a last resort as it will almost certainly flake at some point. When it does someone will probably just increase the wait duration- so over time these paddings accumulate. These can add up to make your test run unbearably slow. The preferable approach is to wait for assertions on the page to pass. Take this example from one of our interaction snapshots:

--- a/e2e/helpers/index.js
+++ b/e2e/helpers/index.js
@@ -83,6 +83,13 @@ async function analyzeAccessibility(page, options = {rules: []}) {
   return accessibilityReport;
 }
 
+// This utility is available in newer versions of puppetteer, but upgrading did not seem worth just for this
+function waitForTimeout(ms) {
+  return new Promise(res => {
+    setTimeout(res, ms);
+  });
+}
+
 const defaultOptions = {
   violationsThreshold: 0,
   incompleteThreshold: 0,
@@ -140,4 +147,5 @@ expect.extend({
 module.exports = {
   analyzeAccessibility,
   mount,
+  waitForTimeout,
 };

--- a/src/accordion/__tests__/accordion.e2e.js
+++ b/src/accordion/__tests__/accordion.e2e.js
@@ -16,7 +16,7 @@ const expanded = '[aria-expanded=true]';
 describe('accordion', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'accordion');
-    await page.waitFor('ul');
+    await page.waitForSelector('ul');
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });

--- a/src/breadcrumbs/__tests__/breadcrumbs.e2e.js
+++ b/src/breadcrumbs/__tests__/breadcrumbs.e2e.js
@@ -13,7 +13,7 @@ const {mount, analyzeAccessibility} = require('../../../e2e/helpers');
 describe('breadcrumbs', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'breadcrumbs');
-    await page.waitFor('a');
+    await page.waitForSelector('a');
 
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();

--- a/src/button-group/__tests__/button-group.e2e.js
+++ b/src/button-group/__tests__/button-group.e2e.js
@@ -13,7 +13,7 @@ const {mount, analyzeAccessibility} = require('../../../e2e/helpers');
 describe('button-group', () => {
   it('radio mode passes basic a11y tests', async () => {
     await mount(page, 'button-group-radio');
-    await page.waitFor('div');
+    await page.waitForSelector('div');
     await page.click('button');
 
     const accessibilityReport = await analyzeAccessibility(page);
@@ -22,7 +22,7 @@ describe('button-group', () => {
 
   it('checkbox mode passes basic a11y tests', async () => {
     await mount(page, 'button-group-checkbox');
-    await page.waitFor('div');
+    await page.waitForSelector('div');
     await page.click('button');
 
     const accessibilityReport = await analyzeAccessibility(page);

--- a/src/button/__tests__/button.e2e.js
+++ b/src/button/__tests__/button.e2e.js
@@ -12,7 +12,7 @@ const {mount, analyzeAccessibility} = require('../../../e2e/helpers');
 describe('button', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'button');
-    await page.waitFor('button');
+    await page.waitForSelector('button');
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });

--- a/src/checkbox/__tests__/checkbox.e2e.js
+++ b/src/checkbox/__tests__/checkbox.e2e.js
@@ -27,7 +27,7 @@ describe('checkbox', () => {
 
   it('can switch states', async () => {
     await mount(page, 'checkbox-indeterminate');
-    await page.waitFor(childLabel2);
+    await page.waitForSelector(childLabel2);
     await page.click(childLabel2);
     const checked = await page.$eval(parentCheckbox, input => input.checked);
     expect(checked).toBe(true);

--- a/src/data-table/__tests__/data-table-columns-not-sortable.e2e.js
+++ b/src/data-table/__tests__/data-table-columns-not-sortable.e2e.js
@@ -22,7 +22,7 @@ describe('data table non-sortable columns', () => {
   it('clicks on column header does not sort', async () => {
     const index = 0;
     await mount(page, 'data-table-columns-not-sortable');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const before = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,

--- a/src/data-table/__tests__/data-table-columns.e2e.js
+++ b/src/data-table/__tests__/data-table-columns.e2e.js
@@ -7,7 +7,11 @@ LICENSE file in the root directory of this source tree.
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-const {mount, analyzeAccessibility} = require('../../../e2e/helpers');
+const {
+  mount,
+  analyzeAccessibility,
+  waitForTimeout,
+} = require('../../../e2e/helpers');
 
 const {
   TABLE_ROOT,
@@ -29,7 +33,7 @@ describe('data table columns', () => {
   it('sorts boolean column', async () => {
     const index = 0;
     await mount(page, 'data-table-columns');
-    await page.waitFor('div[data-baseweb="data-table"]');
+    await page.waitForSelector('div[data-baseweb="data-table"]');
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -57,7 +61,7 @@ describe('data table columns', () => {
   it('sorts categorical column', async () => {
     const index = 1;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -85,7 +89,7 @@ describe('data table columns', () => {
   it('sorts numerical column', async () => {
     const index = 2;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -113,7 +117,7 @@ describe('data table columns', () => {
   it('sorts string column', async () => {
     const index = 3;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -124,14 +128,14 @@ describe('data table columns', () => {
     );
 
     await sortColumnAtIndex(page, index);
-    await page.waitFor(150);
+    await waitForTimeout(150);
     const desc = await getCellContentsAtColumnIndex(page, COLUMN_COUNT, index);
     expect(matchArrayElements(desc, ['four', 'one', 'three', 'two'])).toBe(
       true,
     );
 
     await sortColumnAtIndex(page, index);
-    await page.waitFor(150);
+    await waitForTimeout(150);
     const asc = await getCellContentsAtColumnIndex(page, COLUMN_COUNT, index);
     expect(matchArrayElements(asc, ['two', 'three', 'one', 'four'])).toBe(true);
 
@@ -147,7 +151,7 @@ describe('data table columns', () => {
   it('sorts datetime column', async () => {
     const index = 4;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -163,7 +167,7 @@ describe('data table columns', () => {
     ).toBe(true);
 
     await sortColumnAtIndex(page, index);
-    await page.waitFor(150);
+    await waitForTimeout(150);
     const desc = await getCellContentsAtColumnIndex(page, COLUMN_COUNT, index);
     expect(
       matchArrayElements(desc, [
@@ -175,7 +179,7 @@ describe('data table columns', () => {
     ).toBe(true);
 
     await sortColumnAtIndex(page, index);
-    await page.waitFor(150);
+    await waitForTimeout(150);
     const asc = await getCellContentsAtColumnIndex(page, COLUMN_COUNT, index);
     expect(
       matchArrayElements(asc, [
@@ -198,7 +202,7 @@ describe('data table columns', () => {
   it('filters boolean column', async () => {
     const index = 0;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -236,7 +240,7 @@ describe('data table columns', () => {
   it('filters categorical column', async () => {
     const index = 1;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -274,7 +278,7 @@ describe('data table columns', () => {
   it('filters numerical column as single value', async () => {
     const index = 2;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -317,7 +321,7 @@ describe('data table columns', () => {
   it('filters numerical column between case', async () => {
     const index = 2;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -355,7 +359,7 @@ describe('data table columns', () => {
   it('filters numerical column excludes between case', async () => {
     const index = 2;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -396,7 +400,7 @@ describe('data table columns', () => {
   it('filters datetime column - datetime range', async () => {
     const index = 4;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -448,7 +452,7 @@ describe('data table columns', () => {
   it('filters datetime column - date range', async () => {
     const index = 4;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -494,7 +498,7 @@ describe('data table columns', () => {
   it('filters datetime column - date range - default', async () => {
     const index = 4;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -539,7 +543,7 @@ describe('data table columns', () => {
   it('filters datetime column - time range', async () => {
     const index = 4;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -590,7 +594,7 @@ describe('data table columns', () => {
   it('filters datetime column - weekday categorical', async () => {
     const index = 4;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -629,7 +633,7 @@ describe('data table columns', () => {
   it('filters datetime column - month categorical', async () => {
     const index = 4;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -675,7 +679,7 @@ describe('data table columns', () => {
   it('filters datetime column - quarter categorical', async () => {
     const index = 4;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -721,7 +725,7 @@ describe('data table columns', () => {
   it('filters datetime column - half categorical', async () => {
     const index = 4;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -767,7 +771,7 @@ describe('data table columns', () => {
   it('filters datetime column - year categorical', async () => {
     const index = 4;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,

--- a/src/data-table/__tests__/data-table-extracted-filters.e2e.js
+++ b/src/data-table/__tests__/data-table-extracted-filters.e2e.js
@@ -24,7 +24,7 @@ describe('data-table-extracted-filters', () => {
     await page.setViewport({width: 1366, height: 1000});
 
     await mount(page, 'data-table-extracted-filters');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const phylumFilter = await page.$('#Phylum-filter');
     const checkboxes = await phylumFilter.$$('label[data-baseweb="checkbox"');
     await checkboxes[1].click();

--- a/src/data-table/__tests__/data-table-included-rows-change.e2e.js
+++ b/src/data-table/__tests__/data-table-included-rows-change.e2e.js
@@ -15,7 +15,7 @@ describe('data table columns', () => {
   it('updates application state when rows change', async () => {
     const index = 0;
     await mount(page, 'data-table-included-rows-change');
-    await page.waitFor('div[data-baseweb="data-table"]');
+    await page.waitForSelector('div[data-baseweb="data-table"]');
 
     const initialLi = await page.$$('li');
     const initial = await Promise.all(

--- a/src/data-table/__tests__/data-table-initial-filters.e2e.js
+++ b/src/data-table/__tests__/data-table-initial-filters.e2e.js
@@ -21,14 +21,14 @@ const COLUMN_COUNT = 1;
 describe('data table initial filters', () => {
   it('mounts with initial filters applied', async () => {
     await mount(page, 'data-table-initial-filters');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const data = await getCellContentsAtColumnIndex(page, COLUMN_COUNT, 0);
     expect(matchArrayElements(data, ['a'])).toBe(true);
   });
 
   it('calls onFilterRemove when expected', async () => {
     await mount(page, 'data-table-initial-filters');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const before = await page.$$('li[data-log="remove"]');
     expect(before.length).toBe(0);
 
@@ -42,7 +42,7 @@ describe('data table initial filters', () => {
 
   it('calls onFilterAdd when expected', async () => {
     await mount(page, 'data-table-initial-filters');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
 
     const before = await page.$$('li[data-log="add"]');
     expect(before.length).toBe(0);

--- a/src/data-table/__tests__/data-table-initial-selected-rows.e2e.js
+++ b/src/data-table/__tests__/data-table-initial-selected-rows.e2e.js
@@ -14,7 +14,7 @@ const {TABLE_ROOT} = require('./utilities.js');
 describe('data table initial filters', () => {
   it('mounts with initial rows selected', async () => {
     await mount(page, 'data-table-initial-selected-rows');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     // cell 1x1 should have a label with checkbox checked
     const cell1x1 = await page.$(
       `${TABLE_ROOT} > div:nth-child(2) label > input`,

--- a/src/data-table/__tests__/data-table-initial-sort.e2e.js
+++ b/src/data-table/__tests__/data-table-initial-sort.e2e.js
@@ -20,7 +20,7 @@ const COLUMN_COUNT = 1;
 describe('data table initial filters', () => {
   it('mounts with initial sort applied', async () => {
     await mount(page, 'data-table-initial-sort');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const data = await getCellContentsAtColumnIndex(page, COLUMN_COUNT, 0);
     expect(matchArrayElements(data, ['d', 'c', 'b', 'a'])).toBe(true);
   });

--- a/src/data-table/__tests__/data-table-text-search.e2e.js
+++ b/src/data-table/__tests__/data-table-text-search.e2e.js
@@ -25,7 +25,7 @@ describe('data table text search', () => {
   jest.setTimeout(10 * 1000);
   it('filters to expected number of rows', async () => {
     await mount(page, 'data-table-text-search');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     await page.type('input', 'arti');
     await wait(250); // input is debounced by 250ms
 
@@ -36,7 +36,7 @@ describe('data table text search', () => {
 
   it('filters custom columns', async () => {
     await mount(page, 'data-table-text-search');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     await page.type('input', 'moll');
     await wait(250); // input is debounced by 250ms
 

--- a/src/data-table/__tests__/data-table-unreliable.e2e.js
+++ b/src/data-table/__tests__/data-table-unreliable.e2e.js
@@ -24,7 +24,7 @@ describe('data table columns', () => {
   it('updates categorical column', async () => {
     const index = 1;
     await mount(page, 'data-table-columns');
-    await page.waitFor(TABLE_ROOT);
+    await page.waitForSelector(TABLE_ROOT);
     const initial = await getCellContentsAtColumnIndex(
       page,
       COLUMN_COUNT,
@@ -59,7 +59,7 @@ describe('data table columns', () => {
       const button = items.find(item => item.textContent === 'Apply');
       return button.click();
     });
-    await page.waitFor('div[data-baseweb="popover"]', {hidden: true});
+    await page.waitForSelector('div[data-baseweb="popover"]', {hidden: true});
 
     const updated = await getCellContentsAtColumnIndex(
       page,

--- a/src/datepicker/__tests__/calendar.e2e.js
+++ b/src/datepicker/__tests__/calendar.e2e.js
@@ -32,7 +32,7 @@ const isActiveEl = async (page, selector) => {
 describe('Calendar', () => {
   it('calendar passes basic a11y tests', async () => {
     await mount(page, 'calendar');
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     const accessibilityReport = await analyzeAccessibility(page, {
       rules: [
         {
@@ -45,8 +45,8 @@ describe('Calendar', () => {
   });
   const waitTillDay = async page => {
     await mount(page, 'calendar');
-    await page.waitFor(selectors.calendar);
-    await page.waitFor(selectors.day0);
+    await page.waitForSelector(selectors.calendar);
+    await page.waitForSelector(selectors.day0);
     await page.focus(selectors.day0);
   };
 

--- a/src/datepicker/__tests__/datepicker-int-range.e2e.js
+++ b/src/datepicker/__tests__/datepicker-int-range.e2e.js
@@ -22,18 +22,18 @@ const selectors = {
 describe('Datepicker, Int', () => {
   it('selects range - int', async () => {
     await mount(page, 'datepicker-int-range');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     await page.click(selectors.day);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     const selectedValue1 = await page.$eval(
       selectors.input,
       input => input.value,
     );
     expect(selectedValue1).toBe('2019 vasárnap 10');
     await page.click(selectors.day2);
-    await page.waitFor(selectors.calendar, {
+    await page.waitForSelector(selectors.calendar, {
       hidden: true,
     });
     const selectedValue2 = await page.$eval(

--- a/src/datepicker/__tests__/datepicker-int.e2e.js
+++ b/src/datepicker/__tests__/datepicker-int.e2e.js
@@ -19,17 +19,17 @@ const selectors = {
 describe('Datepicker, Int', () => {
   it('parses input with formatString', async () => {
     await mount(page, 'datepicker-int');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
 
     await page.keyboard.type('31.03.202');
-    await page.waitFor(selectors.day, {hidden: true});
+    await page.waitForSelector(selectors.day, {hidden: true});
 
     await page.keyboard.type('0');
     const inputValue = await page.$eval(selectors.input, input => input.value);
 
     expect(inputValue).toBe('31.03.2020');
 
-    await page.waitFor(selectors.day);
+    await page.waitForSelector(selectors.day);
   });
 });

--- a/src/datepicker/__tests__/datepicker-keyboard-nav.e2e.js
+++ b/src/datepicker/__tests__/datepicker-keyboard-nav.e2e.js
@@ -42,13 +42,13 @@ const isActiveEl = async (page, selector) => {
 describe('Datepicker - keyboard navigation', () => {
   it('calendar is focusable and can be navigated in', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.focus(selectors.input);
     const isInputActive = await isActiveEl(page, selectors.input);
     expect(isInputActive).toBe(true);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     // march should be visible
-    await page.waitFor(selectors.mar10);
+    await page.waitForSelector(selectors.mar10);
 
     // focus the calendar
     await page.keyboard.press('ArrowDown');
@@ -86,9 +86,9 @@ describe('Datepicker - keyboard navigation', () => {
     // press the next month button
     await page.keyboard.press('Enter');
     // make sure March is gone
-    await page.waitFor(selectors.mar10, {hidden: true});
+    await page.waitForSelector(selectors.mar10, {hidden: true});
     // and make sure April is now visible
-    await page.waitFor(selectors.apr1);
+    await page.waitForSelector(selectors.apr1);
 
     // tab into the calendar
     await page.keyboard.press('Tab');
@@ -117,14 +117,14 @@ describe('Datepicker - keyboard navigation', () => {
 
   it('calendar sets highlighted date appropriately when selecting a new date or navigating around', async () => {
     await mount(page, 'datepicker-range-highlight');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     // open the calendar by moving focus into input
     await page.focus(selectors.input);
     let isInputActive = await isActiveEl(page, selectors.input);
     expect(isInputActive).toBe(true);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     // march should be visible
-    await page.waitFor(selectors.mar10);
+    await page.waitForSelector(selectors.mar10);
 
     // focus the calendar
     await page.keyboard.press('ArrowDown');
@@ -143,7 +143,7 @@ describe('Datepicker - keyboard navigation', () => {
     await page.keyboard.press('Enter');
 
     // check that calendar stays opened
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
 
     // check that Mar 12 is still an active element
     isMar12Active = await isActiveEl(page, selectors.mar12Selected);
@@ -166,7 +166,7 @@ describe('Datepicker - keyboard navigation', () => {
     await page.keyboard.press('Enter');
 
     // check that calendar is closed and input gets focus
-    await page.waitFor(selectors.calendar, {hidden: true});
+    await page.waitForSelector(selectors.calendar, {hidden: true});
     isInputActive = await isActiveEl(page, selectors.input);
     expect(isInputActive).toBe(true);
 
@@ -177,7 +177,7 @@ describe('Datepicker - keyboard navigation', () => {
 
     // open the calendar again
     await page.keyboard.press('ArrowDown');
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     // focus the calendar
     await page.keyboard.press('ArrowDown');
     // check that the first date (Mar 12) in the selected range is active
@@ -240,9 +240,9 @@ describe('Datepicker - keyboard navigation', () => {
     // press the next month button
     await page.keyboard.press('Enter');
     // make sure March is gone
-    await page.waitFor(selectors.mar14, {hidden: true});
+    await page.waitForSelector(selectors.mar14, {hidden: true});
     // and make sure April is now visible
-    await page.waitFor(selectors.apr1);
+    await page.waitForSelector(selectors.apr1);
 
     // tab into the calendar
     await page.keyboard.press('Tab');
@@ -263,9 +263,9 @@ describe('Datepicker - keyboard navigation', () => {
     // press the prev month button
     await page.keyboard.press('Enter');
     // make sure April is gone
-    await page.waitFor(selectors.apr1, {hidden: true});
+    await page.waitForSelector(selectors.apr1, {hidden: true});
     // and make sure March is now visible
-    await page.waitFor(selectors.mar10);
+    await page.waitForSelector(selectors.mar10);
 
     // navigate back into the calendar and check the focused date
     // to be the beginning of the selected range (Mar 12)

--- a/src/datepicker/__tests__/datepicker-range.e2e.js
+++ b/src/datepicker/__tests__/datepicker-range.e2e.js
@@ -27,18 +27,18 @@ const selectors = {
 describe('Datepicker, Range', () => {
   it('selects range', async () => {
     await mount(page, 'datepicker-range');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     await page.click(selectors.day);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     const selectedValue1 = await page.$eval(
       selectors.input,
       input => input.value,
     );
     expect(selectedValue1).toBe('2019/03/10 –     /  /  ');
     await page.click(selectors.day2);
-    await page.waitFor(selectors.calendar, {
+    await page.waitForSelector(selectors.calendar, {
       hidden: true,
     });
     const selectedValue2 = await page.$eval(
@@ -49,18 +49,18 @@ describe('Datepicker, Range', () => {
   });
   it('selects range in multi-month', async () => {
     await mount(page, 'datepicker-range-multi-month');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     await page.click(selectors.day);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     const selectedValue1 = await page.$eval(
       selectors.input,
       input => input.value,
     );
     expect(selectedValue1).toBe('2019/03/10 –     /  /  ');
     await page.click(selectors.day4);
-    await page.waitFor(selectors.calendar, {
+    await page.waitForSelector(selectors.calendar, {
       hidden: true,
     });
     const selectedValue2 = await page.$eval(
@@ -71,14 +71,14 @@ describe('Datepicker, Range', () => {
   });
   it('selects range in multi-month - do not autoAdvance calendar months since selected date is in view', async () => {
     await mount(page, 'datepicker-range-multi-month');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     // datepicker should show 2 months - March and April
     // we can see both a day in March and a day in April are rendered
-    await page.waitFor(selectors.day);
+    await page.waitForSelector(selectors.day);
     await page.click(selectors.day4);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     const selectedValue1 = await page.$eval(
       selectors.input,
       input => input.value,
@@ -86,10 +86,10 @@ describe('Datepicker, Range', () => {
     expect(selectedValue1).toBe('2019/04/01 –     /  /  ');
     // after clicking on a date in April, in the second month, the months should NOT change at all. March should still be visible, and May should not be rendered
     // we finish off the test by clicking on a day in March (simulating clicking the "end" of the range first, then the "beginning" of the range last)
-    // await page.waitFor(selectors.day5, {hidden: true});
-    await page.waitFor(selectors.day);
+    // await page.waitForSelector(selectors.day5, {hidden: true});
+    await page.waitForSelector(selectors.day);
     await page.click(selectors.day);
-    await page.waitFor(selectors.calendar, {
+    await page.waitForSelector(selectors.calendar, {
       hidden: true,
     });
     const selectedValue2 = await page.$eval(
@@ -100,14 +100,14 @@ describe('Datepicker, Range', () => {
   });
   it('selected time is preserved when dates are changed', async () => {
     await mount(page, 'datepicker-range');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.timeSelect);
+    await page.waitForSelector(selectors.timeSelect);
 
     let timeSelects = await page.$$(selectors.timeSelect);
     // Set the start time
     await timeSelects[0].click();
-    await page.waitFor(selectors.timeSelectDropdown);
+    await page.waitForSelector(selectors.timeSelectDropdown);
     await page.keyboard.type('12:30 AM');
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
@@ -118,7 +118,7 @@ describe('Datepicker, Range', () => {
     expect(timeSelectValue).toBe('12:30 AM');
     // Set the end time
     await timeSelects[1].click();
-    await page.waitFor(selectors.timeSelectDropdown);
+    await page.waitForSelector(selectors.timeSelectDropdown);
     await page.keyboard.type('4:30 AM');
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
@@ -128,8 +128,8 @@ describe('Datepicker, Range', () => {
     );
     expect(timeSelectValue2).toBe('4:30 AM');
     // Select the start day
-    await page.waitFor(selectors.calendar);
-    await page.waitFor(selectors.day);
+    await page.waitForSelector(selectors.calendar);
+    await page.waitForSelector(selectors.day);
     await page.click(selectors.day);
     const selectedValue1 = await page.$eval(
       selectors.input,
@@ -137,9 +137,9 @@ describe('Datepicker, Range', () => {
     );
     expect(selectedValue1).toBe('2019/03/10 –     /  /  ');
     // Select the start day
-    await page.waitFor(selectors.day2);
+    await page.waitForSelector(selectors.day2);
     await page.click(selectors.day2);
-    await page.waitFor(selectors.calendar, {
+    await page.waitForSelector(selectors.calendar, {
       hidden: true,
     });
     const selectedValue2 = await page.$eval(
@@ -147,11 +147,11 @@ describe('Datepicker, Range', () => {
       input => input.value,
     );
     expect(selectedValue2).toBe('2019/03/10 – 2019/03/28');
-    await page.waitFor(selectors.calendar, {hidden: true});
+    await page.waitForSelector(selectors.calendar, {hidden: true});
 
     // Open the calendar again and check that the time is set correctly
     await page.click(selectors.input);
-    await page.waitFor(selectors.timeSelect);
+    await page.waitForSelector(selectors.timeSelect);
     timeSelectValue = await page.$$eval(
       `${selectors.timeSelect} ${selectors.timeSelectValue}`,
       selects => selects[0].textContent,

--- a/src/datepicker/__tests__/datepicker-unreliable.e2e.js
+++ b/src/datepicker/__tests__/datepicker-unreliable.e2e.js
@@ -34,35 +34,35 @@ describe('Datepicker', () => {
 
   it('renders previous month when the left arrow is clicked', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.leftArrow);
+    await page.waitForSelector(selectors.leftArrow);
     await page.click(selectors.leftArrow);
-    await page.waitFor(selectors.day, {
+    await page.waitForSelector(selectors.day, {
       hidden: true,
     });
-    await page.waitFor(selectors.day3);
+    await page.waitForSelector(selectors.day3);
   });
 
   it('renders next month when the right arrow is clicked', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.rightArrow);
+    await page.waitForSelector(selectors.rightArrow);
     await page.click(selectors.rightArrow);
-    await page.waitFor(selectors.day, {
+    await page.waitForSelector(selectors.day, {
       hidden: true,
     });
-    await page.waitFor(selectors.day4);
+    await page.waitForSelector(selectors.day4);
   });
 
   it('updates the calendar when a year selected from the dropdown', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.monthYearSelectButton);
+    await page.waitForSelector(selectors.monthYearSelectButton);
     await page.click(selectors.monthYearSelectButton);
-    await page.waitFor(selectors.monthYearSelectMenu);
+    await page.waitForSelector(selectors.monthYearSelectMenu);
 
     await page.$$eval('ul[role="listbox"] li', items => {
       const option = items.find(item => {
@@ -71,18 +71,18 @@ describe('Datepicker', () => {
       return option.click();
     });
 
-    await page.waitFor(selectors.monthYearSelectMenu, {hidden: true});
-    await page.waitFor(selectors.calendar);
-    await page.waitFor(selectors.day5);
+    await page.waitForSelector(selectors.monthYearSelectMenu, {hidden: true});
+    await page.waitForSelector(selectors.calendar);
+    await page.waitForSelector(selectors.day5);
   });
 
   it('updates the calendar when a month selected from the dropdown', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.monthYearSelectButton);
+    await page.waitForSelector(selectors.monthYearSelectButton);
     await page.click(selectors.monthYearSelectButton);
-    await page.waitFor(selectors.monthYearSelectMenu);
+    await page.waitForSelector(selectors.monthYearSelectMenu);
 
     await page.$$eval('ul[role="listbox"] li', items => {
       const option = items.find(item => {
@@ -91,18 +91,18 @@ describe('Datepicker', () => {
       return option.click();
     });
 
-    await page.waitFor(selectors.monthYearSelectMenu, {hidden: true});
-    await page.waitFor(selectors.calendar);
-    await page.waitFor(selectors.day6);
+    await page.waitForSelector(selectors.monthYearSelectMenu, {hidden: true});
+    await page.waitForSelector(selectors.calendar);
+    await page.waitForSelector(selectors.day6);
   });
 
   it('disables previous month button if minimum month is selected', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.monthYearSelectButton);
+    await page.waitForSelector(selectors.monthYearSelectButton);
     await page.click(selectors.monthYearSelectButton);
-    await page.waitFor(selectors.monthYearSelectMenu);
+    await page.waitForSelector(selectors.monthYearSelectMenu);
 
     await page.$$eval('ul[role="listbox"] li', items => {
       const option = items.find(item => {
@@ -119,11 +119,11 @@ describe('Datepicker', () => {
 
   it('disables next month button if maximum month is selected', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.monthYearSelectButton);
+    await page.waitForSelector(selectors.monthYearSelectButton);
     await page.click(selectors.monthYearSelectButton);
-    await page.waitFor(selectors.monthYearSelectMenu);
+    await page.waitForSelector(selectors.monthYearSelectMenu);
 
     await page.$$eval('ul[role="listbox"] li', items => {
       const option = items.find(item => {
@@ -140,7 +140,7 @@ describe('Datepicker', () => {
 
   it('selects day when typed', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
 
     // input mask
@@ -156,11 +156,11 @@ describe('Datepicker', () => {
   it('selects range - verifies end of year', async () => {
     await mount(page, 'datepicker-range');
 
-    await page.waitFor('input');
+    await page.waitForSelector('input');
     await page.click('input');
-    await page.waitFor('[data-baseweb="calendar"]');
+    await page.waitForSelector('[data-baseweb="calendar"]');
     await page.click('[data-id="monthYearSelectButton"]');
-    await page.waitFor('[data-id="monthYearSelectMenu"]');
+    await page.waitForSelector('[data-id="monthYearSelectMenu"]');
 
     await page.$$eval('ul[role="listbox"] li', items => {
       const option = items.find(item => {

--- a/src/datepicker/__tests__/datepicker.e2e.js
+++ b/src/datepicker/__tests__/datepicker.e2e.js
@@ -28,16 +28,16 @@ const selectors = {
 describe('Datepicker', () => {
   it('datepicker passes basic a11y tests', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });
 
   it('opens the calendar on click', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     const calendarCount = await page.$$eval(
       selectors.calendar,
       calendar => calendar.length,
@@ -47,9 +47,9 @@ describe('Datepicker', () => {
 
   it('opens the calendar on input focus', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.focus(selectors.input);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     const calendarCount = await page.$$eval(
       selectors.calendar,
       calendar => calendar.length,
@@ -59,22 +59,22 @@ describe('Datepicker', () => {
 
   it('closes the calendar on esc', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     await page.keyboard.press('Escape');
-    await page.waitFor(selectors.calendar, {
+    await page.waitForSelector(selectors.calendar, {
       hidden: true,
     });
   });
 
   it('selects day when clicked', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     await page.click(selectors.day);
-    await page.waitFor(selectors.calendar, {
+    await page.waitForSelector(selectors.calendar, {
       hidden: true,
     });
 
@@ -87,7 +87,7 @@ describe('Datepicker', () => {
 
   it('rerenders input if value is changed', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click('button');
 
     const selectedValue = await page.$eval(
@@ -99,11 +99,11 @@ describe('Datepicker', () => {
 
   it('input causes calendar to switch to appropriate month', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     // march should be visible
-    await page.waitFor(selectors.day);
+    await page.waitForSelector(selectors.day);
 
     // we want to enter entire date but the onChange functionality only fires on key press so...
     await page.$eval(selectors.input, el => (el.value = '2019/07/0'));
@@ -111,46 +111,46 @@ describe('Datepicker', () => {
     await page.keyboard.press('2');
 
     // make sure march is gone
-    await page.waitFor(selectors.day, {hidden: true});
+    await page.waitForSelector(selectors.day, {hidden: true});
     // and make sure july is now visible
-    await page.waitFor(selectors.day6);
+    await page.waitForSelector(selectors.day6);
   });
 
   it('month year dropdown opens on arrow down', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
-    await page.waitFor(selectors.day);
+    await page.waitForSelector(selectors.calendar);
+    await page.waitForSelector(selectors.day);
     await page.focus(selectors.monthYearSelectButton);
     await page.keyboard.press('ArrowDown');
 
-    await page.waitFor(selectors.monthYearSelectMenu);
+    await page.waitForSelector(selectors.monthYearSelectMenu);
   });
 
   it('month year dropdown opens on arrow up', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
-    await page.waitFor(selectors.day);
+    await page.waitForSelector(selectors.calendar);
+    await page.waitForSelector(selectors.day);
     await page.focus(selectors.monthYearSelectButton);
     await page.keyboard.press('ArrowUp');
 
-    await page.waitFor(selectors.monthYearSelectMenu);
+    await page.waitForSelector(selectors.monthYearSelectMenu);
   });
 
   it('month year dropdown escape does not close calendar', async () => {
     await mount(page, 'datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
-    await page.waitFor(selectors.day);
+    await page.waitForSelector(selectors.calendar);
+    await page.waitForSelector(selectors.day);
     await page.focus(selectors.monthYearSelectButton);
     await page.keyboard.press('ArrowDown');
-    await page.waitFor(selectors.monthYearSelectMenu);
+    await page.waitForSelector(selectors.monthYearSelectMenu);
     await page.keyboard.press('Escape');
-    await page.waitFor(selectors.monthYearSelectMenu, {hidden: true});
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.monthYearSelectMenu, {hidden: true});
+    await page.waitForSelector(selectors.calendar);
   });
 });

--- a/src/datepicker/__tests__/datepickers-composed-range.e2e.js
+++ b/src/datepicker/__tests__/datepickers-composed-range.e2e.js
@@ -21,7 +21,7 @@ const SET_UNDEFINED_BTN = '[id="set-undefined"]';
 describe('datepicker-composed-range', () => {
   it('displaying start date can update value from text input with existing dates', async () => {
     await mount(page, 'datepickers-composed-range');
-    await page.waitFor(START_DATE_INPUT);
+    await page.waitForSelector(START_DATE_INPUT);
 
     const before = await page.$eval(DISPLAY_START_DATE, e => e.textContent);
     expect(before).toBe('2019/4/1');
@@ -36,7 +36,7 @@ describe('datepicker-composed-range', () => {
 
   it('displaying end date can update value from text input with existing dates', async () => {
     await mount(page, 'datepickers-composed-range');
-    await page.waitFor(END_DATE_INPUT);
+    await page.waitForSelector(END_DATE_INPUT);
 
     const before = await page.$eval(DISPLAY_END_DATE, e => e.textContent);
     expect(before).toBe('2019/4/10');
@@ -51,7 +51,7 @@ describe('datepicker-composed-range', () => {
 
   it('displaying start date can update value from text input with undefined dates', async () => {
     await mount(page, 'datepickers-composed-range');
-    await page.waitFor(START_DATE_INPUT);
+    await page.waitForSelector(START_DATE_INPUT);
 
     await page.click(SET_UNDEFINED_BTN);
 
@@ -67,7 +67,7 @@ describe('datepicker-composed-range', () => {
 
   it('displaying end date can update value from text input with undefined dates', async () => {
     await mount(page, 'datepickers-composed-range');
-    await page.waitFor(END_DATE_INPUT);
+    await page.waitForSelector(END_DATE_INPUT);
 
     await page.click(SET_UNDEFINED_BTN);
 
@@ -85,7 +85,7 @@ describe('datepicker-composed-range', () => {
 
   it('displaying start date does not update if selection is after end date', async () => {
     await mount(page, 'datepickers-composed-range');
-    await page.waitFor(START_DATE_INPUT);
+    await page.waitForSelector(START_DATE_INPUT);
 
     const before = await page.$eval(DISPLAY_START_DATE, e => e.textContent);
     expect(before).toBe('2019/4/1');
@@ -102,7 +102,7 @@ describe('datepicker-composed-range', () => {
 
   it('displaying end date does not update if selection is before start date', async () => {
     await mount(page, 'datepickers-composed-range');
-    await page.waitFor(END_DATE_INPUT);
+    await page.waitForSelector(END_DATE_INPUT);
 
     const before = await page.$eval(DISPLAY_END_DATE, e => e.textContent);
     expect(before).toBe('2019/4/10');

--- a/src/datepicker/__tests__/stateful-datepicker-quick-select.e2e.js
+++ b/src/datepicker/__tests__/stateful-datepicker-quick-select.e2e.js
@@ -32,11 +32,11 @@ describe('Stateful Datepicker Quick Select', () => {
 
   it('can quick select with keyboard', async () => {
     await mount(page, 'stateful-datepicker-quick-select');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     await page.click(selectors.quickSelect);
-    await page.waitFor(selectors.quickSelectMenu);
+    await page.waitForSelector(selectors.quickSelectMenu);
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
 
@@ -54,11 +54,11 @@ describe('Stateful Datepicker Quick Select', () => {
 
   it('can quick select with mouse', async () => {
     await mount(page, 'stateful-datepicker-quick-select');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     await page.click(selectors.quickSelect);
-    await page.waitFor(selectors.quickSelectMenu);
+    await page.waitForSelector(selectors.quickSelectMenu);
     await page.click(selectors.quickSelectPastMonth);
 
     const selectedValue = await page.$eval(

--- a/src/datepicker/__tests__/stateful-datepicker.e2e.js
+++ b/src/datepicker/__tests__/stateful-datepicker.e2e.js
@@ -31,56 +31,56 @@ describe('Stateful Datepicker', () => {
 
   it('passes basic a11y tests', async () => {
     await mount(page, 'stateful-datepicker');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });
 
   it('datepicker with min max date allows browsing', async () => {
     await mount(page, 'stateful-datepicker-min-max-date');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     await page.click(selectors.day);
-    await page.waitFor(selectors.calendar, {
+    await page.waitForSelector(selectors.calendar, {
       hidden: true,
     });
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
-    await page.waitFor(selectors.leftArrow);
+    await page.waitForSelector(selectors.calendar);
+    await page.waitForSelector(selectors.leftArrow);
     let value = await page.$eval(
       selectors.leftArrow,
       select => select.disabled,
     );
     expect(value).toBe(false);
     await page.click(selectors.leftArrow);
-    await page.waitFor(selectors.day, {
+    await page.waitForSelector(selectors.day, {
       hidden: true,
     });
-    await page.waitFor(selectors.leftArrow);
+    await page.waitForSelector(selectors.leftArrow);
     value = await page.$eval(selectors.leftArrow, select => select.disabled);
     expect(value).toBe(true);
-    await page.waitFor(selectors.selected);
+    await page.waitForSelector(selectors.selected);
     await page.click(selectors.selected);
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
-    await page.waitFor(selectors.leftArrow);
+    await page.waitForSelector(selectors.calendar);
+    await page.waitForSelector(selectors.leftArrow);
     value = await page.$eval(selectors.leftArrow, select => select.disabled);
     expect(value).toBe(true);
-    await page.waitFor(selectors.rightArrow);
+    await page.waitForSelector(selectors.rightArrow);
     value = await page.$eval(selectors.rightArrow, select => select.disabled);
     expect(value).toBe(false);
   });
 
   it('datepicker with min max date shows valid months in header dropdown', async () => {
     await mount(page, 'stateful-datepicker-min-max-date');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     await page.click(selectors.input);
-    await page.waitFor(selectors.calendar);
+    await page.waitForSelector(selectors.calendar);
     await page.click(selectors.monthYearSelectButton);
-    await page.waitFor(selectors.monthYearSelectMenu);
+    await page.waitForSelector(selectors.monthYearSelectMenu);
 
     let value = await page.$$eval('ul[role="listbox"] li', items => {
       // Return the first and last month year option

--- a/src/drawer/__tests__/drawer.e2e.js
+++ b/src/drawer/__tests__/drawer.e2e.js
@@ -28,14 +28,14 @@ jest.setTimeout(60000);
 describe('drawer', () => {
   it('drawer component handles focus changes properly', async () => {
     await mount(page, 'drawer');
-    await page.waitFor(selectors.closeButton);
+    await page.waitForSelector(selectors.closeButton);
     // close drawer to start fresh
     await page.click(selectors.closeButton);
-    await page.waitFor(selectors.closeButton, {
+    await page.waitForSelector(selectors.closeButton, {
       hidden: true,
     });
     await page.click(selectors.openDrawer);
-    await page.waitFor(selectors.drawer);
+    await page.waitForSelector(selectors.drawer);
 
     await page.keyboard.down('Shift');
     await page.keyboard.press('Tab');
@@ -57,7 +57,7 @@ describe('drawer', () => {
 
     // close again
     await page.click(selectors.closeButton);
-    await page.waitFor(selectors.closeButton, {
+    await page.waitForSelector(selectors.closeButton, {
       hidden: true,
     });
 
@@ -71,12 +71,12 @@ describe('drawer', () => {
   // This is a regression test to verify that elements in a portal will still work.
   it('allows interaction with select', async () => {
     await mount(page, 'drawer-select');
-    await page.waitFor(selectors.drawer);
+    await page.waitForSelector(selectors.drawer);
 
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     await page.click(optionAtPosition(1));
-    await page.waitFor(selectors.selectDropDown, {
+    await page.waitForSelector(selectors.selectDropDown, {
       hidden: true,
     });
 
@@ -89,35 +89,35 @@ describe('drawer', () => {
 
   it('closes one popover at a time on esc key press', async () => {
     await mount(page, 'drawer-select');
-    await page.waitFor(selectors.drawer);
+    await page.waitForSelector(selectors.drawer);
 
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
 
     await page.keyboard.press('Escape');
-    await page.waitFor(selectors.selectDropDown, {hidden: true});
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectDropDown, {hidden: true});
+    await page.waitForSelector(selectors.selectInput);
 
     await page.keyboard.press('Escape');
-    await page.waitFor(selectors.selectInput, {hidden: true});
+    await page.waitForSelector(selectors.selectInput, {hidden: true});
   });
 
   it('renders content even when hidden: with renderAll prop', async () => {
     await mount(page, 'drawer-render-all');
     // check for content while drawer is closed, then open
-    await page.waitFor(selectors.drawerContent);
+    await page.waitForSelector(selectors.drawerContent);
     await page.click(selectors.openDrawer);
-    await page.waitFor(selectors.drawer);
+    await page.waitForSelector(selectors.drawer);
 
     // check for content while drawer is open, then close
-    await page.waitFor(selectors.drawerContent);
-    await page.waitFor(selectors.closeButton);
+    await page.waitForSelector(selectors.drawerContent);
+    await page.waitForSelector(selectors.closeButton);
     await page.click(selectors.closeButton);
-    await page.waitFor(selectors.closeButton, {
+    await page.waitForSelector(selectors.closeButton, {
       hidden: true,
     });
 
     // check for content again
-    await page.waitFor(selectors.drawerContent);
+    await page.waitForSelector(selectors.drawerContent);
   });
 });

--- a/src/input/__tests__/input.e2e.js
+++ b/src/input/__tests__/input.e2e.js
@@ -20,21 +20,21 @@ const selectors = {
 describe('input', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'input');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });
 
   it('preset value is displayed', async () => {
     await mount(page, 'input');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
     const value = await page.$eval(selectors.input, input => input.value);
     expect(value).toBe('uber');
   });
 
   it('entered value is displayed', async () => {
     await mount(page, 'input');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
 
     await page.keyboard.type('_good');
 
@@ -45,14 +45,14 @@ describe('input', () => {
   describe('can clear values', () => {
     it('shows a clear value icon', async () => {
       await mount(page, 'input-clearable');
-      await page.waitFor(selectors.clearIcon, {
+      await page.waitForSelector(selectors.clearIcon, {
         visible: true,
       });
     });
 
     it('with escape key', async () => {
       await mount(page, 'input-clearable');
-      await page.waitFor(selectors.input);
+      await page.waitForSelector(selectors.input);
 
       let inputValue = await page.$eval(selectors.input, input => input.value);
       expect(inputValue).toBe('Thing');
@@ -63,14 +63,14 @@ describe('input', () => {
       inputValue = await page.$eval(selectors.input, input => input.value);
       expect(inputValue).toBe('');
 
-      await page.waitFor(selectors.clearIcon, {
+      await page.waitForSelector(selectors.clearIcon, {
         hidden: true,
       });
     });
 
     it('not with escape key when its disabled', async () => {
       await mount(page, 'input-clearable-noescape');
-      await page.waitFor(selectors.input);
+      await page.waitForSelector(selectors.input);
 
       let inputValue = await page.$eval(selectors.input, input => input.value);
       expect(inputValue).toBe('Thing');
@@ -84,7 +84,7 @@ describe('input', () => {
 
     it('with delete icon', async () => {
       await mount(page, 'input-clearable');
-      await page.waitFor(selectors.input);
+      await page.waitForSelector(selectors.input);
 
       let inputValue = await page.$eval(selectors.input, input => input.value);
       expect(inputValue).toBe('Thing');
@@ -94,14 +94,14 @@ describe('input', () => {
       inputValue = await page.$eval(selectors.input, input => input.value);
       expect(inputValue).toBe('');
 
-      await page.waitFor(selectors.clearIcon, {
+      await page.waitForSelector(selectors.clearIcon, {
         hidden: true,
       });
     });
 
     it('with delete icon via enter', async () => {
       await mount(page, 'input-clearable');
-      await page.waitFor(selectors.input);
+      await page.waitForSelector(selectors.input);
 
       let inputValue = await page.$eval(selectors.input, input => input.value);
       expect(inputValue).toBe('Thing');
@@ -112,14 +112,14 @@ describe('input', () => {
       inputValue = await page.$eval(selectors.input, input => input.value);
       expect(inputValue).toBe('');
 
-      await page.waitFor(selectors.clearIcon, {
+      await page.waitForSelector(selectors.clearIcon, {
         hidden: true,
       });
     });
 
     it('with delete icon via space', async () => {
       await mount(page, 'input-clearable');
-      await page.waitFor(selectors.input);
+      await page.waitForSelector(selectors.input);
 
       let inputValue = await page.$eval(selectors.input, input => input.value);
       expect(inputValue).toBe('Thing');
@@ -130,7 +130,7 @@ describe('input', () => {
       inputValue = await page.$eval(selectors.input, input => input.value);
       expect(inputValue).toBe('');
 
-      await page.waitFor(selectors.clearIcon, {
+      await page.waitForSelector(selectors.clearIcon, {
         hidden: true,
       });
     });
@@ -139,7 +139,7 @@ describe('input', () => {
     // verify that the input receiving the clear event is cleared and not another input
     it('clears the correct input', async () => {
       await mount(page, 'input-clearable');
-      await page.waitFor(selectors.input);
+      await page.waitForSelector(selectors.input);
 
       // verify first input value is "Thing"
       expect(await page.$eval(selectors.input, input => input.value)).toBe(
@@ -167,7 +167,7 @@ describe('input', () => {
     describe('while in a form', () => {
       beforeEach(async () => {
         await mount(page, 'input-password');
-        await page.waitFor(selectors.input);
+        await page.waitForSelector(selectors.input);
         // set global variable '__e2e__formSubmitted__' to false
         await page.evaluate(() => (window.__e2e__formSubmitted__ = false));
       });

--- a/src/menu/__tests__/menu.e2e.js
+++ b/src/menu/__tests__/menu.e2e.js
@@ -140,22 +140,22 @@ describe('menu-child', () => {
   it('opens child menu on hover', async () => {
     await mount(page, 'menu-child');
     await hoverItem(page, 0, 5);
-    await page.waitFor(childSelector);
+    await page.waitForSelector(childSelector);
   });
 
   it('allows child menu to release focus and closes menu when different menu item selected', async () => {
     await mount(page, 'menu-child');
     await hoverItem(page, 0, 5);
-    await page.waitFor(childSelector);
+    await page.waitForSelector(childSelector);
     await page.keyboard.press('ArrowLeft');
     await page.keyboard.press('ArrowDown');
-    await page.waitFor(childSelector, {hidden: true});
+    await page.waitForSelector(childSelector, {hidden: true});
   });
 
   it('highlights child menu item on hover', async () => {
     await mount(page, 'menu-child');
     await hoverItem(page, 0, 5);
-    await page.waitFor(childSelector);
+    await page.waitForSelector(childSelector);
 
     await hoverItem(page, 1, 5);
     const text = await findHighlightedLabel(page);
@@ -164,27 +164,27 @@ describe('menu-child', () => {
 
   it('renders content even when hidden: with renderAll prop', async () => {
     await mount(page, 'menu-child-render-all');
-    await page.waitFor(parentSelector);
-    await page.waitFor(childSelector);
+    await page.waitForSelector(parentSelector);
+    await page.waitForSelector(childSelector);
     await hoverItem(page, 0, 0);
 
     const parent = await page.$(parentSelector);
     const activeElement = await findActiveElement(page);
     const isEqual = await compareElements(page, parent, activeElement);
     expect(isEqual).toBe(true);
-    await page.waitFor(childSelector);
+    await page.waitForSelector(childSelector);
   });
 
   it('child menu clicks do not close if inside popover content', async () => {
     await mount(page, 'menu-child-in-popover');
     await page.click('button');
-    await page.waitFor(parentSelector);
+    await page.waitForSelector(parentSelector);
     await page.mouse.move(150, 159);
-    await page.waitFor(childSelector);
+    await page.waitForSelector(childSelector);
     await page.mouse.click(450, 159);
-    await page.waitFor(childSelector);
+    await page.waitForSelector(childSelector);
     await page.click('button');
-    await page.waitFor(childSelector, {hidden: true});
+    await page.waitForSelector(childSelector, {hidden: true});
   });
 
   it('keyboard navigation works when ancestor stopPropagations', async () => {

--- a/src/modal/__tests__/modal.e2e.js
+++ b/src/modal/__tests__/modal.e2e.js
@@ -28,14 +28,14 @@ const optionAtPosition = position =>
 describe('modal', () => {
   it('handles focus changes properly', async () => {
     await mount(page, 'modal');
-    await page.waitFor(selectors.closeButton);
+    await page.waitForSelector(selectors.closeButton);
     // close modal to start fresh
     await page.click(selectors.closeButton);
-    await page.waitFor(selectors.closeButton, {
+    await page.waitForSelector(selectors.closeButton, {
       hidden: true,
     });
     await page.click(selectors.openModal);
-    await page.waitFor(selectors.dialog);
+    await page.waitForSelector(selectors.dialog);
 
     const cancelButtonIsFocused = await page.$eval(
       selectors.cancelButton,
@@ -65,7 +65,7 @@ describe('modal', () => {
 
     // close again
     await page.click(selectors.closeButton);
-    await page.waitFor(selectors.closeButton, {
+    await page.waitForSelector(selectors.closeButton, {
       hidden: true,
     });
 
@@ -79,12 +79,12 @@ describe('modal', () => {
   // This is a regression test to verify that elements in a portal will still work.
   it('allows interaction with select', async () => {
     await mount(page, 'modal-select');
-    await page.waitFor(selectors.dialog);
+    await page.waitForSelector(selectors.dialog);
 
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     await page.click(optionAtPosition(1));
-    await page.waitFor(selectors.selectDropDown, {
+    await page.waitForSelector(selectors.selectDropDown, {
       hidden: true,
     });
 
@@ -97,37 +97,37 @@ describe('modal', () => {
 
   it('closes one layer at a time on click outside', async () => {
     await mount(page, 'modal-select');
-    await page.waitFor(selectors.dialog);
+    await page.waitForSelector(selectors.dialog);
 
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
 
     // clicking outside of the modal content
     // and outside the select dropdown
     await page.click(selectors.openModal);
-    await page.waitFor(selectors.selectDropDown, {
+    await page.waitForSelector(selectors.selectDropDown, {
       hidden: true,
     });
-    await page.waitFor(selectors.dialog);
+    await page.waitForSelector(selectors.dialog);
 
     await page.click(selectors.openModal);
-    await page.waitFor(selectors.dialog, {
+    await page.waitForSelector(selectors.dialog, {
       hidden: true,
     });
   });
 
   it('closes one popover at a time on esc key press', async () => {
     await mount(page, 'modal-select');
-    await page.waitFor(selectors.dialog);
+    await page.waitForSelector(selectors.dialog);
 
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
 
     await page.keyboard.press('Escape');
-    await page.waitFor(selectors.selectDropDown, {hidden: true});
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectDropDown, {hidden: true});
+    await page.waitForSelector(selectors.selectInput);
 
     await page.keyboard.press('Escape');
-    await page.waitFor(selectors.selectInput, {hidden: true});
+    await page.waitForSelector(selectors.selectInput, {hidden: true});
   });
 });

--- a/src/pagination/__tests__/pagination.e2e.js
+++ b/src/pagination/__tests__/pagination.e2e.js
@@ -18,14 +18,14 @@ const selectors = {
 describe('pagination', () => {
   it('passes basic accessibility tests', async () => {
     await mount(page, 'pagination');
-    await page.waitFor(selectors.prevButton);
+    await page.waitForSelector(selectors.prevButton);
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });
 
   it('can be navigated using the prev and next buttons', async () => {
     await mount(page, 'pagination');
-    await page.waitFor(selectors.prevButton);
+    await page.waitForSelector(selectors.prevButton);
     // assert initial state
     const initialValue = await page.$eval(
       selectors.dropDownButton,
@@ -52,7 +52,7 @@ describe('pagination', () => {
 
   it('can be navigated using the dropdown menu', async () => {
     await mount(page, 'pagination');
-    await page.waitFor(selectors.prevButton);
+    await page.waitForSelector(selectors.prevButton);
     // assert initial state
     const initialValue = await page.$eval(
       selectors.dropDownButton,

--- a/src/payment-card/__tests__/payment-card.e2e.js
+++ b/src/payment-card/__tests__/payment-card.e2e.js
@@ -17,7 +17,7 @@ const selectors = {
 describe('PaymentCard', () => {
   beforeEach(async () => {
     await mount(page, 'stateful-payment-card');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
   });
 
   it('passes basic a11y tests', async () => {

--- a/src/phone-input/__tests__/phone-input-next-dropdown.e2e.js
+++ b/src/phone-input/__tests__/phone-input-next-dropdown.e2e.js
@@ -27,7 +27,7 @@ const UK = {iso: 'GB', dialCode: '+44'};
 describe('PhoneInput', () => {
   beforeEach(async () => {
     await mount(page, 'phone-input-next-dropdown');
-    await page.waitFor(selectors.phoneInput);
+    await page.waitForSelector(selectors.phoneInput);
   });
 
   it('passes basic a11y tests', async () => {
@@ -40,9 +40,9 @@ describe('PhoneInput', () => {
     // click select
     await page.click(selectors.countryPicker);
     // verify dropdown is open
-    await page.waitFor(selectors.countryPickerDropdown);
+    await page.waitForSelector(selectors.countryPickerDropdown);
     // select a new country - UK
-    await page.waitFor(countryListItemForIso(UK.iso));
+    await page.waitForSelector(countryListItemForIso(UK.iso));
     await page.click(countryListItemForIso(UK.iso));
     // verify dropdown has closed
     await page.waitForSelector(selectors.countryPickerDropdown, {

--- a/src/phone-input/__tests__/phone-input.e2e.js
+++ b/src/phone-input/__tests__/phone-input.e2e.js
@@ -30,7 +30,7 @@ const unitedKingdom = {iso: 'GB', dialCode: '+44'};
 describe('PhoneInput', () => {
   beforeEach(async () => {
     await mount(page, 'phone-input');
-    await page.waitFor(selectors.phoneInput);
+    await page.waitForSelector(selectors.phoneInput);
   });
 
   it('passes basic a11y tests', async () => {
@@ -56,7 +56,7 @@ describe('PhoneInput', () => {
     // click select
     await page.click(selectors.phoneInputSelect);
     // verify dropdown is open
-    await page.waitFor(selectors.phoneInputSelectDropdown);
+    await page.waitForSelector(selectors.phoneInputSelectDropdown);
     // // verify US option is visible
     await page.waitForSelector(countryListItemForIso(unitedStates.iso), {
       visible: true,
@@ -67,7 +67,7 @@ describe('PhoneInput', () => {
     // click select
     await page.click(selectors.phoneInputSelect);
     // verify dropdown is open
-    await page.waitFor(selectors.phoneInputSelectDropdown);
+    await page.waitForSelector(selectors.phoneInputSelectDropdown);
 
     await page.keyboard.type('United');
     await page.keyboard.press('ArrowDown');
@@ -86,7 +86,7 @@ describe('PhoneInput', () => {
     // click select
     await page.click(selectors.phoneInputSelect);
     // verify dropdown is open
-    await page.waitFor(selectors.phoneInputSelectDropdown);
+    await page.waitForSelector(selectors.phoneInputSelectDropdown);
     // select a new country, United Kingdom
     await page.click(countryListItemForIso(unitedKingdom.iso));
     // verify dropdown has closed

--- a/src/pin-code/__tests__/pin-code.e2e.js
+++ b/src/pin-code/__tests__/pin-code.e2e.js
@@ -27,7 +27,7 @@ function compareElements(page, a, b) {
 describe('PinCode', () => {
   beforeEach(async () => {
     await mount(page, 'pin-code');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
   });
 
   it('passes basic a11y tests', async () => {
@@ -109,7 +109,7 @@ describe('PinCode', () => {
 describe('PinCodeMask', () => {
   beforeEach(async () => {
     await mount(page, 'pin-code-mask');
-    await page.waitFor(selectors.input);
+    await page.waitForSelector(selectors.input);
   });
 
   it('successfully masks', async () => {

--- a/src/popover/__tests__/popover-focus-loop.e2e.js
+++ b/src/popover/__tests__/popover-focus-loop.e2e.js
@@ -12,17 +12,17 @@ const {mount} = require('../../../e2e/helpers');
 describe('popover', () => {
   it('hover trigger does not cause loop on click', async () => {
     await mount(page, 'popover-focus-loop');
-    await page.waitFor('button');
+    await page.waitForSelector('button');
     await page.hover('button');
-    await page.waitFor('div[data-e2e="content"]');
+    await page.waitForSelector('div[data-e2e="content"]');
 
     await page.click('button');
-    await page.waitFor('div[data-e2e="content"]', {hidden: true});
+    await page.waitForSelector('div[data-e2e="content"]', {hidden: true});
     await page.click('button');
-    await page.waitFor('div[data-e2e="content"]', {hidden: true});
+    await page.waitForSelector('div[data-e2e="content"]', {hidden: true});
 
     await page.mouse.move(0, 0);
     await page.hover('button');
-    await page.waitFor('div[data-e2e="content"]');
+    await page.waitForSelector('div[data-e2e="content"]');
   });
 });

--- a/src/popover/__tests__/popover-unreliable.e2e.js
+++ b/src/popover/__tests__/popover-unreliable.e2e.js
@@ -26,29 +26,29 @@ describe('popover', () => {
 
   it('closes one popover at a time on esc key press', async () => {
     await mount(page, 'popover-select');
-    await page.waitFor('button');
+    await page.waitForSelector('button');
     await page.click('button');
-    await page.waitFor(selectors.tooltip);
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.tooltip);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
 
     await page.keyboard.press('Escape');
-    await page.waitFor(selectors.selectDropDown, {hidden: true});
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectDropDown, {hidden: true});
+    await page.waitForSelector(selectors.selectInput);
 
     await page.keyboard.press('Escape');
-    await page.waitFor(selectors.selectInput, {hidden: true});
+    await page.waitForSelector(selectors.selectInput, {hidden: true});
   });
 
   it('closes one popover at a time on click outside', async () => {
     await mount(page, 'popover-select');
-    await page.waitFor('button');
+    await page.waitForSelector('button');
     await page.click('button');
-    await page.waitFor(selectors.tooltip);
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.tooltip);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     // Both popovers opened at this point.
     // Verify that popovers are not nested but rendered in a flat layers way
     // where every new layer rendered as a sibling to the rest of layers
@@ -66,12 +66,12 @@ describe('popover', () => {
     // First document and outside of the popovers click
     // closes only the top-most popover
     await page.click(selectors.outsideOfPopover);
-    await page.waitFor(selectors.selectDropDown, {hidden: true});
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectDropDown, {hidden: true});
+    await page.waitForSelector(selectors.selectInput);
 
     // Second document and outside of the remaining popover click
     // closes only the that popover
     await page.click(selectors.outsideOfPopover);
-    await page.waitFor(selectors.selectInput, {hidden: true});
+    await page.waitForSelector(selectors.selectInput, {hidden: true});
   });
 });

--- a/src/popover/__tests__/popover.e2e.js
+++ b/src/popover/__tests__/popover.e2e.js
@@ -7,7 +7,11 @@ LICENSE file in the root directory of this source tree.
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-const {mount, analyzeAccessibility} = require('../../../e2e/helpers');
+const {
+  mount,
+  analyzeAccessibility,
+  waitForTimeout,
+} = require('../../../e2e/helpers');
 
 const selectors = {
   popover: '[data-baseweb="popover"]',
@@ -23,37 +27,37 @@ const selectors = {
 describe('popover', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'popover');
-    await page.waitFor(selectors.tooltip);
+    await page.waitForSelector(selectors.tooltip);
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });
 
   it('hover opens the popover', async () => {
     await mount(page, 'popover-hover');
-    await page.waitFor('button');
+    await page.waitForSelector('button');
     await page.hover('button');
-    await page.waitFor(selectors.tooltip);
+    await page.waitForSelector(selectors.tooltip);
     await page.mouse.move(0, 0);
-    await page.waitFor(selectors.tooltip, {hidden: true});
+    await page.waitForSelector(selectors.tooltip, {hidden: true});
   });
 
   it('opened popover can be closed with ESC', async () => {
     await mount(page, 'popover-click');
-    await page.waitFor('button');
+    await page.waitForSelector('button');
     await page.click('button');
-    await page.waitFor(selectors.tooltip);
+    await page.waitForSelector(selectors.tooltip);
     await page.keyboard.press('Escape');
-    await page.waitFor(selectors.tooltip, {hidden: true});
+    await page.waitForSelector(selectors.tooltip, {hidden: true});
   });
 
   it('allows interaction with select', async () => {
     await mount(page, 'popover-select');
-    await page.waitFor('button');
+    await page.waitForSelector('button');
     await page.click('button');
-    await page.waitFor(selectors.tooltip);
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.tooltip);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     // Both popovers opened at this point.
     // Make sure that layers rendered flat and not nested.
     const noNestedPopovers = await page.$$eval(selectors.popover, popovers => {
@@ -68,7 +72,7 @@ describe('popover', () => {
     // Select an option from the select dropdown
     const options = await page.$$(selectors.dropDownOption);
     await options[0].click();
-    await page.waitFor(selectors.selectDropDown, {hidden: true});
+    await page.waitForSelector(selectors.selectDropDown, {hidden: true});
 
     const selectedValue = await page.$eval(
       selectors.selectedList,
@@ -77,19 +81,19 @@ describe('popover', () => {
     expect(selectedValue).toBe('AliceBlue');
     // Click outside to close the initial popover
     await page.click(selectors.outsideOfPopover);
-    await page.waitFor(selectors.selectInput, {hidden: true});
+    await page.waitForSelector(selectors.selectInput, {hidden: true});
   });
 
   it('renders content even when hidden: with renderAll prop', async () => {
     await mount(page, 'popover-render-all');
-    await page.waitFor('button');
-    await page.waitFor(selectors.content);
+    await page.waitForSelector('button');
+    await page.waitForSelector(selectors.content);
     await page.click('button');
-    await page.waitFor(selectors.tooltip);
-    await page.waitFor(selectors.content);
+    await page.waitForSelector(selectors.tooltip);
+    await page.waitForSelector(selectors.content);
     await page.keyboard.press('Escape');
-    await page.waitFor(selectors.tooltip, {hidden: true});
-    await page.waitFor(selectors.content);
+    await page.waitForSelector(selectors.tooltip, {hidden: true});
+    await page.waitForSelector(selectors.content);
   });
 
   it('updates position when width of popover changes', async () => {
@@ -98,8 +102,8 @@ describe('popover', () => {
     let popover = await page.$('#e2e-popover');
     const {x: startX, width: startWidth} = await popover.boundingBox();
     await page.click('#e2e-update');
-    await page.waitFor('#e2e-expanded');
-    await page.waitFor(1000); // wait for animation
+    await page.waitForSelector('#e2e-expanded');
+    await waitForTimeout(1000); // wait for animation
     const {x: endX, width: endWidth} = await popover.boundingBox();
     expect(endWidth).toBeGreaterThan(startWidth);
     expect(endX).toBeLessThan(startX);

--- a/src/progress-bar/__tests__/progressbar.e2e.js
+++ b/src/progress-bar/__tests__/progressbar.e2e.js
@@ -13,7 +13,7 @@ const {mount, analyzeAccessibility} = require('../../../e2e/helpers');
 describe('Progress Bar', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'progressbar');
-    await page.waitFor('[role="progressbar"]');
+    await page.waitForSelector('[role="progressbar"]');
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });

--- a/src/progress-steps/__tests__/progress-steps.e2e.js
+++ b/src/progress-steps/__tests__/progress-steps.e2e.js
@@ -19,14 +19,14 @@ const selectors = {
 describe('progress steps', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'progress-steps');
-    await page.waitFor(selectors.nextButton);
+    await page.waitForSelector(selectors.nextButton);
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });
 
   it('can be moved to the next step, and back too', async () => {
     await mount(page, 'progress-steps');
-    await page.waitFor(selectors.nextButton);
+    await page.waitForSelector(selectors.nextButton);
 
     // verifies that the first content block is visible
     let firstContent = await page.$eval(

--- a/src/rating/__tests__/rating.e2e.js
+++ b/src/rating/__tests__/rating.e2e.js
@@ -18,14 +18,14 @@ const selectors = {
 describe('Rating', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'rating-star');
-    await page.waitFor(selectors.container);
+    await page.waitForSelector(selectors.container);
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });
 
   it('for a value of three, three stars are highlighted', async () => {
     await mount(page, 'rating-star');
-    await page.waitFor(selectors.container);
+    await page.waitForSelector(selectors.container);
 
     const highlightedStars = await page.$$eval(
       selectors.checked,
@@ -36,7 +36,7 @@ describe('Rating', () => {
 
   it('for a value of three, the third emoticon is highlighted', async () => {
     await mount(page, 'rating-emoticon');
-    await page.waitFor(selectors.container);
+    await page.waitForSelector(selectors.container);
 
     const highlightedEmoticons = await page.$$eval(
       selectors.checked,

--- a/src/select/__tests__/select-backspace-behavior.e2e.js
+++ b/src/select/__tests__/select-backspace-behavior.e2e.js
@@ -16,7 +16,7 @@ describe('select backspace works as expected', () => {
   it('backspace one character', async () => {
     await mount(page, 'select-backspace-behavior');
     const selector = `#backspace-behavior ${SELECT_INPUT}`;
-    await page.waitFor(selector);
+    await page.waitForSelector(selector);
     const input = await page.$(selector);
 
     // Select AliceBlue
@@ -32,7 +32,7 @@ describe('select backspace works as expected', () => {
   it('backspace clears input value', async () => {
     await mount(page, 'select-backspace-behavior');
     const selector = `#backspace-clears-input-value ${SELECT_INPUT}`;
-    await page.waitFor(selector);
+    await page.waitForSelector(selector);
     const input = await page.$(selector);
 
     // Select AliceBlue

--- a/src/select/__tests__/select-calls-provided-blur.e2e.js
+++ b/src/select/__tests__/select-calls-provided-blur.e2e.js
@@ -24,7 +24,7 @@ function getActiveTag(page) {
 describe('select option click returns focus', () => {
   it('calls provided blur function when another element is focused', async () => {
     await mount(page, 'select-calls-provided-blur');
-    await page.waitFor(SELECT_INPUT);
+    await page.waitForSelector(SELECT_INPUT);
 
     const input = await page.$(SELECT_INPUT);
     await input.click();

--- a/src/select/__tests__/select-click-maintains-focus.e2e.js
+++ b/src/select/__tests__/select-click-maintains-focus.e2e.js
@@ -24,7 +24,7 @@ function getActiveTag(page) {
 describe('select option click returns focus', () => {
   it('returns focus to select input after clicking option', async () => {
     await mount(page, 'select-click-maintains-focus');
-    await page.waitFor(SELECT_INPUT);
+    await page.waitForSelector(SELECT_INPUT);
 
     const input = await page.$(SELECT_INPUT);
     await input.click();

--- a/src/select/__tests__/select-maintains-input-value.e2e.js
+++ b/src/select/__tests__/select-maintains-input-value.e2e.js
@@ -16,7 +16,7 @@ describe('select option maintains input value after actions', () => {
   it('maintains input value after blur action', async () => {
     await mount(page, 'select-maintains-input-value');
     const selector = `#maintain-after-blur ${SELECT_INPUT}`;
-    await page.waitFor(selector);
+    await page.waitForSelector(selector);
     const input = await page.$(selector);
     await input.type('a');
     await page.keyboard.press('Tab');
@@ -27,7 +27,7 @@ describe('select option maintains input value after actions', () => {
   it('maintains input value after close action', async () => {
     await mount(page, 'select-maintains-input-value');
     const selector = `#maintain-after-close ${SELECT_INPUT}`;
-    await page.waitFor(selector);
+    await page.waitForSelector(selector);
     const input = await page.$(selector);
     await input.type('a');
     await page.keyboard.press('Escape');
@@ -38,7 +38,7 @@ describe('select option maintains input value after actions', () => {
   it('maintains input value after select action', async () => {
     await mount(page, 'select-maintains-input-value');
     const selector = `#maintain-after-select ${SELECT_INPUT}`;
-    await page.waitFor(selector);
+    await page.waitForSelector(selector);
     const input = await page.$(selector);
     await input.type('a');
     await page.click('li');
@@ -49,7 +49,7 @@ describe('select option maintains input value after actions', () => {
   it('maintains input value after any action', async () => {
     await mount(page, 'select-maintains-input-value');
     const selector = `#maintain-after-all ${SELECT_INPUT}`;
-    await page.waitFor(selector);
+    await page.waitForSelector(selector);
     const input = await page.$(selector);
 
     await input.type('a');

--- a/src/select/__tests__/select.e2e.js
+++ b/src/select/__tests__/select.e2e.js
@@ -39,29 +39,29 @@ describe('select', () => {
 
   it('opens dropdown menu when click on select input', async () => {
     await mount(page, 'select');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
   });
 
   it('opened dropdown can be closed with ESC', async () => {
     await mount(page, 'select');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     await page.keyboard.press('Escape');
-    await page.waitFor(selectors.selectDropDown, {
+    await page.waitForSelector(selectors.selectDropDown, {
       hidden: true,
     });
   });
 
   it('selects option when clicked in dropdown', async () => {
     await mount(page, 'select-search-single');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     await page.click(optionAtPosition(1));
-    await page.waitFor(selectors.selectDropDown, {
+    await page.waitForSelector(selectors.selectDropDown, {
       hidden: true,
     });
 
@@ -74,11 +74,11 @@ describe('select', () => {
 
   it('doesnt allow to click and select disabled options', async () => {
     await mount(page, 'select-search-single');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     await page.click(optionAtPosition(2));
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     const selectedValue = await page.$eval(
       selectors.selectedList,
       select => select.textContent,
@@ -88,7 +88,7 @@ describe('select', () => {
 
   it('allows left/right arrow keys to navigate search text', async () => {
     await mount(page, 'select-search-single');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.focus(selectors.selectInput);
     await page.keyboard.type('Aqua');
     await page.keyboard.press('ArrowLeft');
@@ -102,7 +102,7 @@ describe('select', () => {
 
   it('renders clear button after input text is typed in', async () => {
     await mount(page, 'select-search-single');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.focus(selectors.selectInput);
 
     await page.keyboard.type('a');
@@ -122,22 +122,22 @@ describe('select', () => {
 
   it('does not close dropdown after multiple selections were made', async () => {
     await mount(page, 'select-search-multi');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     await page.click(optionAtPosition(1));
-    await page.waitFor(optionAtPosition(3));
+    await page.waitForSelector(optionAtPosition(3));
     await page.click(optionAtPosition(3));
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
   });
 
   it('selects options when search input successful with results', async () => {
     await mount(page, 'select-search-multi');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
     await page.type(selectors.selectInput, 'dark');
-    await page.waitFor(selectors.selectDropDown);
-    await page.waitFor(optionAtPosition(2));
+    await page.waitForSelector(selectors.selectDropDown);
+    await page.waitForSelector(optionAtPosition(2));
     await page.click(optionAtPosition(1));
     const selectedValue = await page.$eval(
       selectors.selectedList,
@@ -148,9 +148,9 @@ describe('select', () => {
 
   it('subsequent multi select dropdown opens highlights first value', async () => {
     await mount(page, 'select-search-multi');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     await page.keyboard.press('Enter');
 
     const first = await page.$eval(
@@ -169,9 +169,9 @@ describe('select', () => {
 
   it('subsequent multi select dropdown opens highlights first value after keyboard navigation', async () => {
     await mount(page, 'select-search-multi');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('ArrowDown');
@@ -188,9 +188,9 @@ describe('select', () => {
 
   it('creates and selects a new option', async () => {
     await mount(page, 'select-creatable');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     await page.keyboard.type('Paris');
     const option1Text = await page.$eval(
       optionAtPosition(1),
@@ -207,13 +207,13 @@ describe('select', () => {
 
   it('shows the no result msg if there are no options', async () => {
     await mount(page, 'select-creatable-multi');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     await page.click(optionAtPosition(1));
 
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
     const dropdown = await page.$(selectors.selectDropDown);
     const text = await page.evaluate(
       dropdown => dropdown.textContent,
@@ -224,9 +224,9 @@ describe('select', () => {
 
   it('creates multiple options', async () => {
     await mount(page, 'select-creatable-multi');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
-    await page.waitFor(selectors.selectDropDown);
+    await page.waitForSelector(selectors.selectDropDown);
 
     // add "Paris"
     await page.keyboard.type('Paris');
@@ -254,7 +254,7 @@ describe('select', () => {
 
   it('selects second option without mouse or arrow keys', async () => {
     await mount(page, 'select-search-multi');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
     await page.type(selectors.selectInput, 'dark');
     await page.keyboard.press('Enter');
@@ -269,7 +269,7 @@ describe('select', () => {
 
   it('renders expected grouped list items', async () => {
     await mount(page, 'select-option-group');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.click(selectors.selectInput);
     const listElements = await page.$$('li');
     const actual = await Promise.all(
@@ -294,7 +294,7 @@ describe('select', () => {
 
   it('renders expected grouped list items if filtered', async () => {
     await mount(page, 'select-option-group');
-    await page.waitFor(selectors.selectInput);
+    await page.waitForSelector(selectors.selectInput);
     await page.focus(selectors.selectInput);
     await page.keyboard.type('Aqua');
     const listElements = await page.$$('li');
@@ -314,7 +314,7 @@ describe('select', () => {
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
-    await page.waitFor(selectors.selectDropDown, {
+    await page.waitForSelector(selectors.selectDropDown, {
       hidden: true,
     });
     const selectedValue = await page.$eval(

--- a/src/side-navigation/__tests__/nav.e2e.js
+++ b/src/side-navigation/__tests__/nav.e2e.js
@@ -17,7 +17,7 @@ const selectors = {
 describe('side navigation', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'nav');
-    await page.waitFor(selectors.root);
+    await page.waitForSelector(selectors.root);
     const accessibilityReport = await analyzeAccessibility(page, {
       rules: [
         {

--- a/src/tabs-motion/__tests__/tabs-motion.e2e.js
+++ b/src/tabs-motion/__tests__/tabs-motion.e2e.js
@@ -38,7 +38,7 @@ const isActiveEl = async el => {
 describe('tabs', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'tabs-motion');
-    await page.waitFor('[role="tab"]');
+    await page.waitForSelector('[role="tab"]');
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });

--- a/src/tabs/__tests__/tabs.e2e.js
+++ b/src/tabs/__tests__/tabs.e2e.js
@@ -12,14 +12,14 @@ const {mount, analyzeAccessibility} = require('../../../e2e/helpers');
 describe('tabs', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'tabs');
-    await page.waitFor('[role="tab"]');
+    await page.waitForSelector('[role="tab"]');
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });
 
   it('changes content on tab click', async () => {
     await mount(page, 'tabs');
-    await page.waitFor('[role="tab"]');
+    await page.waitForSelector('[role="tab"]');
 
     // verify initial state, tab 0 is visible, tab 1 and 2 are hidden
     let states = [true, false, false];

--- a/src/textarea/__tests__/textarea.e2e.js
+++ b/src/textarea/__tests__/textarea.e2e.js
@@ -18,7 +18,7 @@ const selectors = {
 describe('textarea', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'textarea');
-    await page.waitFor(selectors.textarea);
+    await page.waitForSelector(selectors.textarea);
     const accessibilityReport = await analyzeAccessibility(page, {
       rules: [
         {
@@ -32,7 +32,7 @@ describe('textarea', () => {
 
   it('preset value is displayed', async () => {
     await mount(page, 'textarea');
-    await page.waitFor(selectors.textarea);
+    await page.waitForSelector(selectors.textarea);
 
     const value = await page.$eval(selectors.textarea, input => input.value);
     expect(value).toBe('initial value');
@@ -40,7 +40,7 @@ describe('textarea', () => {
 
   it('entered value is displayed', async () => {
     await mount(page, 'textarea');
-    await page.waitFor(selectors.textarea);
+    await page.waitForSelector(selectors.textarea);
     await page.click(selectors.textarea);
     await page.keyboard.type('!');
 
@@ -50,7 +50,7 @@ describe('textarea', () => {
 
   it('can be cleared with a click', async () => {
     await mount(page, 'textarea');
-    await page.waitFor(selectors.textarea);
+    await page.waitForSelector(selectors.textarea);
     await page.click(selectors.textarea);
     await page.keyboard.type('Something or other');
     await page.click(selectors.clearIcon);
@@ -60,7 +60,7 @@ describe('textarea', () => {
 
   it('can be cleared with escape', async () => {
     await mount(page, 'textarea');
-    await page.waitFor(selectors.textarea);
+    await page.waitForSelector(selectors.textarea);
     await page.click(selectors.textarea);
     await page.keyboard.type('Something or other');
     await page.keyboard.press('Escape');

--- a/src/timepicker/__tests__/time-picker.e2e.js
+++ b/src/timepicker/__tests__/time-picker.e2e.js
@@ -27,16 +27,16 @@ const selectors = {
 describe('TimePicker', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'time-picker');
-    await page.waitFor(selectors.twelveHour);
+    await page.waitForSelector(selectors.twelveHour);
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });
 
   it('is renders expected 12 hour format times', async () => {
     await mount(page, 'time-picker');
-    await page.waitFor(selectors.twelveHour);
+    await page.waitForSelector(selectors.twelveHour);
     await page.click(`${selectors.twelveHour} ${selectors.input}`);
-    await page.waitFor(selectors.dropdown);
+    await page.waitForSelector(selectors.dropdown);
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('ArrowDown');
@@ -64,9 +64,9 @@ describe('TimePicker', () => {
 
   it('is renders expected 24 hour format times with custom step', async () => {
     await mount(page, 'time-picker');
-    await page.waitFor(selectors.twentyFourHour);
+    await page.waitForSelector(selectors.twentyFourHour);
     await page.click(`${selectors.twentyFourHour} ${selectors.input}`);
-    await page.waitFor(selectors.dropdown);
+    await page.waitForSelector(selectors.dropdown);
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('ArrowDown');
@@ -95,8 +95,8 @@ describe('TimePicker', () => {
 
   it('renders a date that is not one of the steps', async () => {
     await mount(page, 'time-picker');
-    await page.waitFor(selectors.twelveHourCreatable);
-    await page.waitFor(selectors.twentyFourHourCreatable);
+    await page.waitForSelector(selectors.twelveHourCreatable);
+    await page.waitForSelector(selectors.twentyFourHourCreatable);
 
     const twelveHourValue = await page.$eval(
       `${selectors.twelveHourCreatable} ${selectors.value}`,
@@ -115,9 +115,9 @@ describe('TimePicker', () => {
   describe('creatable', () => {
     it('shows both AM and PM options when a 12-hour time without meridiem is entered', async () => {
       await mount(page, 'time-picker');
-      await page.waitFor(selectors.twelveHourCreatable);
+      await page.waitForSelector(selectors.twelveHourCreatable);
       await page.click(`${selectors.twelveHourCreatable} ${selectors.input}`);
-      await page.waitFor(selectors.dropdown);
+      await page.waitForSelector(selectors.dropdown);
       await page.keyboard.type('3:33');
 
       const options = await page.$$(`${selectors.option}`);
@@ -131,9 +131,9 @@ describe('TimePicker', () => {
 
     it('shows AM option when a 12-hour time with partial meridiem is entered', async () => {
       await mount(page, 'time-picker');
-      await page.waitFor(selectors.twelveHourCreatable);
+      await page.waitForSelector(selectors.twelveHourCreatable);
       await page.click(`${selectors.twelveHourCreatable} ${selectors.input}`);
-      await page.waitFor(selectors.dropdown);
+      await page.waitForSelector(selectors.dropdown);
       await page.keyboard.type('3:33a');
 
       const options = await page.$$(`${selectors.option}`);
@@ -145,9 +145,9 @@ describe('TimePicker', () => {
 
     it('generates the correct seconds for 12PM', async () => {
       await mount(page, 'time-picker');
-      await page.waitFor(selectors.twelveHourCreatable);
+      await page.waitForSelector(selectors.twelveHourCreatable);
       await page.click(`${selectors.twelveHourCreatable} ${selectors.input}`);
-      await page.waitFor(selectors.dropdown);
+      await page.waitForSelector(selectors.dropdown);
       await page.keyboard.type('12:11pm');
       await page.keyboard.press('ArrowDown');
       await page.keyboard.press('Enter');
@@ -174,9 +174,9 @@ describe('TimePicker', () => {
 
     it('generates the correct seconds for 12AM', async () => {
       await mount(page, 'time-picker');
-      await page.waitFor(selectors.twelveHourCreatable);
+      await page.waitForSelector(selectors.twelveHourCreatable);
       await page.click(`${selectors.twelveHourCreatable} ${selectors.input}`);
-      await page.waitFor(selectors.dropdown);
+      await page.waitForSelector(selectors.dropdown);
       await page.keyboard.type('12:22am');
       await page.keyboard.press('ArrowDown');
       await page.keyboard.press('Enter');
@@ -191,11 +191,11 @@ describe('TimePicker', () => {
 
     it('shows an option when a 24 hour time without leading zero is entered', async () => {
       await mount(page, 'time-picker');
-      await page.waitFor(selectors.twentyFourHourCreatable);
+      await page.waitForSelector(selectors.twentyFourHourCreatable);
       await page.click(
         `${selectors.twentyFourHourCreatable} ${selectors.input}`,
       );
-      await page.waitFor(selectors.dropdown);
+      await page.waitForSelector(selectors.dropdown);
       await page.keyboard.type('3:33');
 
       const options = await page.$$(`${selectors.option}`);
@@ -207,11 +207,11 @@ describe('TimePicker', () => {
 
     it('shows only one option when a time is entered that matches an existing option', async () => {
       await mount(page, 'time-picker');
-      await page.waitFor(selectors.twentyFourHourCreatable);
+      await page.waitForSelector(selectors.twentyFourHourCreatable);
       await page.click(
         `${selectors.twentyFourHourCreatable} ${selectors.input}`,
       );
-      await page.waitFor(selectors.dropdown);
+      await page.waitForSelector(selectors.dropdown);
       await page.keyboard.type('00:15');
 
       const options = await page.$$(`${selectors.option}`);
@@ -224,9 +224,9 @@ describe('TimePicker', () => {
   describe('when using moment', () => {
     it('is renders expected 24 hour format times with custom step', async () => {
       await mount(page, 'time-picker');
-      await page.waitFor(selectors.twentyFourHourMoment);
+      await page.waitForSelector(selectors.twentyFourHourMoment);
       await page.click(`${selectors.twentyFourHourMoment} ${selectors.input}`);
-      await page.waitFor(selectors.dropdown);
+      await page.waitForSelector(selectors.dropdown);
       await page.keyboard.press('ArrowDown');
       await page.keyboard.press('ArrowDown');
       await page.keyboard.press('ArrowDown');

--- a/src/timezonepicker/__tests__/timezone-picker.e2e.js
+++ b/src/timezonepicker/__tests__/timezone-picker.e2e.js
@@ -24,16 +24,16 @@ const labelToShortCode = label => label.split(' ')[0];
 describe('TimezonePicker', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'timezone-picker');
-    await page.waitFor(selectors.standard);
+    await page.waitForSelector(selectors.standard);
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });
 
   it('provides appropriate zone options if standard time', async () => {
     await mount(page, 'timezone-picker');
-    await page.waitFor(selectors.standard);
+    await page.waitForSelector(selectors.standard);
     await page.click(`${selectors.standard} ${selectors.input}`);
-    await page.waitFor(selectors.dropdown);
+    await page.waitForSelector(selectors.dropdown);
     await page.keyboard.type('new york');
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
@@ -47,9 +47,9 @@ describe('TimezonePicker', () => {
 
   it('provides appropriate zone options if daylight savings time', async () => {
     await mount(page, 'timezone-picker');
-    await page.waitFor(selectors.daylight);
+    await page.waitForSelector(selectors.daylight);
     await page.click(`${selectors.daylight} ${selectors.input}`);
-    await page.waitFor(selectors.dropdown);
+    await page.waitForSelector(selectors.dropdown);
     await page.keyboard.type('new york');
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
@@ -63,7 +63,7 @@ describe('TimezonePicker', () => {
 
   it('prioritizes select with controlled value over browser default', async () => {
     await mount(page, 'timezone-picker');
-    await page.waitFor(selectors.controlled);
+    await page.waitForSelector(selectors.controlled);
     const initial = await page.$eval(
       `${selectors.controlled} ${selectors.value}`,
       select => select.textContent,
@@ -73,9 +73,9 @@ describe('TimezonePicker', () => {
 
   it('provides appropriate zone options if no acronym exists', async () => {
     await mount(page, 'timezone-picker');
-    await page.waitFor(selectors.daylight);
+    await page.waitForSelector(selectors.daylight);
     await page.click(`${selectors.daylight} ${selectors.input}`);
-    await page.waitFor(selectors.dropdown);
+    await page.waitForSelector(selectors.dropdown);
     await page.keyboard.type('minsk');
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');

--- a/src/toast/__tests__/toast.e2e.js
+++ b/src/toast/__tests__/toast.e2e.js
@@ -28,14 +28,14 @@ const isActiveEl = async (page, selector) => {
 describe('toast', () => {
   it('passes basic a11y tests', async () => {
     await mount(page, 'toast');
-    await page.waitFor(selectors.toast);
+    await page.waitForSelector(selectors.toast);
     const accessibilityReport = await analyzeAccessibility(page);
     expect(accessibilityReport).toHaveNoAccessibilityIssues();
   });
 
   it('the close icon removes the notification', async () => {
     await mount(page, 'toast');
-    await page.waitFor(selectors.toast);
+    await page.waitForSelector(selectors.toast);
 
     const originalNumberOfAlerts = await page.$$eval(
       selectors.toast,
@@ -64,7 +64,7 @@ describe('toast', () => {
 
   it('opens two notifications if triggered twice (auto-generate incrementing keys)', async () => {
     await mount(page, 'toaster');
-    await page.waitFor(selectors.buttonDefault);
+    await page.waitForSelector(selectors.buttonDefault);
     await page.click(selectors.buttonDefault);
     await page.click(selectors.buttonDefault);
 
@@ -78,7 +78,7 @@ describe('toast', () => {
 
   it('updates existing notification if the same key is provided', async () => {
     await mount(page, 'toaster');
-    await page.waitFor(selectors.buttonSameKey);
+    await page.waitForSelector(selectors.buttonSameKey);
     await page.click(selectors.buttonSameKey);
     await page.click(selectors.buttonSameKey);
 
@@ -102,7 +102,7 @@ describe('toast', () => {
   it('focuses toast dismiss when autofocus is active and refocuses previously focused element on close', async () => {
     await mount(page, 'toaster-focus');
     await page.click(selectors.buttonDefault);
-    await page.waitFor(selectors.toast);
+    await page.waitForSelector(selectors.toast);
     const isDismissActive = await isActiveEl(page, selectors.dismiss);
     expect(isDismissActive).toBe(true);
     await page.click(selectors.dismiss);

--- a/src/tooltip/__tests__/tooltip.e2e.js
+++ b/src/tooltip/__tests__/tooltip.e2e.js
@@ -16,9 +16,9 @@ const selectors = {
 describe('tooltip', () => {
   it('passes basic a11y tests when hovered', async () => {
     await mount(page, 'tooltip');
-    await page.waitFor('span');
+    await page.waitForSelector('span');
     await page.hover('span');
-    await page.waitFor(selectors.tooltip);
+    await page.waitForSelector(selectors.tooltip);
     const accessibilityReport = await analyzeAccessibility(page);
     // focus locks applies guards with tabIndex=1 to trap the focus on purpose
     accessibilityReport.violations = accessibilityReport.violations.filter(

--- a/src/tree-view/__tests__/tree-view.e2e.js
+++ b/src/tree-view/__tests__/tree-view.e2e.js
@@ -46,7 +46,7 @@ describe('tree view', () => {
     const checkbox = '[data-baseweb="checkbox"]';
     const checkboxInput = '[data-baseweb="checkbox"] input';
     await mount(page, 'tree-view-interactable');
-    await page.waitFor(checkbox);
+    await page.waitForSelector(checkbox);
     let isChecked = await page.$eval(checkboxInput, i => i.checked);
     expect(isChecked).toBe(false);
     await page.click(checkbox);

--- a/vrt/config.js
+++ b/vrt/config.js
@@ -487,7 +487,7 @@ const config = {
             visible: true,
           });
           await page.click(firstOption);
-          await page.waitFor(dropdownSelector, {
+          await page.waitForSelector(dropdownSelector, {
             hidden: true,
           });
         },

--- a/vrt/tests.vrt.js
+++ b/vrt/tests.vrt.js
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
 const globby = require('globby');
 const {configureToMatchImageSnapshot} = require('jest-image-snapshot');
 const {getSnapshotConfig} = require('./config.js');
-const {mount} = require('../e2e/helpers');
+const {mount, waitForTimeout} = require('../e2e/helpers');
 
 const THEME = {
   light: 'light',
@@ -68,7 +68,7 @@ describe('visual snapshot tests', () => {
         await interaction.behavior(page);
 
         // Bad, but lets let things settle down after the interaction.
-        await page.waitFor(250);
+        await waitForTimeout(250);
 
         await snapshot(`${scenarioName}__${interaction.name}`);
       });
@@ -106,7 +106,7 @@ async function preparePageForSnapshot(
   });
 
   // Bad, but lets let things settle down after resizing.
-  await page.waitFor(250);
+  await waitForTimeout(250);
 }
 
 async function getPageScrollHeight() {


### PR DESCRIPTION
Puppeteer currently spams CI warning that `waitFor` is deprecated. This should clean it up

#### Scope
Patch: Bug Fix
