### PR TITLE
feat(table-semantic): add loading and empty messages

### DIFF
--- a/documentation-site/components/yard/config/table-semantic.ts
+++ b/documentation-site/components/yard/config/table-semantic.ts
@@ -34,6 +34,21 @@ const TableSemanticConfig: TConfig = {
       type: PropTypes.String,
       description: 'Table width fills this provided value.',
     },
+    isLoading: {
+      value: false,
+      type: PropTypes.Boolean,
+      description: 'Lets you specify loading state.',
+    },
+    loadingMessage: {
+      value: '',
+      type: PropTypes.ReactNode,
+      description: `Loading message.`,
+    },
+    emptyMessage: {
+      value: '',
+      type: PropTypes.ReactNode,
+      description: `Empty message.`,
+    },
     overrides: {
       value: undefined,
       type: PropTypes.Custom,
@@ -49,6 +64,8 @@ const TableSemanticConfig: TConfig = {
           'TableBody',
           'TableBodyRow',
           'TableBodyCell',
+          'TableLoadingMessage',
+          'TableEmptyMessage',
           'SortAscIcon',
           'SortDescIcon',
           'SortNoneIcon',

--- a/documentation-site/examples/table-semantic/empty-message.js
+++ b/documentation-site/examples/table-semantic/empty-message.js
@@ -1,0 +1,9 @@
+// @flow
+import * as React from 'react';
+import {Table} from 'baseui/table-semantic';
+
+const COLUMNS = ['Name', 'Age', 'Address'];
+
+export default () => (
+  <Table columns={COLUMNS} data={[]} emptyMessage="No data" />
+);

--- a/documentation-site/examples/table-semantic/empty-message.tsx
+++ b/documentation-site/examples/table-semantic/empty-message.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import {Table} from 'baseui/table-semantic';
+
+const COLUMNS = ['Name', 'Age', 'Address'];
+
+export default () => (
+  <Table
+    columns={COLUMNS}
+    data={[]}
+    emptyMessage={<h1>No data</h1>}
+  />
+);

--- a/documentation-site/examples/table-semantic/span.js
+++ b/documentation-site/examples/table-semantic/span.js
@@ -13,16 +13,16 @@ export default () => (
   <StyledRoot>
     <StyledTable>
       <StyledTableHeadRow>
-        <StyledTableHeadCell colspan="2">
+        <StyledTableHeadCell colSpan="2">
           Parent
         </StyledTableHeadCell>
-        <StyledTableHeadCell colspan="2">
+        <StyledTableHeadCell colSpan="2">
           Children
         </StyledTableHeadCell>
       </StyledTableHeadRow>
       <StyledTableBodyRow>
-        <StyledTableBodyCell rowspan="3">Sarah</StyledTableBodyCell>
-        <StyledTableBodyCell rowspan="3">Brown</StyledTableBodyCell>
+        <StyledTableBodyCell rowSpan="3">Sarah</StyledTableBodyCell>
+        <StyledTableBodyCell rowSpan="3">Brown</StyledTableBodyCell>
         <StyledTableBodyCell>Sally</StyledTableBodyCell>
         <StyledTableBodyCell>Brown</StyledTableBodyCell>
       </StyledTableBodyRow>
@@ -35,8 +35,8 @@ export default () => (
         <StyledTableBodyCell>Black</StyledTableBodyCell>
       </StyledTableBodyRow>
       <StyledTableBodyRow>
-        <StyledTableBodyCell rowspan="2">Jane</StyledTableBodyCell>
-        <StyledTableBodyCell rowspan="2">Smith</StyledTableBodyCell>
+        <StyledTableBodyCell rowSpan="2">Jane</StyledTableBodyCell>
+        <StyledTableBodyCell rowSpan="2">Smith</StyledTableBodyCell>
         <StyledTableBodyCell>Molly</StyledTableBodyCell>
         <StyledTableBodyCell>Smith</StyledTableBodyCell>
       </StyledTableBodyRow>

--- a/documentation-site/examples/table-semantic/span.tsx
+++ b/documentation-site/examples/table-semantic/span.tsx
@@ -12,16 +12,16 @@ export default () => (
   <StyledRoot>
     <StyledTable>
       <StyledTableHeadRow>
-        <StyledTableHeadCell colspan="2">
+        <StyledTableHeadCell colSpan="2">
           Parent
         </StyledTableHeadCell>
-        <StyledTableHeadCell colspan="2">
+        <StyledTableHeadCell colSpan="2">
           Children
         </StyledTableHeadCell>
       </StyledTableHeadRow>
       <StyledTableBodyRow>
-        <StyledTableBodyCell rowspan="3">Sarah</StyledTableBodyCell>
-        <StyledTableBodyCell rowspan="3">Brown</StyledTableBodyCell>
+        <StyledTableBodyCell rowSpan="3">Sarah</StyledTableBodyCell>
+        <StyledTableBodyCell rowSpan="3">Brown</StyledTableBodyCell>
         <StyledTableBodyCell>Sally</StyledTableBodyCell>
         <StyledTableBodyCell>Brown</StyledTableBodyCell>
       </StyledTableBodyRow>
@@ -34,8 +34,8 @@ export default () => (
         <StyledTableBodyCell>Black</StyledTableBodyCell>
       </StyledTableBodyRow>
       <StyledTableBodyRow>
-        <StyledTableBodyCell rowspan="2">Jane</StyledTableBodyCell>
-        <StyledTableBodyCell rowspan="2">Smith</StyledTableBodyCell>
+        <StyledTableBodyCell rowSpan="2">Jane</StyledTableBodyCell>
+        <StyledTableBodyCell rowSpan="2">Smith</StyledTableBodyCell>
         <StyledTableBodyCell>Molly</StyledTableBodyCell>
         <StyledTableBodyCell>Smith</StyledTableBodyCell>
       </StyledTableBodyRow>

--- a/documentation-site/pages/components/table-semantic.mdx
+++ b/documentation-site/pages/components/table-semantic.mdx
@@ -17,6 +17,7 @@ import Builder from 'examples/table-semantic/builder.js';
 import Sortable from 'examples/table-semantic/sortable.js';
 import Toggleable from 'examples/table-semantic/toggleable.js';
 import Span from 'examples/table-semantic/span.js';
+import EmptyMessage from 'examples/table-semantic/empty-message.js';
 
 import Yard from '../../components/yard/index';
 import tableYardConfig from '../../components/yard/config/table-semantic';
@@ -63,6 +64,13 @@ you should use the virtualized scrolling features of the div-based
 
 <Example title="Table custom with merged cells" path="table-semantic/span.js">
   <Span />
+</Example>
+
+<Example
+  title="Table with empty message"
+  path="table-semantic/empty-message.js"
+>
+  <EmptyMessage />
 </Example>
 
 ## API

--- a/src/table-semantic/__tests__/table-builder.test.js
+++ b/src/table-semantic/__tests__/table-builder.test.js
@@ -16,6 +16,7 @@ import {
   StyledTableHeadCellSortable,
   StyledTableBodyRow,
   StyledTableBodyCell,
+  StyledTableLoadingMessage,
   StyledSortAscIcon,
   StyledSortDescIcon,
   StyledSortNoneIcon,
@@ -297,5 +298,19 @@ describe('Table Semantic Builder', () => {
 
     const tableBody = wrapper.find(StyledTableBody);
     expect(tableBody.text()).toContain('No data');
+  });
+
+  it('does not render unset empty message', () => {
+    const wrapper = mount(
+      <TableBuilder data={[]}>
+        <TableBuilderColumn header="Foo">{row => row.foo}</TableBuilderColumn>
+        <TableBuilderColumn header="Bar">
+          {row => <a href={row.url}>{row.bar}</a>}
+        </TableBuilderColumn>
+        <TableBuilderColumn>{row => 'Hey'}</TableBuilderColumn>
+      </TableBuilder>,
+    );
+
+    expect(wrapper.find(StyledTableLoadingMessage)).toHaveLength(0);
   });
 });

--- a/src/table-semantic/__tests__/table-builder.test.js
+++ b/src/table-semantic/__tests__/table-builder.test.js
@@ -16,7 +16,6 @@ import {
   StyledTableHeadCellSortable,
   StyledTableBodyRow,
   StyledTableBodyCell,
-  StyledTableLoadingMessage,
   StyledTableEmptyMessage,
   StyledSortAscIcon,
   StyledSortDescIcon,
@@ -280,9 +279,8 @@ describe('Table Semantic Builder', () => {
 
     expect(wrapper.find(StyledTableBodyRow)).toHaveLength(0);
 
-    expect(wrapper.find(StyledTableBodyRow)).toHaveLength(0);
-
     const tableBody = wrapper.find(StyledTableBody);
+    expect(tableBody.find('td').prop('colSpan')).toEqual(3);
     expect(tableBody.text()).toContain('Loading...');
   });
 
@@ -298,14 +296,9 @@ describe('Table Semantic Builder', () => {
     );
 
     expect(wrapper.find(StyledTableBodyRow)).toHaveLength(0);
-    expect(
-      wrapper
-        .find(StyledTableBody)
-        .find('td')
-        .prop('colSpan'),
-    ).toEqual(3);
 
     const tableBody = wrapper.find(StyledTableBody);
+    expect(tableBody.find('td').prop('colSpan')).toEqual(3);
     expect(tableBody.text()).toContain('No data');
   });
 

--- a/src/table-semantic/__tests__/table-builder.test.js
+++ b/src/table-semantic/__tests__/table-builder.test.js
@@ -17,6 +17,7 @@ import {
   StyledTableBodyRow,
   StyledTableBodyCell,
   StyledTableLoadingMessage,
+  StyledTableEmptyMessage,
   StyledSortAscIcon,
   StyledSortDescIcon,
   StyledSortNoneIcon,
@@ -279,6 +280,8 @@ describe('Table Semantic Builder', () => {
 
     expect(wrapper.find(StyledTableBodyRow)).toHaveLength(0);
 
+    expect(wrapper.find(StyledTableBodyRow)).toHaveLength(0);
+
     const tableBody = wrapper.find(StyledTableBody);
     expect(tableBody.text()).toContain('Loading...');
   });
@@ -295,6 +298,12 @@ describe('Table Semantic Builder', () => {
     );
 
     expect(wrapper.find(StyledTableBodyRow)).toHaveLength(0);
+    expect(
+      wrapper
+        .find(StyledTableBody)
+        .find('td')
+        .prop('colSpan'),
+    ).toEqual(3);
 
     const tableBody = wrapper.find(StyledTableBody);
     expect(tableBody.text()).toContain('No data');
@@ -311,6 +320,6 @@ describe('Table Semantic Builder', () => {
       </TableBuilder>,
     );
 
-    expect(wrapper.find(StyledTableLoadingMessage)).toHaveLength(0);
+    expect(wrapper.find(StyledTableEmptyMessage)).toHaveLength(0);
   });
 });

--- a/src/table-semantic/__tests__/table-builder.test.js
+++ b/src/table-semantic/__tests__/table-builder.test.js
@@ -12,6 +12,7 @@ import {mount} from 'enzyme';
 import {
   TableBuilder,
   TableBuilderColumn,
+  StyledTableBody,
   StyledTableHeadCellSortable,
   StyledTableBodyRow,
   StyledTableBodyCell,
@@ -262,5 +263,39 @@ describe('Table Semantic Builder', () => {
       'Foo Aria Label, ascending sorting',
     );
     expect(headCells.at(1).prop('aria-label')).toBe('Bar, ascending sorting');
+  });
+
+  it('renders loading message', () => {
+    const wrapper = mount(
+      <TableBuilder data={DATA} isLoading={true}>
+        <TableBuilderColumn header="Foo">{row => row.foo}</TableBuilderColumn>
+        <TableBuilderColumn header="Bar">
+          {row => <a href={row.url}>{row.bar}</a>}
+        </TableBuilderColumn>
+        <TableBuilderColumn>{row => 'Hey'}</TableBuilderColumn>
+      </TableBuilder>,
+    );
+
+    expect(wrapper.find(StyledTableBodyRow)).toHaveLength(0);
+
+    const tableBody = wrapper.find(StyledTableBody);
+    expect(tableBody.text()).toContain('Loading...');
+  });
+
+  it('renders empty message', () => {
+    const wrapper = mount(
+      <TableBuilder data={[]} emptyMessage="No data">
+        <TableBuilderColumn header="Foo">{row => row.foo}</TableBuilderColumn>
+        <TableBuilderColumn header="Bar">
+          {row => <a href={row.url}>{row.bar}</a>}
+        </TableBuilderColumn>
+        <TableBuilderColumn>{row => 'Hey'}</TableBuilderColumn>
+      </TableBuilder>,
+    );
+
+    expect(wrapper.find(StyledTableBodyRow)).toHaveLength(0);
+
+    const tableBody = wrapper.find(StyledTableBody);
+    expect(tableBody.text()).toContain('No data');
   });
 });

--- a/src/table-semantic/__tests__/table-semantic-compose.scenario.js
+++ b/src/table-semantic/__tests__/table-semantic-compose.scenario.js
@@ -21,12 +21,12 @@ export default function Scenario() {
     <StyledRoot>
       <StyledTable>
         <StyledTableHeadRow>
-          <StyledTableHeadCell colspan="2">Parent</StyledTableHeadCell>
-          <StyledTableHeadCell colspan="2">Children</StyledTableHeadCell>
+          <StyledTableHeadCell colSpan="2">Parent</StyledTableHeadCell>
+          <StyledTableHeadCell colSpan="2">Children</StyledTableHeadCell>
         </StyledTableHeadRow>
         <StyledTableBodyRow>
-          <StyledTableBodyCell rowspan="3">Sarah</StyledTableBodyCell>
-          <StyledTableBodyCell rowspan="3">Brown</StyledTableBodyCell>
+          <StyledTableBodyCell rowSpan="3">Sarah</StyledTableBodyCell>
+          <StyledTableBodyCell rowSpan="3">Brown</StyledTableBodyCell>
           <StyledTableBodyCell>Sally</StyledTableBodyCell>
           <StyledTableBodyCell>Brown</StyledTableBodyCell>
         </StyledTableBodyRow>
@@ -39,8 +39,8 @@ export default function Scenario() {
           <StyledTableBodyCell>Black</StyledTableBodyCell>
         </StyledTableBodyRow>
         <StyledTableBodyRow>
-          <StyledTableBodyCell rowspan="2">Jane</StyledTableBodyCell>
-          <StyledTableBodyCell rowspan="2">Smith</StyledTableBodyCell>
+          <StyledTableBodyCell rowSpan="2">Jane</StyledTableBodyCell>
+          <StyledTableBodyCell rowSpan="2">Smith</StyledTableBodyCell>
           <StyledTableBodyCell>Molly</StyledTableBodyCell>
           <StyledTableBodyCell>Smith</StyledTableBodyCell>
         </StyledTableBodyRow>

--- a/src/table-semantic/__tests__/table.test.js
+++ b/src/table-semantic/__tests__/table.test.js
@@ -14,6 +14,7 @@ import {
   StyledTableBody,
   StyledTableBodyRow,
   StyledTableBodyCell,
+  StyledTableLoadingMessage,
 } from '../index.js';
 
 const COLUMNS = ['ID', 'First Name', 'Last Name', 'Age', 'Address'];
@@ -111,5 +112,11 @@ describe('Table Semantic', () => {
 
     const tableBody = wrapper.find(StyledTableBody);
     expect(tableBody.text()).toContain('No data');
+  });
+
+  it('does not render unset empty message', () => {
+    const wrapper = shallow(<Table columns={COLUMNS} data={[]} />);
+    const rows = wrapper.find(StyledTableLoadingMessage);
+    expect(rows).toHaveLength(0);
   });
 });

--- a/src/table-semantic/__tests__/table.test.js
+++ b/src/table-semantic/__tests__/table.test.js
@@ -14,7 +14,6 @@ import {
   StyledTableBody,
   StyledTableBodyRow,
   StyledTableBodyCell,
-  StyledTableLoadingMessage,
   StyledTableEmptyMessage,
 } from '../index.js';
 
@@ -97,17 +96,11 @@ describe('Table Semantic', () => {
     const wrapper = shallow(
       <Table columns={COLUMNS} data={DATA} isLoading={true} />,
     );
-    const styledRows = wrapper.find(StyledTableBodyRow);
-    expect(styledRows).toHaveLength(0);
 
-    expect(
-      wrapper
-        .find(StyledTableBody)
-        .find('td')
-        .prop('colSpan'),
-    ).toEqual(COLUMNS.length);
+    expect(wrapper.find(StyledTableBodyRow)).toHaveLength(0);
 
     const tableBody = wrapper.find(StyledTableBody);
+    expect(tableBody.find('td').prop('colSpan')).toEqual(COLUMNS.length);
     expect(tableBody.text()).toContain('Loading...');
   });
 
@@ -115,15 +108,17 @@ describe('Table Semantic', () => {
     const wrapper = shallow(
       <Table columns={COLUMNS} data={[]} emptyMessage="No data" />,
     );
-    const rows = wrapper.find(StyledTableBodyRow);
-    expect(rows).toHaveLength(0);
+
+    expect(wrapper.find(StyledTableBodyRow)).toHaveLength(0);
 
     const tableBody = wrapper.find(StyledTableBody);
+    expect(tableBody.find('td').prop('colSpan')).toEqual(COLUMNS.length);
     expect(tableBody.text()).toContain('No data');
   });
 
   it('does not render unset empty message', () => {
     const wrapper = shallow(<Table columns={COLUMNS} data={[]} />);
+
     const rows = wrapper.find(StyledTableEmptyMessage);
     expect(rows).toHaveLength(0);
   });

--- a/src/table-semantic/__tests__/table.test.js
+++ b/src/table-semantic/__tests__/table.test.js
@@ -15,6 +15,7 @@ import {
   StyledTableBodyRow,
   StyledTableBodyCell,
   StyledTableLoadingMessage,
+  StyledTableEmptyMessage,
 } from '../index.js';
 
 const COLUMNS = ['ID', 'First Name', 'Last Name', 'Age', 'Address'];
@@ -99,6 +100,13 @@ describe('Table Semantic', () => {
     const styledRows = wrapper.find(StyledTableBodyRow);
     expect(styledRows).toHaveLength(0);
 
+    expect(
+      wrapper
+        .find(StyledTableBody)
+        .find('td')
+        .prop('colSpan'),
+    ).toEqual(COLUMNS.length);
+
     const tableBody = wrapper.find(StyledTableBody);
     expect(tableBody.text()).toContain('Loading...');
   });
@@ -116,7 +124,7 @@ describe('Table Semantic', () => {
 
   it('does not render unset empty message', () => {
     const wrapper = shallow(<Table columns={COLUMNS} data={[]} />);
-    const rows = wrapper.find(StyledTableLoadingMessage);
+    const rows = wrapper.find(StyledTableEmptyMessage);
     expect(rows).toHaveLength(0);
   });
 });

--- a/src/table-semantic/__tests__/table.test.js
+++ b/src/table-semantic/__tests__/table.test.js
@@ -9,7 +9,12 @@ LICENSE file in the root directory of this source tree.
 import * as React from 'react';
 import {shallow, mount} from 'enzyme';
 
-import {Table, StyledTableBodyRow, StyledTableBodyCell} from '../index.js';
+import {
+  Table,
+  StyledTableBody,
+  StyledTableBodyRow,
+  StyledTableBodyCell,
+} from '../index.js';
 
 const COLUMNS = ['ID', 'First Name', 'Last Name', 'Age', 'Address'];
 
@@ -84,5 +89,27 @@ describe('Table Semantic', () => {
         $row: DATA[0],
       }),
     );
+  });
+
+  it('renders loading message', () => {
+    const wrapper = shallow(
+      <Table columns={COLUMNS} data={DATA} isLoading={true} />,
+    );
+    const styledRows = wrapper.find(StyledTableBodyRow);
+    expect(styledRows).toHaveLength(0);
+
+    const tableBody = wrapper.find(StyledTableBody);
+    expect(tableBody.text()).toContain('Loading...');
+  });
+
+  it('renders empty message', () => {
+    const wrapper = shallow(
+      <Table columns={COLUMNS} data={[]} emptyMessage="No data" />,
+    );
+    const rows = wrapper.find(StyledTableBodyRow);
+    expect(rows).toHaveLength(0);
+
+    const tableBody = wrapper.find(StyledTableBody);
+    expect(tableBody.text()).toContain('No data');
   });
 });

--- a/src/table-semantic/index.d.ts
+++ b/src/table-semantic/index.d.ts
@@ -11,12 +11,17 @@ export interface TableOverrides {
   TableBody?: Override<any>;
   TableBodyRow?: Override<any>;
   TableBodyCell?: Override<any>;
+  TableLoadingMessage?: Override<any>;
+  TableEmptyMessage?: Override<any>;
 }
 export interface TableProps {
   overrides?: TableOverrides;
   columns: Array<React.ReactNode>;
   data: React.ReactNode[][];
   horizontalScrollWidth?: string;
+  isLoading?: boolean;
+  loadingMessage?: React.ReactNode | (() => React.ReactNode);
+  emptyMessage?: React.ReactNode | (() => React.ReactNode);
 }
 export class Table extends React.Component<TableProps> {}
 
@@ -34,6 +39,9 @@ export interface TableBuilderProps<RowT> {
   sortColumn?: string | null;
   sortOrder?: 'ASC' | 'DESC' | null;
   onSort?: (columnId: string) => void;
+  isLoading?: boolean;
+  loadingMessage?: React.ReactNode | (() => React.ReactNode);
+  emptyMessage?: React.ReactNode | (() => React.ReactNode);
 }
 export class TableBuilder<RowT> extends React.Component<
   TableBuilderProps<RowT>
@@ -69,6 +77,8 @@ export const StyledTableHeadCellSortable: StyletronComponent<any>;
 export const StyledTableBody: StyletronComponent<any>;
 export const StyledTableBodyRow: StyletronComponent<any>;
 export const StyledTableBodyCell: StyletronComponent<any>;
+export const StyledTableLoadingMessage: StyletronComponent<any>;
+export const StyledTableEmptyMessage: StyletronComponent<any>;
 export const StyledSortAscIcon: StyletronComponent<any>;
 export const StyledSortDescIcon: StyletronComponent<any>;
 export const StyledSortNoneIcon: StyletronComponent<any>;

--- a/src/table-semantic/index.js
+++ b/src/table-semantic/index.js
@@ -19,6 +19,8 @@ export {
   StyledTableBody,
   StyledTableBodyRow,
   StyledTableBodyCell,
+  StyledTableLoadingMessage,
+  StyledTableEmptyMessage,
   StyledSortAscIcon,
   StyledSortDescIcon,
   StyledSortNoneIcon,

--- a/src/table-semantic/styled-components.js
+++ b/src/table-semantic/styled-components.js
@@ -212,3 +212,13 @@ export const StyledTableBodyCell = styled<StyledTableBodyCellPropsT>(
     };
   },
 );
+
+export const StyledTableLoadingMessage = styled<{}>('div', ({$theme}) => {
+  return {
+    ...$theme.typography.ParagraphSmall,
+    color: $theme.colors.contentPrimary,
+    padding: $theme.sizing.scale600,
+  };
+});
+
+export const StyledTableEmptyMessage = StyledTableLoadingMessage;

--- a/src/table-semantic/table-builder.js
+++ b/src/table-semantic/table-builder.js
@@ -17,6 +17,8 @@ import {
   StyledTableBody,
   StyledTableBodyRow,
   StyledTableBodyCell,
+  StyledTableLoadingMessage,
+  StyledTableEmptyMessage,
   StyledSortAscIcon,
   StyledSortDescIcon,
   StyledSortNoneIcon,
@@ -32,6 +34,8 @@ export default class TableBuilder<T> extends React.Component<
 > {
   static defaultProps = {
     data: [],
+    loadingMessage: 'Loading...',
+    emptyMessage: '',
   };
 
   state = {
@@ -59,6 +63,9 @@ export default class TableBuilder<T> extends React.Component<
       sortColumn,
       sortOrder = 'ASC',
       onSort,
+      isLoading,
+      loadingMessage,
+      emptyMessage,
       ...rest
     } = this.props;
 
@@ -99,6 +106,16 @@ export default class TableBuilder<T> extends React.Component<
     const [TableBodyCell, tableBodyCellProps] = getOverrides(
       overrides.TableBodyCell,
       StyledTableBodyCell,
+    );
+
+    const [TableLoadingMessage, tableLoadingMessageProps] = getOverrides(
+      overrides.TableLoadingMessage,
+      StyledTableLoadingMessage,
+    );
+
+    const [TableEmptyMessage, tableEmptyMessageProps] = getOverrides(
+      overrides.TableEmptyMessage,
+      StyledTableEmptyMessage,
     );
 
     const [SortAscIcon, sortAscIconProps] = getOverrides(
@@ -234,6 +251,9 @@ export default class TableBuilder<T> extends React.Component<
       );
     }
 
+    const isEmpty = !isLoading && data.length === 0;
+    const isRendered = !isLoading && !isEmpty;
+
     return (
       <Root data-baseweb="table-builder-semantic" {...rootProps} {...rest}>
         <Table
@@ -250,18 +270,41 @@ export default class TableBuilder<T> extends React.Component<
             </TableHeadRow>
           </TableHead>
           <TableBody {...tableBodyProps}>
-            {data.map((row, rowIndex) => (
-              <TableBodyRow
-                key={rowIndex}
-                $row={row}
-                $rowIndex={rowIndex}
-                {...tableBodyRowProps}
-              >
-                {columns.map((col, colIndex) =>
-                  renderCell(col, colIndex, row, rowIndex),
-                )}
-              </TableBodyRow>
-            ))}
+            {isLoading && (
+              <tr>
+                <td colSpan={columns.length}>
+                  <TableLoadingMessage {...tableLoadingMessageProps}>
+                    {typeof loadingMessage === 'function'
+                      ? loadingMessage()
+                      : loadingMessage}
+                  </TableLoadingMessage>
+                </td>
+              </tr>
+            )}
+            {isEmpty && (
+              <tr>
+                <td colSpan={columns.length}>
+                  <TableEmptyMessage {...tableEmptyMessageProps}>
+                    {typeof emptyMessage === 'function'
+                      ? emptyMessage()
+                      : emptyMessage}
+                  </TableEmptyMessage>
+                </td>
+              </tr>
+            )}
+            {isRendered &&
+              data.map((row, rowIndex) => (
+                <TableBodyRow
+                  key={rowIndex}
+                  $row={row}
+                  $rowIndex={rowIndex}
+                  {...tableBodyRowProps}
+                >
+                  {columns.map((col, colIndex) =>
+                    renderCell(col, colIndex, row, rowIndex),
+                  )}
+                </TableBodyRow>
+              ))}
           </TableBody>
         </Table>
       </Root>

--- a/src/table-semantic/table-builder.js
+++ b/src/table-semantic/table-builder.js
@@ -281,7 +281,7 @@ export default class TableBuilder<T> extends React.Component<
                 </td>
               </tr>
             )}
-            {isEmpty && (
+            {isEmpty && emptyMessage && (
               <tr>
                 <td colSpan={columns.length}>
                   <TableEmptyMessage {...tableEmptyMessageProps}>

--- a/src/table-semantic/table-builder.js
+++ b/src/table-semantic/table-builder.js
@@ -35,7 +35,6 @@ export default class TableBuilder<T> extends React.Component<
   static defaultProps = {
     data: [],
     loadingMessage: 'Loading...',
-    emptyMessage: '',
   };
 
   state = {

--- a/src/table-semantic/table.js
+++ b/src/table-semantic/table.js
@@ -28,7 +28,6 @@ export default class Table extends React.Component<TablePropsT> {
     columns: [],
     data: [[]],
     loadingMessage: 'Loading...',
-    emptyMessage: '',
   };
 
   render() {

--- a/src/table-semantic/table.js
+++ b/src/table-semantic/table.js
@@ -16,6 +16,8 @@ import {
   StyledTableBody,
   StyledTableBodyRow,
   StyledTableBodyCell,
+  StyledTableLoadingMessage,
+  StyledTableEmptyMessage,
 } from './styled-components.js';
 import {getOverrides} from '../helpers/overrides.js';
 
@@ -25,6 +27,8 @@ export default class Table extends React.Component<TablePropsT> {
   static defaultProps = {
     columns: [],
     data: [[]],
+    loadingMessage: 'Loading...',
+    emptyMessage: '',
   };
 
   render() {
@@ -33,6 +37,9 @@ export default class Table extends React.Component<TablePropsT> {
       columns,
       data,
       horizontalScrollWidth,
+      isLoading,
+      loadingMessage,
+      emptyMessage,
       ...rest
     } = this.props;
 
@@ -70,6 +77,19 @@ export default class Table extends React.Component<TablePropsT> {
       StyledTableBodyCell,
     );
 
+    const [TableLoadingMessage, tableLoadingMessageProps] = getOverrides(
+      overrides.TableLoadingMessage,
+      StyledTableLoadingMessage,
+    );
+
+    const [TableEmptyMessage, tableEmptyMessageProps] = getOverrides(
+      overrides.TableEmptyMessage,
+      StyledTableEmptyMessage,
+    );
+
+    const isEmpty = !isLoading && data.length === 0;
+    const isRendered = !isLoading && !isEmpty;
+
     return (
       <Root data-baseweb="table-semantic" {...rootProps} {...rest}>
         <Table $width={horizontalScrollWidth} {...tableProps}>
@@ -88,27 +108,50 @@ export default class Table extends React.Component<TablePropsT> {
             </TableHeadRow>
           </TableHead>
           <TableBody {...tableBodyProps}>
-            {data.map((row, rowIndex) => (
-              <TableBodyRow
-                key={rowIndex}
-                $row={row}
-                $rowIndex={rowIndex}
-                {...tableBodyRowProps}
-              >
-                {columns.map((col, colIndex) => (
-                  <TableBodyCell
-                    key={colIndex}
-                    $col={col}
-                    $colIndex={colIndex}
-                    $row={row}
-                    $rowIndex={rowIndex}
-                    {...tableBodyCellProps}
-                  >
-                    {row[colIndex]}
-                  </TableBodyCell>
-                ))}
-              </TableBodyRow>
-            ))}
+            {isLoading && (
+              <tr>
+                <td colSpan={columns.length}>
+                  <TableLoadingMessage {...tableLoadingMessageProps}>
+                    {typeof loadingMessage === 'function'
+                      ? loadingMessage()
+                      : loadingMessage}
+                  </TableLoadingMessage>
+                </td>
+              </tr>
+            )}
+            {isEmpty && (
+              <tr>
+                <td colSpan={columns.length}>
+                  <TableEmptyMessage {...tableEmptyMessageProps}>
+                    {typeof emptyMessage === 'function'
+                      ? emptyMessage()
+                      : emptyMessage}
+                  </TableEmptyMessage>
+                </td>
+              </tr>
+            )}
+            {isRendered &&
+              data.map((row, rowIndex) => (
+                <TableBodyRow
+                  key={rowIndex}
+                  $row={row}
+                  $rowIndex={rowIndex}
+                  {...tableBodyRowProps}
+                >
+                  {columns.map((col, colIndex) => (
+                    <TableBodyCell
+                      key={colIndex}
+                      $col={col}
+                      $colIndex={colIndex}
+                      $row={row}
+                      $rowIndex={rowIndex}
+                      {...tableBodyCellProps}
+                    >
+                      {row[colIndex]}
+                    </TableBodyCell>
+                  ))}
+                </TableBodyRow>
+              ))}
           </TableBody>
         </Table>
       </Root>

--- a/src/table-semantic/table.js
+++ b/src/table-semantic/table.js
@@ -119,7 +119,7 @@ export default class Table extends React.Component<TablePropsT> {
                 </td>
               </tr>
             )}
-            {isEmpty && (
+            {isEmpty && emptyMessage && (
               <tr>
                 <td colSpan={columns.length}>
                   <TableEmptyMessage {...tableEmptyMessageProps}>

--- a/src/table-semantic/types.js
+++ b/src/table-semantic/types.js
@@ -18,6 +18,8 @@ export type OverridesT = {
   TableBody?: OverrideT,
   TableBodyRow?: OverrideT,
   TableBodyCell?: OverrideT,
+  TableLoadingMessage?: OverrideT,
+  TableEmptyMessage?: OverrideT,
 };
 
 export type TablePropsT = {
@@ -25,6 +27,9 @@ export type TablePropsT = {
   columns: Array<React.Node>,
   data: Array<Array<React.Node>>,
   horizontalScrollWidth?: string,
+  isLoading?: boolean,
+  loadingMessage?: React.Node | (() => React.Node),
+  emptyMessage?: React.Node | (() => React.Node),
 };
 
 export type BuilderOverridesT = {
@@ -43,6 +48,9 @@ export type TableBuilderPropsT<RowT> = {
   sortColumn?: ?string,
   sortOrder?: 'ASC' | 'DESC' | null,
   onSort?: (columnId: string) => void,
+  isLoading?: boolean,
+  loadingMessage?: React.Node | (() => React.Node),
+  emptyMessage?: React.Node | (() => React.Node),
 };
 
 export type ColumnOverridesT = {


### PR DESCRIPTION
#### Description

Added loading and empty message support for semantic-table.
`Table` and `TableBuilder` accepts three new properties `isLoading`, `loadingMessage` and `emptyMessage`.

The loading message will be displayed when a property `isLoading` is set to true. Defaults value is `Loading...`
It will expand to the full table width using the `colSpan` attribute of total columns in the table.

The empty message will be displayed when the data array is zero length and `loadingMessage` is provided as property. By default, message value is not set and it won't be shown.

The messages are rendered inside `tr > td` tag to complain to table semantics.

![semantic-table-messages](https://user-images.githubusercontent.com/6738026/95749818-d903b200-0ca4-11eb-9dcd-fbe1cdaad484.gif)

#### Scope
Minor: New Feature