### PR TITLE
fix(docs): include guidance to migrate way from overrides props functions

### DIFF
--- a/documentation-site/examples/datepicker/with-callback-overrides.js
+++ b/documentation-site/examples/datepicker/with-callback-overrides.js
@@ -1,0 +1,48 @@
+// @flow
+import * as React from 'react';
+import {DatePicker} from 'baseui/datepicker';
+import {Label3} from 'baseui/typography';
+import {Select} from 'baseui/select';
+
+export default function Example() {
+  const [date, setDate] = React.useState(new Date('2020/01/01'));
+  const [quickSelected, setQuickSelected] = React.useState(null);
+  return (
+    <div>
+      <Label3>Quick Selected: {quickSelected || 'nothing'}</Label3>
+      <DatePicker
+        value={date}
+        onChange={({date}) => setDate(date)}
+        quickSelect
+        quickSelectOptions={[
+          {
+            id: 'suggested-time',
+            beginDate: new Date(),
+          },
+          {
+            id: 'other-time',
+            beginDate: new Date(),
+          },
+        ]}
+        overrides={{
+          QuickSelectFormControl: {
+            props: {
+              overrides: {
+                Label: () => <Label3>{'Pick me!'}</Label3>,
+              },
+            },
+          },
+          QuickSelect: ({onChange, ...rest}) => (
+            <Select
+              onChange={params => {
+                setQuickSelected(params.option.id);
+                onChange(params); // call original
+              }}
+              {...rest}
+            />
+          ),
+        }}
+      />
+    </div>
+  );
+}

--- a/documentation-site/examples/datepicker/with-callback-overrides.tsx
+++ b/documentation-site/examples/datepicker/with-callback-overrides.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import {DatePicker} from 'baseui/datepicker';
+import {Label3} from 'baseui/typography';
+import {Select} from 'baseui/select';
+
+export default function Example() {
+  const [date, setDate] = React.useState(new Date('2020/01/01'));
+  const [quickSelected, setQuickSelected] = React.useState('');
+
+  return (
+    <div>
+      <Label3>Quick Selected: {quickSelected || 'nothing'}</Label3>
+      <DatePicker
+        value={date}
+        onChange={({date}) => setDate(date as Date)}
+        quickSelect
+        quickSelectOptions={[
+          {
+            id: 'suggested-time',
+            beginDate: new Date(),
+          },
+          {
+            id: 'other-time',
+            beginDate: new Date(),
+          },
+        ]}
+        overrides={{
+          QuickSelectFormControl: {
+            props: {
+              overrides: {
+                Label: () => <Label3>{'Pick me!'}</Label3>,
+              },
+            },
+          },
+          // @ts-ignore
+          QuickSelect: ({onChange, ...rest}) => (
+            <Select
+              // @ts-ignore
+              onChange={(params: {option: {id: string}}) => {
+                setQuickSelected(params.option.id);
+                onChange(params); // call original
+              }}
+              {...rest}
+            />
+          ),
+        }}
+      />
+    </div>
+  );
+}

--- a/documentation-site/pages/components/datepicker.mdx
+++ b/documentation-site/pages/components/datepicker.mdx
@@ -21,6 +21,7 @@ import ComposedSinglePickers from 'examples/datepicker/composed-single-pickers.j
 import DatepickersColorStates from 'examples/datepicker/datepickers-color-states.js';
 import DatepickerTimezone from 'examples/datepicker/datepicker-with-timezone.js';
 import NestedOverride from 'examples/datepicker/nested-override.js';
+import NestedOverridePropMerge from 'examples/datepicker/with-callback-overrides.js';
 import DatepickerWithMask from 'examples/datepicker/with-mask.js';
 import DatepickerNullMask from 'examples/datepicker/null-mask.js';
 
@@ -141,6 +142,15 @@ Some date formats will operate better without a restrictive input mask. You can 
 </Example>
 
 In this example we use a [nested override](/guides/understanding-overrides/#override-nested-components) to customize the `ListItem` within the month/year dropdown (`MonthYearSelectStatefulMenu`).
+
+<Example
+  title="Overriding and watching nested component callback"
+  path="datepicker/with-callback-overrides.js"
+>
+  <NestedOverridePropMerge />
+</Example>
+
+Here we use the most flexible and complex [override by component replacement](/guides/understanding-overrides/#override-the-entire-subcomponent) where we wrap a components onChange handler to subscribe to the datepicker event when a quick selection is picked.
 
 ## API
 

--- a/documentation-site/pages/guides/understanding-overrides.mdx
+++ b/documentation-site/pages/guides/understanding-overrides.mdx
@@ -19,6 +19,7 @@ import DndListExampleStyle from 'examples/dnd-list/overrides_style.js';
 import DndListExampleStateProps from 'examples/dnd-list/overrides_state_props.js';
 import DndListExampleSubcomponent from 'examples/dnd-list/overrides_whole_subcomponent.js';
 import SelectTagExample from 'examples/select/overridden-tag.js';
+import DatePickerComponentExample from 'examples/datepicker/with-callback-overrides.js';
 
 export default Layout;
 
@@ -318,6 +319,14 @@ The named import always matches the override key with an addition of `Styled` pr
  initialState={{items: ['A', 'B', 'C']}}
 />
 ```
+
+### Enhancing & Merging component props
+
+This example demonstrates a complex scenario where component props are wrapped and enhanced but the original functionality is retained.
+
+<Example path="datepicker/with-callback-overrides.js">
+  <DatePickerComponentExample />
+</Example>
 
 **This technique gives you a ridiculous amount of flexibility.** However, with great power comes great responsibility. We might not be able to effectively support you if you run into issues and upgrades to future versions of Base Web can be complicated. If you have a need to change components behavior this way, you should first [ask maintainers](https://github.com/uber/baseweb/issues) of Base Web. We might add your feature through an official API instead so you don't need to use this override.
 

--- a/src/helpers/overrides.js
+++ b/src/helpers/overrides.js
@@ -110,7 +110,8 @@ export function getOverrides(
     // TODO(v11)
     if (__DEV__) {
       console.warn(
-        'baseui:Overrides Props as a function will be removed in the next major version.',
+        'baseui:Overrides Props as a function will be removed in the next major version. Override the whole component instead. ' +
+          'See https://baseweb.design/guides/understanding-overrides/#override-the-entire-subcomponent',
       );
     }
     const DynamicOverride = React.forwardRef((props, ref) => {


### PR DESCRIPTION
* Clarify and provide guidance for users seeing the warning: `baseui:Overrides Props as a function will be removed in the next major version`
* Add complex component prop merging example for overrides and datepicker docs.

Fixes #4035 