### PR TITLE
fix(slider): updates to react-range 1.8.0 and fixes error

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "react-is": "^16.8.6",
     "react-movable": "^2.4.0",
     "react-multi-ref": "^1.0.0",
-    "react-range": "^1.7.0",
+    "react-range": "^1.8.0",
     "react-uid": "^2.3.0",
     "react-virtualized": "^9.21.1",
     "react-virtualized-auto-sizer": "^1.0.2",

--- a/src/slider/slider.js
+++ b/src/slider/slider.js
@@ -40,31 +40,6 @@ const limitValue = (value: number[]) => {
   return value;
 };
 
-export function useHover() {
-  const [value, setValue] = React.useState(false);
-
-  // eslint-disable-next-line flowtype/no-weak-types
-  const ref = React.useRef<any>(null);
-
-  const handleMouseOver = () => setValue(true);
-  const handleMouseOut = () => setValue(false);
-
-  React.useEffect(() => {
-    const node = ref.current;
-    if (node) {
-      node.addEventListener('mouseover', handleMouseOver);
-      node.addEventListener('mouseout', handleMouseOut);
-
-      return () => {
-        node.removeEventListener('mouseover', handleMouseOver);
-        node.removeEventListener('mouseout', handleMouseOut);
-      };
-    }
-  });
-
-  return [ref, value];
-}
-
 function Slider({
   overrides = {},
   disabled = false,
@@ -78,8 +53,9 @@ function Slider({
 }: PropsT) {
   const theme = React.useContext(ThemeContext);
 
-  const [hoverRef0, isHovered0] = useHover();
-  const [hoverRef1, isHovered1] = useHover();
+  const [isHovered0, setIsHovered0] = React.useState(false);
+  const [isHovered1, setIsHovered1] = React.useState(false);
+
   const [isFocusVisible, setIsFocusVisible] = React.useState(false);
   const [focusedThumbIndex, setFocusedThumbIndex] = React.useState(-1);
   const handleFocus = React.useCallback((event: SyntheticEvent<>) => {
@@ -173,7 +149,20 @@ function Slider({
           return (
             <Thumb
               {...props}
-              ref={index ? hoverRef1 : hoverRef0}
+              onMouseEnter={() => {
+                if (index === 0) {
+                  setIsHovered0(true);
+                } else {
+                  setIsHovered1(true);
+                }
+              }}
+              onMouseLeave={() => {
+                if (index === 0) {
+                  setIsHovered0(false);
+                } else {
+                  setIsHovered1(false);
+                }
+              }}
               $thumbIndex={index}
               $isDragged={isDragged}
               style={{

--- a/yarn.lock
+++ b/yarn.lock
@@ -17111,10 +17111,10 @@ react-proptype-conditional-require@^1.0.4:
   resolved "https://registry.yarnpkg.com/react-proptype-conditional-require/-/react-proptype-conditional-require-1.0.4.tgz#69c2d5741e6df5e08f230f36bbc2944ee1222555"
   integrity sha1-acLVdB5t9eCPIw82u8KUTuEiJVU=
 
-react-range@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/react-range/-/react-range-1.7.0.tgz#94ac3851661dabbb9bcc37001ba5ddd7cd0cca5d"
-  integrity sha512-OFF+bcD5o1TJ8M6YcQI4A3b6OYh4bDG0gUkyXETPJHXeut39XL8RZZZPUgfeoEOP1PmtMtluGMbFleP59S9OXg==
+react-range@^1.8.0:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/react-range/-/react-range-1.8.2.tgz#0d22961d65917777ef7f66228147d6752aeccef9"
+  integrity sha512-zegXW7xgWn/4HQ9EqFsxrFamx1rN/CDcG0a7v0dDYb975IG1l7yycQE02CXfWtclM0pUzSZa0iop3zHLPWyyMw==
 
 react-refresh@0.8.2:
   version "0.8.2"


### PR DESCRIPTION
fixes: https://github.com/uber/baseweb/issues/3811

#### Description

https://github.com/uber/baseweb/pull/3833 is no longer needed since the fix is simple enough. baseui slider fails to operate when react-range is version 1.8.0. This didn't show up in our testing because it's locked to 1.7.0. 🤷 The reason it was failing was because baseui code was clobbering the `ref` supplied by the `react-range` library. This diff removed the need for our own ref

#### Scope
Patch: Bug Fix
