### PR TITLE
refactor(slider): make it work with a single numeric value

### DIFF
--- a/documentation-site/examples/slider/basic.tsx
+++ b/documentation-site/examples/slider/basic.tsx
@@ -1,9 +1,14 @@
 import * as React from 'react';
-import {Slider} from 'baseui/slider';
+import {Slider, SliderState} from 'baseui/slider';
 
 export default () => {
-  const [value, setValue] = React.useState([60]);
+  const [value, setValue] = React.useState<SliderState['value']>(
+    60,
+  );
   return (
-    <Slider value={value} onChange={({value}) => setValue(value)} />
+    <Slider
+      value={value}
+      onChange={({value}: SliderState) => setValue(value)}
+    />
   );
 };

--- a/documentation-site/examples/slider/custom-ticks.tsx
+++ b/documentation-site/examples/slider/custom-ticks.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import {Slider} from 'baseui/slider';
+import {Slider, SliderState} from 'baseui/slider';
 import {useStyletron} from 'baseui';
 
 const mToKm = (value: number) => `${(value / 1000).toFixed(1)}km`;
 
 function CustomTicks() {
-  const [value, setValue] = React.useState([4500]);
+  const [value, setValue] = React.useState<SliderState['value']>([
+    4500,
+  ]);
   const [css, theme] = useStyletron();
   return (
     <Slider

--- a/documentation-site/examples/slider/disabled.tsx
+++ b/documentation-site/examples/slider/disabled.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
-import {Slider} from 'baseui/slider';
+import {Slider, SliderState} from 'baseui/slider';
 
 export default () => {
-  const [value, setValue] = React.useState([40]);
+  const [value, setValue] = React.useState<SliderState['value']>([
+    40,
+  ]);
   return (
     <Slider
       disabled

--- a/documentation-site/examples/slider/marks.tsx
+++ b/documentation-site/examples/slider/marks.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
-import {Slider} from 'baseui/slider';
+import {Slider, SliderState} from 'baseui/slider';
 
 export default () => {
-  const [value, setValue] = React.useState([60]);
+  const [value, setValue] = React.useState<SliderState['value']>([
+    60,
+  ]);
   return (
     <Slider
       value={value}

--- a/documentation-site/examples/slider/overrides.tsx
+++ b/documentation-site/examples/slider/overrides.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
-import {Slider} from 'baseui/slider';
+import {Slider, SliderState} from 'baseui/slider';
 
 export default () => {
-  const [value, setValue] = React.useState([70]);
+  const [value, setValue] = React.useState<SliderState['value']>([
+    70,
+  ]);
   return (
     <Slider
       value={value}
       onChange={({value}) => setValue(value)}
       overrides={{
         InnerThumb: ({$value, $thumbIndex}) => (
-          <React.Fragment>{$value[$thumbIndex]}</React.Fragment>
+          <React.Fragment>
+            {Array.isArray($value) ? $value[$thumbIndex] : $value}
+          </React.Fragment>
         ),
         ThumbValue: () => null,
         Thumb: {

--- a/documentation-site/examples/slider/range.tsx
+++ b/documentation-site/examples/slider/range.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
-import {Slider} from 'baseui/slider';
+import {Slider, SliderState} from 'baseui/slider';
 
 export default () => {
-  const [value, setValue] = React.useState([25, 75]);
+  const [value, setValue] = React.useState<SliderState['value']>([
+    25,
+    75,
+  ]);
   return (
     <Slider value={value} onChange={({value}) => setValue(value)} />
   );

--- a/documentation-site/examples/slider/step-min-max.tsx
+++ b/documentation-site/examples/slider/step-min-max.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
-import {Slider} from 'baseui/slider';
+import {Slider, SliderState} from 'baseui/slider';
 
 export default () => {
-  const [value, setValue] = React.useState([90]);
+  const [value, setValue] = React.useState<SliderState['value']>([
+    90,
+  ]);
   return (
     <Slider
       value={value}

--- a/src/slider/__tests__/slider-numeric-value.scenario.js
+++ b/src/slider/__tests__/slider-numeric-value.scenario.js
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2018-2020 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+/* eslint-disable react/display-name*/
+
+import * as React from 'react';
+
+import {Slider} from '../index.js';
+
+export default function Scenario() {
+  if (Date) throw new Error('lol');
+
+  const [rangeValue, setRangeValue] = React.useState(45);
+  return (
+    <div style={{margin: '64px'}}>
+      <Slider
+        value={rangeValue}
+        onChange={({value}) => setRangeValue(value || 0)}
+      />
+    </div>
+  );
+}

--- a/src/slider/index.d.ts
+++ b/src/slider/index.d.ts
@@ -6,15 +6,17 @@ export interface STATE_CHANGE_TYPE {
   change: 'change';
 }
 
-export interface State {
-  value: number[];
+type SliderValue = number | number[];
+
+export interface SliderState {
+  value: SliderValue;
 }
 
 export type StateReducer = (
   stateType: string,
-  nextState: State,
-  currentState: State,
-) => State;
+  nextState: SliderState,
+  currentState: SliderState,
+) => SliderState;
 
 export interface SliderOverrides {
   Root?: Override<SharedProps>;
@@ -29,26 +31,26 @@ export interface SliderOverrides {
 }
 
 export interface SliderProps {
-  value: number[];
+  value: SliderValue;
   min?: number;
   max?: number;
   step?: number;
   overrides?: SliderOverrides;
   disabled?: boolean;
   marks?: boolean;
-  onChange?: (e: State) => any;
-  onFinalChange?: (e: State) => any;
+  onChange?: (e: SliderState) => any;
+  onFinalChange?: (e: SliderState) => any;
 }
 
 export interface StatefulSliderProps {
   overrides?: SliderOverrides;
-  initialState?: State;
+  initialState?: SliderState;
   min?: number;
   max?: number;
   step?: number;
   marks?: boolean;
-  onChange?: (e: State) => any;
-  onFinalChange?: (e: State) => any;
+  onChange?: (e: SliderState) => any;
+  onFinalChange?: (e: SliderState) => any;
 }
 
 export interface StatefulContainerProps {
@@ -58,10 +60,10 @@ export interface StatefulContainerProps {
   max?: number;
   step?: number;
   marks?: boolean;
-  initialState?: State;
+  initialState?: SliderState;
   stateReducer?: StateReducer;
-  onChange?: (e: State) => any;
-  onFinalChange?: (e: State) => any;
+  onChange?: (e: SliderState) => any;
+  onFinalChange?: (e: SliderState) => any;
 }
 
 export type SharedProps = {
@@ -70,7 +72,7 @@ export type SharedProps = {
   $max: number;
   $min: number;
   $thumbIndex: number;
-  $value: Array<number>;
+  $value: SliderValue;
   $marks: boolean;
 };
 
@@ -78,11 +80,11 @@ export const Slider: React.FC<SliderProps>;
 export const StatefulSlider: React.FC<StatefulSliderProps>;
 export class StatefulContainer extends React.Component<
   StatefulContainerProps,
-  State
+  SliderState
 > {
-  onChange(params: State): any;
-  onFinalChange?: (params: State) => any;
-  internalSetState(type: 'change', {value}: State): void;
+  onChange(params: SliderState): any;
+  onFinalChange?: (params: SliderState) => any;
+  internalSetState(type: 'change', {value}: SliderState): void;
 }
 
 export const StyledRoot: StyletronComponent<any>;

--- a/src/slider/slider.js
+++ b/src/slider/slider.js
@@ -31,13 +31,17 @@ import {ThemeContext} from '../styles/theme-provider.js';
 // value.length should not be bigger than two
 // because our design doesn't support more than
 // two thumbs
-const limitValue = (value: number[]) => {
-  if (value.length > 2 || value.length === 0) {
-    throw new Error(
-      'the value prop represents positions of thumbs, so its length can be only one or two',
-    );
+const limitValue = (value: number | number[]): number[] => {
+  if (Array.isArray(value)) {
+    if (value.length > 2 || value.length === 0) {
+      throw new Error(
+        'the value prop represents positions of thumbs, so its length can be only one or two',
+      );
+    }
+    return value;
   }
-  return value;
+
+  return [value];
 };
 
 function Slider({
@@ -107,6 +111,8 @@ function Slider({
   );
   const [Mark, markProps] = getOverrides(overrides.Mark, StyledMark);
 
+  const isValueNumeric = !Array.isArray(providedValue);
+
   return (
     <Root
       data-baseweb="slider"
@@ -121,7 +127,7 @@ function Slider({
         max={max}
         values={value}
         disabled={disabled}
-        onChange={value => onChange({value})}
+        onChange={value => onChange({value: isValueNumeric ? value[0] : value})}
         onFinalChange={value => onFinalChange({value})}
         rtl={theme.direction === 'rtl'}
         renderTrack={({props, children, isDragged}) => (

--- a/src/slider/stateful-slider-container.js
+++ b/src/slider/stateful-slider-container.js
@@ -40,12 +40,12 @@ class StatefulSliderContainer extends React.Component<
     onFinalChange: () => {},
   };
 
-  onChange = (params: {value: Array<number>}) => {
+  onChange = (params: ParamsT) => {
     this.internalSetState(STATE_CHANGE_TYPE.change, params);
     return this.props.onChange({...params});
   };
 
-  onFinalChange = (params: {value: Array<number>}) => {
+  onFinalChange = (params: ParamsT) => {
     this.internalSetState(STATE_CHANGE_TYPE.finalChange, params);
     return this.props.onFinalChange({...params});
   };

--- a/src/slider/styled-components.js
+++ b/src/slider/styled-components.js
@@ -35,19 +35,22 @@ export const Track = styled<StylePropsT>('div', props => {
 });
 Track.displayName = 'StyledTrack';
 
-export const InnerTrack = styled<StylePropsT>('div', props => {
+export const InnerTrack = styled<StylePropsT>('div', (props: StylePropsT) => {
   const {$theme, $value = [], $min, $max, $disabled} = props;
   const {colors, borders, direction} = $theme;
   const borderRadius = $theme.borders.useRoundedCorners ? borders.radius100 : 0;
+
+  const values: number[] = Array.isArray($value) ? $value : [$value];
+
   return {
     borderTopLeftRadius: borderRadius,
     borderTopRightRadius: borderRadius,
     borderBottomRightRadius: borderRadius,
     borderBottomLeftRadius: borderRadius,
     background: getTrackBackground({
-      values: $value,
+      values,
       colors:
-        $value.length === 1
+        values.length === 1
           ? [
               $disabled ? colors.borderOpaque : colors.primary,
               $disabled ? colors.backgroundSecondary : colors.borderOpaque,

--- a/src/slider/types.js
+++ b/src/slider/types.js
@@ -11,7 +11,8 @@ import {STATE_CHANGE_TYPE} from './constants.js';
 
 export type ChangeActionT = $Keys<typeof STATE_CHANGE_TYPE>;
 export type ParamsT = {
-  value: Array<number>,
+  /** Position of the thumbs. It can be a single point (one thumb) or 2 points array (range thumbs). */
+  value: number | Array<number>,
 };
 export type OverridesT = {
   Root?: OverrideT,
@@ -26,8 +27,7 @@ export type OverridesT = {
 };
 
 export type PropsT = {
-  /** Position of the thumbs. It can be a single point (one thumb) or 2 points array (range thumbs). */
-  value: Array<number>,
+  ...ParamsT,
   /** The minimum allowed value of the slider. Should not be bigger than max. */
   min?: number,
   /** The maximum allowed value of the slider. Should not be smaller than min. */
@@ -50,7 +50,7 @@ export type PropsT = {
 };
 
 export type StateT = {|
-  value: Array<number>,
+  value: $ElementType<ParamsT, 'value'>,
 |};
 
 export type StateReducerT = (
@@ -96,6 +96,7 @@ export type StylePropsT = {
   $max?: number,
   $min?: number,
   $thumbIndex?: number,
-  $value?: Array<number>,
+  $value?: $ElementType<ParamsT, 'value'>,
   $isFocusVisible?: boolean,
+  $theme: *,
 };


### PR DESCRIPTION
#### Description

This PR allows the slider component to work even if you just provide a single number as the value prop.
If you do so, the value returned by the onChange handler will also be a single number.

All existing functionality remains the same.

#### Scope

Patch: Refactor
