### PR TITLE
fix(select): opt dropdown out of focus locking

### DIFF
--- a/src/menu/stateful-container.js
+++ b/src/menu/stateful-container.js
@@ -378,15 +378,6 @@ export default class MenuStatefulContainer extends React.Component<
       // $FlowFixMe
       rootRef.current.contains(event.target)
     ) {
-      if (__BROWSER__) {
-        if (
-          event.relatedTarget &&
-          event.relatedTarget === document.activeElement
-        ) {
-          return;
-        }
-      }
-
       if (this.state.highlightedIndex < 0) {
         this.internalSetState(STATE_CHANGE_TYPES.focus, {
           isFocused: true,

--- a/src/select/dropdown.js
+++ b/src/select/dropdown.js
@@ -145,6 +145,7 @@ export default class SelectDropdown extends React.Component<DropdownPropsT> {
     const groupedOptions = groupOptions(options);
     return (
       <DropdownContainer
+        data-no-focus-lock
         ref={this.props.innerRef}
         role="listbox"
         {...this.getSharedProps()}


### PR DESCRIPTION

#### Description

Previous PR was kind of a hacky fix to solve the one particular interaction with modal + select, but this change should completely opt the dropdown out of focus management with the focus lock

#### Scope
Patch: Bug Fix
