### PR TITLE
fix(slider): pin to react-range version

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "react-is": "^16.8.6",
     "react-movable": "^2.4.0",
     "react-multi-ref": "^1.0.0",
-    "react-range": "^1.7.0",
+    "react-range": "1.7.0",
     "react-uid": "^2.3.0",
     "react-virtualized": "^9.21.1",
     "react-virtualized-auto-sizer": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17111,7 +17111,7 @@ react-proptype-conditional-require@^1.0.4:
   resolved "https://registry.yarnpkg.com/react-proptype-conditional-require/-/react-proptype-conditional-require-1.0.4.tgz#69c2d5741e6df5e08f230f36bbc2944ee1222555"
   integrity sha1-acLVdB5t9eCPIw82u8KUTuEiJVU=
 
-react-range@^1.7.0:
+react-range@1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/react-range/-/react-range-1.7.0.tgz#94ac3851661dabbb9bcc37001ba5ddd7cd0cca5d"
   integrity sha512-OFF+bcD5o1TJ8M6YcQI4A3b6OYh4bDG0gUkyXETPJHXeut39XL8RZZZPUgfeoEOP1PmtMtluGMbFleP59S9OXg==


### PR DESCRIPTION
Fixes https://github.com/uber/baseweb/issues/3811

#### Description

baseui slider fails to operate when react-range is version 1.8.0. This didn't show up in our testing because it's locked to 1.7.0. I plan to fix up baseui's slider for 1.8.0, but would like to get a release out for open source baseui users

#### Scope
Patch: Bug Fix
