### PR TITLE
fix(data-table): query handles non-alphanumeric characters

### DIFF
--- a/src/data-table/__tests__/text-search.test.js
+++ b/src/data-table/__tests__/text-search.test.js
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2018-2020 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import {splitByQuery} from '../text-search.js';
+
+describe('data-table text search', () => {
+  it('splitByQuery handles alphabet characters', () => {
+    const result = splitByQuery('Ghostbusters', 'host');
+    expect(result[0]).toBe('G');
+    expect(result[1]).toBe('host');
+    expect(result[2]).toBe('busters');
+  });
+
+  it('splitByQuery handles numeric characters', () => {
+    const result = splitByQuery('123456', '23');
+    expect(result[0]).toBe('1');
+    expect(result[1]).toBe('23');
+    expect(result[2]).toBe('456');
+  });
+
+  it('splitByQuery handles other characters', () => {
+    const result = splitByQuery('prefix[p]suffix', '[p]');
+    expect(result[0]).toBe('prefix');
+    expect(result[1]).toBe('[p]');
+    expect(result[2]).toBe('suffix');
+  });
+
+  it('splitByQuery handles query at start position', () => {
+    const result = splitByQuery('startend', 'start');
+    expect(result[0]).toBe('start');
+    expect(result[1]).toBe('end');
+  });
+
+  it('splitByQuery handles query at end position', () => {
+    const result = splitByQuery('startend', 'end');
+    expect(result[0]).toBe('start');
+    expect(result[1]).toBe('end');
+  });
+
+  it('splitByQuery handles capitalization', () => {
+    const result = splitByQuery('Spotted Hyena', 'hy');
+    expect(result[0]).toBe('Spotted ');
+    expect(result[1]).toBe('Hy');
+    expect(result[2]).toBe('ena');
+  });
+});

--- a/src/data-table/text-search.js
+++ b/src/data-table/text-search.js
@@ -15,7 +15,34 @@ export function matchesQuery(text: string, query: string): boolean {
 }
 
 export function splitByQuery(text: string, query: string): string[] {
-  return text.split(new RegExp(`(${query})`, 'i'));
+  const start = text.toLowerCase().indexOf(query.toLowerCase());
+
+  // query not found
+  if (start === -1) {
+    return [text];
+  }
+
+  if (start === 0) {
+    return [text.slice(0, query.length), text.slice(query.length)];
+  }
+
+  const substrings = [];
+  let substring = '';
+  for (let i = 0; i < text.length; i++) {
+    substring = substring + text[i];
+    if (
+      // prefix
+      i === start - 1 ||
+      // query
+      i === start + query.length - 1 ||
+      // suffix
+      i === text.length - 1
+    ) {
+      substrings.push(substring);
+      substring = '';
+    }
+  }
+  return substrings;
 }
 
 export function HighlightCellText(props: {text: string, query: string}) {


### PR DESCRIPTION
#### Description

Previously, it was building a regex string from the query. This would break if the query contains reserved tokens like `[` for example

#### Scope
Patch: Bug Fix
