### PR TITLE
Fix password input toggle button (eye) visibility when shrunk in Firefox

### DIFF
--- a/src/input/styled-components.js
+++ b/src/input/styled-components.js
@@ -446,6 +446,8 @@ export const getInputStyles = (props: SharedPropsT & {$theme: ThemeT}) => {
     borderBottomStyle: 'none',
     outline: 'none',
     width: '100%',
+    // See https://stackoverflow.com/a/33811151
+    minWidth: 0,
     maxWidth: '100%',
     cursor: $disabled ? 'not-allowed' : 'text',
     margin: '0',


### PR DESCRIPTION
#### Description
Toggle button (eye) becomes partly invisible when testing on small screen sizes or when the input is cramped.
See: https://stackoverflow.com/a/33811151

Screenshot:

<img width="301" alt="Screen Shot 2020-12-28 at 16 43 31" src="https://user-images.githubusercontent.com/6151409/103215292-5b0e8900-492c-11eb-858c-23f6f31ac795.png">

Browser: Firefox
Version: 84.0.1

#### Scope
Patch: Bug Fix