### PR TITLE
docs(blog): fix crashing codesandbox embed

### DIFF
--- a/documentation-site/pages/blog/getting-started-with-base-web/index.mdx
+++ b/documentation-site/pages/blog/getting-started-with-base-web/index.mdx
@@ -245,6 +245,6 @@ By default all the components have the Uber look and feel, but the powerful cust
 You can see all the code for this post in the following demo:
 
 <Demo
-  src="https://codesandbox.io/embed/password-validatorgenerator-w-base-web-forked-w72nq?fontsize=14"
+  src="https://codesandbox.io/embed/password-validatorgenerator-w-base-web-forked-8qtuc?fontsize=14"
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 />

--- a/documentation-site/pages/blog/getting-started-with-base-web/index.mdx
+++ b/documentation-site/pages/blog/getting-started-with-base-web/index.mdx
@@ -245,6 +245,6 @@ By default all the components have the Uber look and feel, but the powerful cust
 You can see all the code for this post in the following demo:
 
 <Demo
-  src="https://codesandbox.io/embed/password-validatorgenerator-w-base-web-ogrn3?fontsize=14"
+  src="https://codesandbox.io/embed/password-validatorgenerator-w-base-web-forked-w72nq?fontsize=14"
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 />


### PR DESCRIPTION
* fix codesandbox embed url on password-generator tutuorial

#### Description
Hi, new to BaseWeb and found it astonishing! While going through the docs, I found that the codesandbox embed is showing import errors.

<img src="https://user-images.githubusercontent.com/5153025/101445702-5118ec00-3965-11eb-9570-b9cd0eced28f.png" width="480px" />

Forked the sandbox and fixed baseui package version.
https://codesandbox.io/s/password-validatorgenerator-w-base-web-forked-w72nq

#### Scope
Patch: Bug Fix
