### PR TITLE
chore(test): fail unit tests of console warn/error

### DIFF
--- a/src/test/test-setup.js
+++ b/src/test/test-setup.js
@@ -9,3 +9,30 @@ import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({adapter: new Adapter()});
+
+// At some point baseui published with errors in unit-tests that caused problems for users.
+// The assertions below will fail unit-tests if any errors or warnings are logs so that we
+// can have greater certainty that fewer bugs are published.
+// https://github.com/facebook/jest/issues/6121
+
+function applyErrorDetails(message) {
+  return `Failing unit test due to unexpected console.error. Please resolve this in the relevant test.\n\n${
+    message instanceof Error ? '' : 'Error: '
+  }${message}`;
+}
+
+let error = console.error;
+console.error = function(message) {
+  error.apply(console, arguments);
+  throw new Error(applyErrorDetails(message));
+};
+
+function applyWarningDetails(message) {
+  return `Failing unit test due to unexpected console.warn. Please mock and assert this in the relevant test.\n\nWarning: ${message}`;
+}
+
+let warn = console.warn;
+console.warn = function(message) {
+  warn.apply(console, arguments);
+  throw new Error(applyWarningDetails(message));
+};

--- a/src/test/test-setup.js
+++ b/src/test/test-setup.js
@@ -22,6 +22,7 @@ function applyErrorDetails(message) {
 }
 
 let error = console.error;
+// $FlowFixMe
 console.error = function(message) {
   error.apply(console, arguments);
   throw new Error(applyErrorDetails(message));
@@ -32,6 +33,7 @@ function applyWarningDetails(message) {
 }
 
 let warn = console.warn;
+// $FlowFixMe
 console.warn = function(message) {
   warn.apply(console, arguments);
   throw new Error(applyWarningDetails(message));


### PR DESCRIPTION
Closes: https://github.com/uber/baseweb/issues/2980

After this change, unit-tests will fail if an unexpected `console.warn` or `console.error` is called. This will help to avoid publishing known errors to users