### PR TITLE
chore(build): use fix and cache eslint options in lint:code command

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "module": "./esm/index.js",
   "repository": "uber/baseweb",
   "scripts": {
-    "lint:code": "eslint ./",
+    "lint:code": "eslint ./ --fix --cache",
     "lint:markdown": "markdownlint -c ./.markdownlint.json proposals",
     "lint": "yarn lint:code && yarn lint:markdown",
     "pretest": "yarn build:documentation-site-files",


### PR DESCRIPTION
#### Description

While working on the project I saw that lint command takes a very long time. Around `30 - 40 seconds` on my machine.
The suggestion is to add two options to eslint command:
- **cache**. Only check changed files. The default cache location is `.eslintcache` file which is already ignored in `.gitignore` [docs](https://eslint.org/docs/user-guide/command-line-interface#caching)
- **fix**. Automatically try to fix as many issues as possible without breaking the code, example adding semicolon ar removing space [docs](https://eslint.org/docs/user-guide/command-line-interface#-fix)

Time differences:
<img width="614" alt="Screenshot 2020-10-20 at 11 00 04" src="https://user-images.githubusercontent.com/6738026/96558500-6c9c3a80-12c4-11eb-9353-9745996e0388.png">

#### Scope
Patch: Bug Fix