### PR TITLE
fix(drawer): showBackdrop prop fix from Issues

### DIFF
--- a/documentation-site/components/yard/config/drawer.ts
+++ b/documentation-site/components/yard/config/drawer.ts
@@ -87,10 +87,10 @@ const DrawerConfig: TConfig = {
       hidden: true,
     },
     showBackdrop: {
-      value: false,
+      value: true,
+      defaultValue: true,
       type: PropTypes.Boolean,
       description: 'Whether the backdrop should be shown.',
-      hidden: true,
     },
     onBackdropClick: {
       value: false,

--- a/src/drawer/__tests__/drawer.test.js
+++ b/src/drawer/__tests__/drawer.test.js
@@ -45,6 +45,21 @@ describe('Drawer', () => {
     expect(text).not.toBeNull();
   });
 
+  it('renders backdrop with opacity 0 when showBackdrop is false', () => {
+    const {container} = render(
+      <Drawer
+        isOpen
+        anchor="right"
+        showBackdrop={false}
+        overrides={{Backdrop: {props: {'data-testid': 'backdrop'}}}}
+      >
+        Hello world
+      </Drawer>,
+    );
+    const backdrop = getByTestId(container, 'backdrop');
+    expect(backdrop).not.toBeNull();
+  });
+
   it('hides content when close button clicked', () => {
     const onClose = jest.fn();
     const {container} = render(

--- a/src/drawer/drawer.js
+++ b/src/drawer/drawer.js
@@ -195,7 +195,7 @@ class Drawer extends React.Component<DrawerPropsT, DrawerStateT> {
   };
 
   getSharedProps(): $Diff<SharedStylePropsArgT, {children?: React.Node}> {
-    const {animate, isOpen, size, closeable, anchor} = this.props;
+    const {animate, isOpen, size, closeable, anchor, showBackdrop} = this.props;
     return {
       $animating: animate,
       $isVisible: this.state.isVisible,
@@ -204,6 +204,7 @@ class Drawer extends React.Component<DrawerPropsT, DrawerStateT> {
       $closeable: !!closeable,
       $anchor: anchor,
       $isFocusVisible: this.state.isFocusVisible,
+      $showBackdrop: showBackdrop,
     };
   }
 
@@ -220,7 +221,7 @@ class Drawer extends React.Component<DrawerPropsT, DrawerStateT> {
   }
 
   renderDrawer(renderedContent: React.Node) {
-    const {overrides = {}, closeable, showBackdrop, autoFocus} = this.props;
+    const {overrides = {}, closeable, autoFocus} = this.props;
 
     const {
       Root: RootOverride,
@@ -259,13 +260,11 @@ class Drawer extends React.Component<DrawerPropsT, DrawerStateT> {
                 {...sharedProps}
                 {...rootProps}
               >
-                {showBackdrop && (
-                  <Backdrop
-                    onClick={this.onBackdropClick}
-                    {...sharedProps}
-                    {...backdropProps}
-                  />
-                )}
+                <Backdrop
+                  onClick={this.onBackdropClick}
+                  {...sharedProps}
+                  {...backdropProps}
+                />
                 <DrawerContainer
                   aria-label="drawer"
                   {...sharedProps}

--- a/src/drawer/types.js
+++ b/src/drawer/types.js
@@ -86,4 +86,5 @@ export type SharedStylePropsArgT = {
   $closeable: boolean,
   $anchor: AnchorPropT,
   $isFocusVisible: boolean,
+  $showBackdrop: boolean,
 };


### PR DESCRIPTION
Fixing Issue: https://github.com/uber/baseweb/issues/4030

#### Description
The showBackdrop prop was being used to determine if the backdrop was rendered. The desired behavior is for the backdrop to still render, so it can catch clicks and close the drawer, but be fully transparent instead of partially transparent. 

After inspecting the code, I found where we could pass along the prop into the styled component and use it as an additional check for setting the opacity to 0. 

Since the backdrop should now always be rendered, I've added a new test to ensure that is the case.

I've also turned on this prop in the documentation page as it seems to be have been turned off because it wasn't working properly yet.

#### Scope
Patch: Bug Fix
