### PR TITLE
fix(tabs): don't apply hover and focus color to active tab

### DIFF
--- a/src/tabs/styled-components.js
+++ b/src/tabs/styled-components.js
@@ -46,7 +46,7 @@ export const Tab = styled<SharedStylePropsArgT>('div', props => {
         : '2px solid transparent',
     display: 'inline-block',
   };
-  if (!$disabled) {
+  if (!$disabled && !$active) {
     style = {
       ...style,
       ':focus': {


### PR DESCRIPTION
fixes #3664

It's not really a bug. We apply `:hover` and `:focus` color to each tab. By default it's identical to the default `active` color. However, if you override color when `$active` is `true` you'll get this "strange" behavior where you have to change focus to actually see it applied.

So not a bug, just multiple CSS rules applied with a different specificity. You can "fix it" by overriding more values (:hover and :focus). Admittedly, it might be a bit head scratcher for some, so I think we should just not apply hover and focus color to the active tab at all. It's not changing anything for our default and it will make the override behave more predictably?