### PR TITLE
feat(rating): allow read-only rating #3741

### DIFF
--- a/documentation-site/components/yard/config/rating.ts
+++ b/documentation-site/components/yard/config/rating.ts
@@ -39,6 +39,11 @@ const ratingConfig: TConfig = {
       description: 'The current rating value.',
       stateful: true,
     },
+    readOnly: {
+      value: false,
+      type: PropTypes.Boolean,
+      description: 'Whether the rating is read-only or editable.',
+    },
     overrides: {
       value: undefined,
       type: PropTypes.Custom,

--- a/documentation-site/examples/rating/starReadOnly.js
+++ b/documentation-site/examples/rating/starReadOnly.js
@@ -1,0 +1,14 @@
+// @flow
+import * as React from 'react';
+import {StarRating} from 'baseui/rating';
+
+export default () => {
+  const [value, setValue] = React.useState(3);
+  return (
+    <StarRating
+      value={value}
+      onChange={({value}) => setValue(value)}
+      readOnly
+    />
+  );
+};

--- a/documentation-site/examples/rating/starReadOnly.tsx
+++ b/documentation-site/examples/rating/starReadOnly.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import {StarRating} from 'baseui/rating';
+
+export default () => {
+  const [value, setValue] = React.useState(3);
+  return (
+    <StarRating
+      value={value}
+      onChange={({value}) => setValue(value)}
+      readOnly
+    />
+  );
+};

--- a/documentation-site/pages/components/rating.mdx
+++ b/documentation-site/pages/components/rating.mdx
@@ -10,6 +10,7 @@ import Layout from '../../components/layout';
 import Exports from '../../components/exports';
 
 import Star from 'examples/rating/star.js';
+import StarReadOnly from 'examples/rating/starReadOnly.js';
 import Emoticon from 'examples/rating/emoticon.js';
 
 import {EmoticonRating, StarRating} from 'baseui/rating';
@@ -40,11 +41,16 @@ This component uses the `[role="radiogroup"]` attribute with the following attri
 - `[aria-setsize=5]` - total number of elements within the Rating
 - `[aria-checked]` - if the rating is active
 - `[aria-posinset]` - position within the Rating
+- `[aria-disabled]` - if the rating is read only
 
 ## Examples
 
 <Example title="Rating with stars" path="rating/star.js">
   <Star />
+</Example>
+
+<Example title="Rating with stars read only" path="rating/starReadOnly.js">
+  <StarReadOnly />
 </Example>
 
 <Example title="Rating with emoticons" path="rating/emoticon.js">

--- a/src/rating/__tests__/emoticon-rating.test.js
+++ b/src/rating/__tests__/emoticon-rating.test.js
@@ -27,7 +27,19 @@ describe('EmoticonRating', () => {
     const {container} = render(<EmoticonRating value={2} />);
     getByRole(container, 'radiogroup');
     const items = getAllByRole(container, 'radio');
+    expect(items[0].getAttribute('aria-checked')).toBe('false');
     expect(items[1].getAttribute('aria-checked')).toBe('true');
+    expect(items[2].getAttribute('aria-checked')).toBe('false');
+    expect(items[3].getAttribute('aria-checked')).toBe('false');
+    expect(items[4].getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('sets correct accessibility attributes to radio elements when read only', () => {
+    const {container} = render(<EmoticonRating value={2} readOnly />);
+    const items = getAllByRole(container, 'radio');
+    items.forEach(item => {
+      expect(item.getAttribute('aria-disabled')).toBe('true');
+    });
   });
 
   it('can update active radio on click', () => {
@@ -44,5 +56,26 @@ describe('EmoticonRating', () => {
     }
     fireEvent.click(items[1]);
     expect(items[1].getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('cannot update rating on click when read only', () => {
+    function TestCase() {
+      const [value, setValue] = React.useState(2);
+      return (
+        <EmoticonRating
+          value={value}
+          onChange={({value}) => setValue(value)}
+          readOnly
+        />
+      );
+    }
+    const {container} = render(<TestCase />);
+    const items = getAllByRole(container, 'radio');
+    fireEvent.click(items[4]);
+    expect(items[0].getAttribute('aria-checked')).toBe('false');
+    expect(items[1].getAttribute('aria-checked')).toBe('true');
+    expect(items[2].getAttribute('aria-checked')).toBe('false');
+    expect(items[3].getAttribute('aria-checked')).toBe('false');
+    expect(items[4].getAttribute('aria-checked')).toBe('false');
   });
 });

--- a/src/rating/__tests__/star-rating.test.js
+++ b/src/rating/__tests__/star-rating.test.js
@@ -33,6 +33,14 @@ describe('StarRating', () => {
     expect(items[4].getAttribute('aria-checked')).toBe('false');
   });
 
+  it('sets correct accessibility attributes to radio elements when read only', () => {
+    const {container} = render(<StarRating value={2} readOnly />);
+    const items = getAllByRole(container, 'radio');
+    items.forEach(item => {
+      expect(item.getAttribute('aria-disabled')).toBe('true');
+    });
+  });
+
   it('can update active radio on click', () => {
     function TestCase() {
       const [value, setValue] = React.useState(-1);
@@ -46,6 +54,27 @@ describe('StarRating', () => {
       expect(item.getAttribute('aria-checked')).toBe('false');
     }
     fireEvent.click(items[1]);
+    expect(items[0].getAttribute('aria-checked')).toBe('true');
+    expect(items[1].getAttribute('aria-checked')).toBe('true');
+    expect(items[2].getAttribute('aria-checked')).toBe('false');
+    expect(items[3].getAttribute('aria-checked')).toBe('false');
+    expect(items[4].getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('cannot update rating on click when read only', () => {
+    function TestCase() {
+      const [value, setValue] = React.useState(2);
+      return (
+        <StarRating
+          value={value}
+          onChange={({value}) => setValue(value)}
+          readOnly
+        />
+      );
+    }
+    const {container} = render(<TestCase />);
+    const items = getAllByRole(container, 'radio');
+    fireEvent.click(items[4]);
     expect(items[0].getAttribute('aria-checked')).toBe('true');
     expect(items[1].getAttribute('aria-checked')).toBe('true');
     expect(items[2].getAttribute('aria-checked')).toBe('false');

--- a/src/rating/emoticon-rating.js
+++ b/src/rating/emoticon-rating.js
@@ -20,6 +20,7 @@ class EmoticonRating extends React.Component<
 > {
   static defaultProps = {
     overrides: {},
+    readOnly: false,
   };
 
   state = {isFocusVisible: false, previewIndex: undefined};
@@ -48,7 +49,12 @@ class EmoticonRating extends React.Component<
   };
 
   renderRatingContents = () => {
-    const {overrides = {}, value = -1, size = 44} = this.props;
+    const {
+      overrides = {},
+      value = -1,
+      size = 44,
+      readOnly = false,
+    } = this.props;
     const {previewIndex} = this.state;
 
     const [Emoticon, emoticonProps] = getOverrides(
@@ -72,6 +78,7 @@ class EmoticonRating extends React.Component<
           aria-setsize={5}
           aria-checked={x === value}
           aria-posinset={x}
+          aria-disabled={readOnly}
           $size={size}
           $index={x}
           $isActive={
@@ -79,8 +86,17 @@ class EmoticonRating extends React.Component<
           }
           $isSelected={x === previewIndex}
           $isFocusVisible={this.state.isFocusVisible && isFocusable}
-          onClick={() => this.selectItem(x)}
+          $isReadOnly={readOnly}
+          onClick={() => {
+            if (readOnly) {
+              return;
+            }
+            this.selectItem(x);
+          }}
           onKeyDown={e => {
+            if (readOnly) {
+              return;
+            }
             if (e.keyCode === ARROW_UP || e.keyCode === ARROW_LEFT) {
               e.preventDefault && e.preventDefault();
               // 5 value comes from non-configurable number of icons
@@ -95,7 +111,12 @@ class EmoticonRating extends React.Component<
               refs[nextIndex].current && refs[nextIndex].current.focus();
             }
           }}
-          onMouseOver={() => this.updatePreview(x)}
+          onMouseOver={() => {
+            if (readOnly) {
+              return;
+            }
+            this.updatePreview(x);
+          }}
           onFocus={forkFocus(emoticonProps, this.handleFocus)}
           onBlur={forkBlur(emoticonProps, this.handleBlur)}
           {...emoticonProps}

--- a/src/rating/index.d.ts
+++ b/src/rating/index.d.ts
@@ -15,6 +15,7 @@ export interface StarRatingProps {
   overrides?: RatingOverrides;
   value?: number;
   numItems?: number;
+  readOnly?: boolean;
   onChange?: (args: {value: number}) => any;
   size?: number;
 }
@@ -22,6 +23,7 @@ export interface StarRatingProps {
 export interface EmoticonRatingProps {
   overrides?: RatingOverrides;
   value?: number;
+  readOnly?: boolean;
   onChange?: (args: {value: number}) => any;
   size?: number;
 }

--- a/src/rating/star-rating.js
+++ b/src/rating/star-rating.js
@@ -18,6 +18,7 @@ class StarRating extends React.Component<StarRatingPropsT, RatingStateT> {
   static defaultProps = {
     overrides: {},
     numItems: 5,
+    readOnly: false,
   };
 
   state = {isFocusVisible: false, previewIndex: undefined};
@@ -46,7 +47,13 @@ class StarRating extends React.Component<StarRatingPropsT, RatingStateT> {
   };
 
   renderRatingContents = () => {
-    const {overrides = {}, value = -1, numItems, size = 22} = this.props;
+    const {
+      overrides = {},
+      value = -1,
+      numItems,
+      size = 22,
+      readOnly = false,
+    } = this.props;
     const {previewIndex} = this.state;
     const [Star, starProps] = getOverrides(overrides.Item, StyledStar);
 
@@ -66,6 +73,7 @@ class StarRating extends React.Component<StarRatingPropsT, RatingStateT> {
           aria-setsize={numItems}
           aria-checked={x <= value}
           aria-posinset={x}
+          aria-disabled={readOnly}
           $size={size}
           $index={x}
           $isActive={
@@ -73,8 +81,17 @@ class StarRating extends React.Component<StarRatingPropsT, RatingStateT> {
           }
           $isSelected={x === previewIndex}
           $isFocusVisible={this.state.isFocusVisible && isFocusable}
-          onClick={() => this.selectItem(x)}
+          $isReadOnly={readOnly}
+          onClick={() => {
+            if (readOnly) {
+              return;
+            }
+            this.selectItem(x);
+          }}
           onKeyDown={e => {
+            if (readOnly) {
+              return;
+            }
             if (e.keyCode === ARROW_UP || e.keyCode === ARROW_LEFT) {
               e.preventDefault && e.preventDefault();
               const prevIndex = value - 1 < 1 ? numItems : value - 1;
@@ -88,7 +105,12 @@ class StarRating extends React.Component<StarRatingPropsT, RatingStateT> {
               refs[nextIndex].current && refs[nextIndex].current.focus();
             }
           }}
-          onMouseOver={() => this.updatePreview(x)}
+          onMouseOver={() => {
+            if (readOnly) {
+              return;
+            }
+            this.updatePreview(x);
+          }}
           {...starProps}
           onFocus={forkFocus(starProps, this.handleFocus)}
           onBlur={forkBlur(starProps, this.handleBlur)}

--- a/src/rating/styled-components.js
+++ b/src/rating/styled-components.js
@@ -37,7 +37,7 @@ export const StyledRoot = styled<StyledRootPropsT>('ul', ({$theme}) => {
 
 export const StyledStar = styled<StyledRatingItemPropsT>(
   'li',
-  ({$theme, $isActive, $isSelected, $isFocusVisible, $size}) => {
+  ({$theme, $isActive, $isSelected, $isFocusVisible, $isReadOnly, $size}) => {
     let starStroke = $theme.colors.mono500;
     let starFill = $theme.colors.mono300;
 
@@ -52,7 +52,7 @@ export const StyledStar = styled<StyledRatingItemPropsT>(
       paddingRight: 0,
       display: 'inline-block',
       transition: `transform ${$theme.animation.timing400}`,
-      cursor: 'pointer',
+      cursor: $isReadOnly ? 'default' : 'pointer',
       marginLeft: 0,
       marginTop: 0,
       marginBottom: 0,
@@ -77,7 +77,15 @@ export const StyledStar = styled<StyledRatingItemPropsT>(
 
 export const StyledEmoticon = styled<StyledRatingItemPropsT>(
   'li',
-  ({$theme, $isActive, $isSelected, $index = 1, $isFocusVisible, $size}) => {
+  ({
+    $theme,
+    $isActive,
+    $isSelected,
+    $index = 1,
+    $isFocusVisible,
+    $isReadOnly,
+    $size,
+  }) => {
     let emoticonFill = $theme.colors.mono500;
 
     if ($isActive) {
@@ -99,7 +107,7 @@ export const StyledEmoticon = styled<StyledRatingItemPropsT>(
       paddingBottom: 0,
       display: 'inline-block',
       transition: `transform ${$theme.animation.timing400}`,
-      cursor: 'pointer',
+      cursor: $isReadOnly ? 'default' : 'pointer',
       marginLeft: 0,
       marginTop: 0,
       marginBottom: 0,

--- a/src/rating/types.js
+++ b/src/rating/types.js
@@ -20,6 +20,7 @@ export type StarRatingPropsT = {
   value?: number,
   /** The total number of items to display. */
   numItems: number,
+  readOnly?: boolean,
   /** Callback that's called with the newly selected value. */
   onChange?: ({value: number}) => mixed,
   size?: number,
@@ -29,6 +30,7 @@ export type EmoticonRatingPropsT = {
   overrides?: RatingOverridesT,
   /** The current rating value. */
   value?: number,
+  readOnly?: boolean,
   /** Callback that's called with the newly selected value. */
   onChange?: ({value: number}) => mixed,
   size?: number,
@@ -48,6 +50,7 @@ export type StyledRatingItemPropsT = {
   $isActive: boolean,
   $isSelected: boolean,
   $isFocusVisible: boolean,
+  $isReadOnly: boolean,
   $index: number,
   $size: number,
 };


### PR DESCRIPTION
Implements enhancement #3741

#### Description
This new minor feature implements a `readOnly` option for the `StarRating` and `EmoticonRating` components.
This allows one to show a rating without allowing user interactivity with this rating.

I've also added this option to the `EmoticonRating` for consistency, although it does make a little less sense here. But I see no issue with providing this option to the user either way.

#### Scope
Minor: New Feature