### PR TITLE
feat(table-semantic) add aria label prop for head cell

### DIFF
--- a/src/table-semantic/__tests__/table-builder.test.js
+++ b/src/table-semantic/__tests__/table-builder.test.js
@@ -238,4 +238,29 @@ describe('Table Semantic Builder', () => {
       }),
     );
   });
+
+  it('renders aria label for column header', () => {
+    const wrapper = mount(
+      <TableBuilder data={DATA}>
+        <TableBuilderColumn
+          header={<span>Foo</span>}
+          tableHeadAriaLabel="Foo Aria Label"
+          sortable
+        >
+          {row => row.foo}
+        </TableBuilderColumn>
+        <TableBuilderColumn header="Bar" sortable>
+          {row => <a href={row.url}>{row.bar}</a>}
+        </TableBuilderColumn>
+        <TableBuilderColumn>{row => 'Hey'}</TableBuilderColumn>
+      </TableBuilder>,
+    );
+
+    const headCells = wrapper.find(StyledTableHeadCellSortable);
+
+    expect(headCells.at(0).prop('aria-label')).toBe(
+      'Foo Aria Label, ascending sorting',
+    );
+    expect(headCells.at(1).prop('aria-label')).toBe('Bar, ascending sorting');
+  });
 });

--- a/src/table-semantic/index.d.ts
+++ b/src/table-semantic/index.d.ts
@@ -54,6 +54,7 @@ export interface TableBuilderColumnProps<RowT> {
   header?: React.ReactNode;
   numeric?: boolean;
   sortable?: boolean;
+  tableHeadAriaLabel?: string;
 }
 export class TableBuilderColumn<RowT> extends React.Component<
   TableBuilderColumnProps<RowT>

--- a/src/table-semantic/table-builder.js
+++ b/src/table-semantic/table-builder.js
@@ -192,7 +192,7 @@ export default class TableBuilder<T> extends React.Component<
           $colIndex={colIndex}
           role="button"
           tabIndex="0"
-          aria-label={`${col.header}, ${sortLabel}`}
+          aria-label={`${col.tableHeadAriaLabel || col.header}, ${sortLabel}`}
           $isFocusVisible={isFocusVisible}
           onClick={() => onSort && onSort(col.id)}
           onKeyDown={(e: KeyboardEvent) => {

--- a/src/table-semantic/types.js
+++ b/src/table-semantic/types.js
@@ -61,4 +61,5 @@ export type TableBuilderColumnPropsT<RowT> = {
   header?: React.Node,
   numeric?: boolean,
   sortable?: boolean,
+  tableHeadAriaLabel?: string,
 };


### PR DESCRIPTION
#### Description
The TableBuilderColumn supports passing React.Node in header prop. 
But the area-label generated for `th` tag doesn't render text properly in this case:
```
<th ... aria-label="[object Object], not sorted">...
```
In this PR I am proposing to add a new optional property `tableHeadAriaLabel` to be shown in aria-label

#### Scope
Patch: Bug Fix