### PR TITLE
feat(block): add id prop to block TS def

### DIFF
--- a/src/block/index.d.ts
+++ b/src/block/index.d.ts
@@ -271,6 +271,7 @@ export interface BlockProps {
   gridTemplateColumns?: Responsive<string>;
   /** available values: https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-rows */
   gridTemplateRows?: Responsive<string>;
+  id?: String;
   /** available values: https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content */
   justifyContent?: Responsive<JustifyContent>;
   /** available values: https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items */


### PR DESCRIPTION
Setting `id` on a `Block` element results in a TypeScript error:

<img width="792" alt="Screen Shot 2021-02-19 at 9 37 41 AM" src="https://user-images.githubusercontent.com/6504944/108540547-28cb3900-7296-11eb-9082-ac3bb672ae25.png">

### Current Behavior

TypeScript error

### Expected Behavior

No TypeScript error

### Related issue for `className`
https://github.com/uber/baseweb/pull/3620
https://github.com/uber/baseweb/issues/2872