### PR TITLE
fix(docs): use overflow: auto instead of scroll for code blocks

### DIFF
--- a/documentation-site/components/code-box.tsx
+++ b/documentation-site/components/code-box.tsx
@@ -7,7 +7,7 @@ const CodeBox = ({children}: {children: React.ReactNode}) => {
   return (
     <div
       className={css({
-        overflow: 'scroll',
+        overflow: 'auto',
         borderLeftWidth: '5px',
         borderLeftStyle: 'solid',
         borderLeftColor: isLight


### PR DESCRIPTION
Use overflow: auto instead of scroll for code blocks so scrollbars only appear when needed.

Before: 
<img width="1280" alt="scrollbars-before" src="https://user-images.githubusercontent.com/1285326/105140653-e0f59e00-5aac-11eb-84b8-d3eaba7ba7ab.png">

After:
<img width="1280" alt="scrollbars-after" src="https://user-images.githubusercontent.com/1285326/105140671-e7841580-5aac-11eb-9439-86e44300bb23.png">