### PR TITLE
fix(stackblitz): pin react to v 16

### DIFF
--- a/documentation-site/components/hooks.js
+++ b/documentation-site/components/hooks.js
@@ -57,8 +57,8 @@ export function useStackBlitz(config = {}) {
         tags: ['baseui'],
         dependencies: {
           baseui: version,
-          react: 'latest',
-          'react-dom': 'latest',
+          react: '16.14.0',
+          'react-dom': '16.14.0',
           'styletron-engine-atomic': 'latest',
           'styletron-react': 'latest',
           'styletron-standard': 'latest',


### PR DESCRIPTION
sets react 16 in stackblitz examples for now
