### PR TITLE
fix(data-table): consistent toLowerCase comparators in textQueryFilter

### DIFF
--- a/src/data-table/__tests__/data-table-text-search.scenario.js
+++ b/src/data-table/__tests__/data-table-text-search.scenario.js
@@ -41,7 +41,7 @@ const columns = [
     minWidth: 90,
     mapDataToValue: (data: RowDataT) => data.Phylum,
     textQueryFilter: function(textQuery, data) {
-      return data.toLocaleLowerCase().includes(textQuery.toLowerCase());
+      return data.toLowerCase().includes(textQuery.toLowerCase());
     },
     renderCell: function PhylumnCell(props) {
       return (

--- a/src/data-table/column-categorical.js
+++ b/src/data-table/column-categorical.js
@@ -257,7 +257,7 @@ function CategoricalColumn(options: OptionsT): CategoricalColumnT {
       };
     },
     textQueryFilter: function(textQuery, data) {
-      return data.toLocaleLowerCase().includes(textQuery.toLowerCase());
+      return data.toLowerCase().includes(textQuery.toLowerCase());
     },
     filterable: options.filterable === undefined ? true : options.filterable,
     mapDataToValue: options.mapDataToValue,

--- a/src/data-table/column-string.js
+++ b/src/data-table/column-string.js
@@ -73,7 +73,7 @@ function StringColumn(options: OptionsT): StringColumnT {
       };
     },
     textQueryFilter: function(textQuery, data) {
-      return data.toLocaleLowerCase().includes(textQuery.toLowerCase());
+      return data.toLowerCase().includes(textQuery.toLowerCase());
     },
     filterable: false,
     mapDataToValue: options.mapDataToValue,


### PR DESCRIPTION
#### Description
There are cases where case-agnostic string equality is checked by comparing the results of `toLocaleLowerCase` to the results of `toLowerCase`. This works in most cases, but [for some locales, the output can be different](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase#:~:text=toLocaleLowerCase()%20does%20not%20affect,may%20be%20a%20different%20result.), even if the input strings are identical.


#### Scope
Patch: Bug Fix
