### PR TITLE
added optional filter close button plus tests

### DIFF
--- a/src/table/__tests__/filter.test.js
+++ b/src/table/__tests__/filter.test.js
@@ -58,28 +58,10 @@ describe('Table-Filter', () => {
     expect(queryByTestId(container, 'content')).toBeNull();
   });
 
-  it('does not display close button when enabled', () => {
-    const {container} = render(
-      <TestBaseProvider>
-        <Filter
-          hasCloseButton={false}
-        >
-          hello
-        </Filter>
-      </TestBaseProvider>,
-    );
-    fireEvent.click(container.querySelector('button'));
-    expect(getByText(container, 'Close')).toBeNull();
-  });
-
   it('does display close button when enabled', () => {
     const {container} = render(
       <TestBaseProvider>
-        <Filter
-          hasCloseButton={true}
-        >
-          hello
-        </Filter>
+        <Filter hasCloseButton={true}>hello</Filter>
       </TestBaseProvider>,
     );
     fireEvent.click(container.querySelector('button'));

--- a/src/table/__tests__/filter.test.js
+++ b/src/table/__tests__/filter.test.js
@@ -58,6 +58,51 @@ describe('Table-Filter', () => {
     expect(queryByTestId(container, 'content')).toBeNull();
   });
 
+  it('does not display close button when enabled', () => {
+    const {container} = render(
+      <TestBaseProvider>
+        <Filter
+          hasCloseButton={false}
+        >
+          hello
+        </Filter>
+      </TestBaseProvider>,
+    );
+    fireEvent.click(container.querySelector('button'));
+    expect(getByText(container, 'Close')).toBeNull();
+  });
+
+  it('does display close button when enabled', () => {
+    const {container} = render(
+      <TestBaseProvider>
+        <Filter
+          hasCloseButton={true}
+        >
+          hello
+        </Filter>
+      </TestBaseProvider>,
+    );
+    fireEvent.click(container.querySelector('button'));
+    expect(getByText(container, 'Close')).not.toBeNull();
+  });
+
+  it('does close filter when when closed is clicked', () => {
+    const {container} = render(
+      <TestBaseProvider>
+        <Filter
+          hasCloseButton={true}
+          overrides={{Content: {props: {'data-testid': 'content'}}}}
+        >
+          hello
+        </Filter>
+      </TestBaseProvider>,
+    );
+    fireEvent.click(container.querySelector('button'));
+    const close = getByText(container, 'Close');
+    fireEvent.click(close);
+    expect(queryByTestId(container, 'content')).toBeNull();
+  });
+
   it('calls provided onSelectAll handler', () => {
     const spy = jest.fn();
     const {container} = render(

--- a/src/table/__tests__/table-filter.scenario.js
+++ b/src/table/__tests__/table-filter.scenario.js
@@ -76,6 +76,7 @@ class FilterTable extends React.Component<any, any> {
               active={!!this.state.filters.filter(Boolean).length}
               onReset={this.handleReset}
               onSelectAll={this.handleSelectAll}
+              hasCloseButton={true}
             >
               {this.FILTER_FUNCTIONS.map((_, index) => (
                 <FilterCheckbox

--- a/src/table/filter.js
+++ b/src/table/filter.js
@@ -54,7 +54,7 @@ export default function Filter(props: FilterProps) {
         }
         return nextState;
       }}
-      content={
+      content={({close}) => (
         // eslint-disable-next-line jsx-a11y/no-autofocus
         <FocusLock autoFocus={false}>
           <Heading {...headingProps}>Filter Column</Heading>
@@ -79,9 +79,17 @@ export default function Filter(props: FilterProps) {
             >
               Reset
             </Button>
+
+            { props.hasCloseButton && <Button
+              kind={KIND.minimal}
+              size={SIZE.compact}
+              onClick={close}
+            >
+              Close
+            </Button>}
           </Footer>
         </FocusLock>
-      }
+      )}
     >
       <MenuButton
         $active={props.active}

--- a/src/table/index.d.ts
+++ b/src/table/index.d.ts
@@ -43,6 +43,7 @@ export interface FilterProps {
   active?: boolean;
   children: React.ReactNode;
   disabled?: boolean;
+  hasCloseButton?: boolean;
   onReset?: () => any;
   onSelectAll?: () => any;
   overrides?: FilterOverrides;

--- a/src/table/types.js
+++ b/src/table/types.js
@@ -54,6 +54,8 @@ export type FilterProps = {|
   children: React.Node,
   /** Disables the icon click action. Filter menu does not open when clicked. */
   disabled?: boolean,
+  /** Adds a button to close the filter menu. */
+  hasCloseButton?: boolean,
   /** Callback for when the 'reset' button is clicked. */
   onReset?: () => mixed,
   /** Callback for when the 'select all' button is clicked. */


### PR DESCRIPTION
Addresses issue #3955 

**Description**
Added an optional close button, determined by a boolean prop on the filter. This gives developers greater customization for design/accessibility when using the filter.

**Scope**
Minor: New Feature