### PR TITLE
fix(datepicker): add with mask example. Fix timezone bug

### DIFF
--- a/documentation-site/examples/datepicker/datepicker-with-timezone.js
+++ b/documentation-site/examples/datepicker/datepicker-with-timezone.js
@@ -16,10 +16,12 @@ export default () => {
     <React.Fragment>
       <FormControl label="Date">
         <DatePicker
-          onChange={({date}) => {
-            setDate(date);
-          }}
-          value={new Date(date.getTime() + tz.offset * 60000)}
+          onChange={({date}) => setDate(date)}
+          value={
+            date
+              ? new Date(date.getTime() + tz.offset * 60000)
+              : undefined
+          }
         />
       </FormControl>
       <FormControl label="Timezone">

--- a/documentation-site/examples/datepicker/datepicker-with-timezone.tsx
+++ b/documentation-site/examples/datepicker/datepicker-with-timezone.tsx
@@ -15,10 +15,12 @@ export default () => {
     <React.Fragment>
       <FormControl label="Date">
         <DatePicker
-          onChange={({date}) => {
-            setDate(date as Date);
-          }}
-          value={new Date(date.getTime() + tz.offset * 60000)}
+          onChange={({date}) => setDate(date as Date)}
+          value={
+            date
+              ? new Date(date.getTime() + tz.offset * 60000)
+              : undefined
+          }
         />
       </FormControl>
       <FormControl label="Timezone">

--- a/documentation-site/examples/datepicker/i18n.js
+++ b/documentation-site/examples/datepicker/i18n.js
@@ -8,6 +8,7 @@ export default () => (
     locale={hu}
     onChange={({date}) => console.log(date)}
     formatString="yyyy MMMM d"
+    placeholder="YYYY MMMM d"
     mask={null}
   />
 );

--- a/documentation-site/examples/datepicker/i18n.tsx
+++ b/documentation-site/examples/datepicker/i18n.tsx
@@ -7,6 +7,7 @@ export default () => (
     locale={hu}
     onChange={({date}) => console.log(date)}
     formatString="yyyy MMMM d"
+    placeholder="YYYY MMMM d"
     mask={null}
   />
 );

--- a/documentation-site/examples/datepicker/with-mask.js
+++ b/documentation-site/examples/datepicker/with-mask.js
@@ -1,0 +1,17 @@
+// @flow
+import * as React from 'react';
+import {Datepicker} from 'baseui/datepicker';
+
+export default function Scenario() {
+  const [date, setDate] = React.useState(new Date('2020/01/01'));
+  return (
+    <Datepicker
+      aria-label="Select a date"
+      value={date}
+      onChange={({date}) => setDate(date)}
+      formatString="yyyy-MM-dd"
+      placeholder="YYYY-MM-DD"
+      mask="9999-99-99"
+    />
+  );
+}

--- a/documentation-site/examples/datepicker/with-mask.tsx
+++ b/documentation-site/examples/datepicker/with-mask.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import {Datepicker} from 'baseui/datepicker';
+
+export default function Scenario() {
+  const [date, setDate] = React.useState(new Date('2020/01/01'));
+  return (
+    <Datepicker
+      aria-label="Select a date"
+      value={date}
+      onChange={({date}) => setDate(date as Date)}
+      formatString="yyyy-MM-dd"
+      placeholder="YYYY-MM-DD"
+      mask="9999-99-99"
+    />
+  );
+}

--- a/documentation-site/pages/components/datepicker.mdx
+++ b/documentation-site/pages/components/datepicker.mdx
@@ -21,6 +21,7 @@ import ComposedSinglePickers from 'examples/datepicker/composed-single-pickers.j
 import DatepickersColorStates from 'examples/datepicker/datepickers-color-states.js';
 import DatepickerTimezone from 'examples/datepicker/datepicker-with-timezone.js';
 import NestedOverride from 'examples/datepicker/nested-override.js';
+import DatepickerWithMask from 'examples/datepicker/with-mask.js';
 import DatepickerNullMask from 'examples/datepicker/null-mask.js';
 
 import {StatefulCalendar} from 'baseui/datepicker';
@@ -75,11 +76,17 @@ Please note, that some of the options require you to pass in the `locale` object
   <DatepickerWithOverrides />
 </Example>
 
-Some date formats will operate better without a restrictive input mask. You can disable that feature by applying `null` to the mask prop.
+<Example title="Datepicker with custom mask" path="datepicker/with-mask.js">
+  <DatepickerWithMask />
+</Example>
+
+When using a custom mask `formatString` prop should be also set to match the mask format.
 
 <Example title="Datepicker with no mask" path="datepicker/null-mask.js">
   <DatepickerNullMask />
 </Example>
+
+Some date formats will operate better without a restrictive input mask. You can disable that feature by applying `null` to the mask prop.
 
 <Example
   title="Calendar with time select actions"


### PR DESCRIPTION
#### Description

This PR includes 4 changes to Datepicker documentation page:

1. adds placeholder for `Datepicker with localization` example
2. adds `Datepicker with custom mask` example. It clarifies that three props (formatString, placeholder, mask) for datepicker must be set to work correctly. If `formatString` is not set, manual date input (typing) will not work, example - https://stackblitz.com/edit/react-xvthsy-ebrvmn?file=src/example.js
3. moves `Datepicker with no mask` description text after input
4. fixes a bug where a page crash if a date is removed in `Datepicker with timezone selection` example

![datepicker](https://user-images.githubusercontent.com/6738026/98830770-76d4d300-2443-11eb-90e5-529c6e4b5da2.gif)

#### Scope
Patch: Bug Fix