### PR TITLE
added returnFocus prop to Table Filter

### DIFF
--- a/src/table/filter.js
+++ b/src/table/filter.js
@@ -90,6 +90,7 @@ export default function Filter(props: FilterProps) {
           </Footer>
         </FocusLock>
       )}
+      returnFocus={props.returnFocus}
     >
       <MenuButton
         $active={props.active}

--- a/src/table/index.d.ts
+++ b/src/table/index.d.ts
@@ -47,6 +47,7 @@ export interface FilterProps {
   onReset?: () => any;
   onSelectAll?: () => any;
   overrides?: FilterOverrides;
+  returnFocus?: boolean;
 }
 export const Filter: React.FC<FilterProps>;
 

--- a/src/table/types.js
+++ b/src/table/types.js
@@ -66,4 +66,6 @@ export type FilterProps = {|
     Heading?: OverrideT,
     Footer?: OverrideT,
   },
+  /** Determines whether focus is returned to Filter menu button. */
+  returnFocus?: boolean,
 |};


### PR DESCRIPTION
Addresses issue #3964 

#### Description
Added an optional returnFocus prop on Filter component, determined by a boolean prop on the filter, giving developers greater customization for focus management/accessibility.

#### Scope
Minor: New Feature
