### PR TITLE
fix(data-table): adds y-overflow to filter menu

### DIFF
--- a/src/data-table/filter-menu.js
+++ b/src/data-table/filter-menu.js
@@ -140,8 +140,10 @@ function Options(props: OptionsPropsT) {
           listStyleType: 'none',
           marginBlockStart: 'unset',
           marginBlockEnd: 'unset',
+          maxHeight: '256px',
           paddingInlineStart: 'unset',
           outline: 'none',
+          overflowY: 'auto',
         })}
       >
         {props.columns.map((column, index) => {


### PR DESCRIPTION

<img width="902" alt="Screen Shot 2021-01-05 at 10 18 45 AM" src="https://user-images.githubusercontent.com/5317799/103684367-4dff2480-4f40-11eb-88b4-4c8e279c4eb8.png">


#### Scope
Patch: Bug Fix
