### PR TITLE
fix(spinner): remove duplicate identifier for size

### DIFF
--- a/src/spinner/index.d.ts
+++ b/src/spinner/index.d.ts
@@ -44,9 +44,3 @@ export const StyledSvg: StyletronComponent<any>;
 export const StyledTrackPath: StyletronComponent<any>;
 export const StyledActivePath: StyletronComponent<any>;
 export const StyledSpinnerNext: StyletronComponent<any>;
-
-export enum SIZE {
-  small = 'small',
-  medium = 'medium',
-  large = 'large',
-}


### PR DESCRIPTION
Fixes #3950 

#### Description
Removed the duplicate entry for the SIZE enum.

#### Scope
Patch: Bug Fix
