### PR TITLE
Don't marginRight on the last star, so as to preserve centering

### DIFF
--- a/src/rating/styled-components.js
+++ b/src/rating/styled-components.js
@@ -69,6 +69,9 @@ export const StyledStar = styled<StyledRatingItemPropsT>(
           starSVG(starFill, starStroke, $size) +
           `')`,
       },
+      ':last-of-type': {
+        marginRight: 0,
+      },
     };
 
     return styles;


### PR DESCRIPTION
#### Description

Currently every single star in the `StarRating` component has `marginRight`. This means that if you're trying to center, or right-align the component, then you'll be out by `$theme.sizing.scale300`

You can side-step this issue by applying the following override:

```
overrides={{
  Item: {
    style: ({ $index }): StyleObject => {
      // currently every single star has
      return $index === numItems ? { marginRight: 0 } : {};
    },
  },
}}
```

but it feels like this should not be necessary.

#### Scope
Patch: Bug Fix
