### PR TITLE
chore(docs): add table guide

### DIFF
--- a/documentation-site/components/gallery.js
+++ b/documentation-site/components/gallery.js
@@ -166,7 +166,7 @@ const COMPONENTS = {
       Component: thumbnails.SvgTable,
     },
     {
-      href: '/components/unstable-data-table',
+      href: '/components/data-table',
       Component: thumbnails.SvgDataTable,
     },
     {

--- a/documentation-site/components/table-guide-notification.js
+++ b/documentation-site/components/table-guide-notification.js
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2018-2020 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+import {Notification, KIND} from 'baseui/notification';
+import {StyledLink} from 'baseui/link';
+import Link from 'next/link';
+
+export default function UnstableWarning() {
+  return (
+    <Notification
+      overrides={{Body: {style: {width: 'auto'}}}}
+      kind={KIND.positive}
+    >
+      <>
+        View the{' '}
+        <Link href="/guides/tables">
+          <StyledLink href="/guides/tables">table guide</StyledLink>
+        </Link>{' '}
+        to see which Base Web table is best suited for your application.
+      </>
+    </Notification>
+  );
+}

--- a/documentation-site/pages/components/data-table.mdx
+++ b/documentation-site/pages/components/data-table.mdx
@@ -5,27 +5,27 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 -->
 
+import {Notification, KIND} from 'baseui/notification';
+
 import Example from '../../components/example';
 import Layout from '../../components/layout';
 import Exports from '../../components/exports';
 import UnstableWarning from '../../components/unstable-warning';
+import TableGuideNotification from '../../components/table-guide-notification';
 
 import Overrides from '../../components/overrides';
 import * as DataTableExports from 'baseui/data-table';
 
-import Basic, {
-  makeRowsFromColumns,
-  columns,
-} from 'examples/data-table/basic.js';
+import Basic from 'examples/data-table/basic.js';
 import BatchAction from 'examples/data-table/batch-action.js';
 import RowHeightLineClamp from 'examples/data-table/row-height-line-clamp.js';
 import CustomizedEmptyState from 'examples/data-table/customized-empty-state.js';
 
 export default Layout;
 
-# Data-Table
+<TableGuideNotification />
 
-<UnstableWarning />
+# Data-Table
 
 Displays tabular data for analysis. The component accepts strict column definitions to consistently
 render the following data types: categorical (enum), number, boolean, string, and arbitrary content.

--- a/documentation-site/pages/components/table-grid.mdx
+++ b/documentation-site/pages/components/table-grid.mdx
@@ -9,6 +9,7 @@ import Example from '../../components/example';
 import API from '../../components/api';
 import Layout from '../../components/layout';
 import Exports from '../../components/exports';
+import TableGuideNotification from '../../components/table-guide-notification';
 
 import * as TableGridExports from 'baseui/table-grid';
 
@@ -19,6 +20,8 @@ import Sortable from 'examples/table-grid/sortable.js';
 import CellNavigation from 'examples/table-grid/cell-navigation.js';
 
 export default Layout;
+
+<TableGuideNotification />
 
 # Table-Grid
 

--- a/documentation-site/pages/components/table-semantic.mdx
+++ b/documentation-site/pages/components/table-semantic.mdx
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 import Example from '../../components/example';
 import Layout from '../../components/layout';
 import Exports from '../../components/exports';
+import TableGuideNotification from '../../components/table-guide-notification';
 
 import * as TableSemanticExports from 'baseui/table-semantic';
 
@@ -24,6 +25,8 @@ import tableYardConfig from '../../components/yard/config/table-semantic';
 import ApiTable from '../../components/api-table';
 
 export default Layout;
+
+<TableGuideNotification />
 
 # Table Semantic
 

--- a/documentation-site/pages/components/table.mdx
+++ b/documentation-site/pages/components/table.mdx
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 import Example from '../../components/example';
 import Layout from '../../components/layout';
 import Exports from '../../components/exports';
+import TableGuideNotification from '../../components/table-guide-notification';
 
 import * as TableExports from 'baseui/table';
 
@@ -28,6 +29,8 @@ import tableYardConfig from '../../components/yard/config/table';
 import ApiTable from '../../components/api-table';
 
 export default Layout;
+
+<TableGuideNotification />
 
 # Table
 

--- a/documentation-site/pages/guides/tables.mdx
+++ b/documentation-site/pages/guides/tables.mdx
@@ -1,0 +1,61 @@
+<!--
+Copyright (c) 2018-2020 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+import Example from '../../components/example';
+import Layout from '../../components/layout';
+
+import TableSemantic from 'examples/table-semantic/basic.js';
+import DataTable from 'examples/data-table/batch-action.js';
+import TableGrid from 'examples/table-grid/cell-span.js';
+import Table from 'examples/table/basic.js';
+
+export default Layout;
+
+# Tables
+
+Tables are used to display data organized in rows and columns. Base Web provides a couple different
+table components that are appropriate in various situations.
+
+You should generally default to using the [`table-semantic`](/components/table-semantic) version. This
+component, which uses the standard `<table>` element, will have accessibility ready to go, supports
+row/column spans, and will dynamically size column widths based on content. It will be most appropriate
+when displaying a smaller number of rows or is paginated. It includes sorting and row selection features
+as well.
+
+<Example title="Table Semantic" path="table-semantic/basic.js">
+  <TableSemantic />
+</Example>
+
+If you are rendering many rows, want to support infinite scrolling, or need data-analysis features like
+filtering, sorting, and search you may be looking for the [`data-table`](/components/data-table) version.
+This component does not support overrides like other Base Web components and requires data to align with
+strict column schemas. Unlike other options it does not support cell/column spans or dynamic row heights.
+Think of this as something closer to Excel rather than a standard table.
+
+<Example title="Data Table" path="data-table/batch-action.js">
+  <DataTable />
+</Example>
+
+Base Web publishes two additional tables that are not quite as useful as the above, but may be appropriate
+in niche situtaions.
+
+First is the [`table-grid`](/components/table-grid). This table ustilizes `css-grid`
+for layout which some developers prefer over the semantic table element. It will require a custom
+accessibility solution, but supports some alternative row/column spans.
+
+<Example title="Table Grid" path="table-grid/cell-span.js">
+  <TableGrid />
+</Example>
+
+Last is a div-based [`table`](/components/table). This is only recommended in situations where 'expanding
+rows' is required and your application needs to support browsers without `css-grid`. If you are only
+targeting newer browsers, `table-grid` is better, but even then it doesn't have great accessibility support.
+Please have good reason to use these last two table components.
+
+<Example title="Table" path="table/basic.js">
+  <Table />
+</Example>

--- a/documentation-site/routes.js
+++ b/documentation-site/routes.js
@@ -235,19 +235,19 @@ const routes = [
         subNav: [
           {
             title: 'Table',
-            itemId: '/components/table',
+            itemId: '/components/table-semantic',
           },
           {
             title: 'Data Table',
-            itemId: '/components/unstable-data-table',
+            itemId: '/components/data-table',
           },
           {
             title: 'Grid Table',
             itemId: '/components/table-grid',
           },
           {
-            title: 'Semantic Table',
-            itemId: '/components/table-semantic',
+            title: 'Flex Table',
+            itemId: '/components/table',
           },
         ],
       },


### PR DESCRIPTION
#### Description

Adds a 'table guide' to compare the different options base web publishes
