### PR TITLE
Allow 'next' tag in publishing

### DIFF
--- a/scripts/publish-to-npm.js
+++ b/scripts/publish-to-npm.js
@@ -23,6 +23,7 @@ const ESLINT_PLUGIN_DIR = path.resolve(
 
 const ALPHA_TAG = 'alpha';
 const LATEST_TAG = 'latest';
+const NEXT_TAG = 'next';
 
 function writeNpmTokenFromEnv() {
   const token = process.env.NPM_TOKEN;
@@ -81,9 +82,9 @@ const rootPackageJSONPath = path.resolve(ROOT_DIR, 'package.json');
 module.exports = function publishToNpm(params /*: any */) {
   const {tag, commit} = params;
 
-  if (tag !== ALPHA_TAG && tag !== LATEST_TAG) {
+  if (tag !== ALPHA_TAG && tag !== LATEST_TAG && tag !== NEXT_TAG) {
     throw new Error(
-      `NPM tag ${tag} must be either ${ALPHA_TAG} or ${LATEST_TAG}.`,
+      `NPM tag ${tag} must be either ${ALPHA_TAG} or ${LATEST_TAG} or ${NEXT_TAG}.`,
     );
   }
 


### PR DESCRIPTION
#### Description

The build is currently failing because in my last PR https://github.com/uber/baseweb/pull/4089 I didn't check that it worked end-to-end, and missed that the publish-to-npm script hardcodes that only `latest` and `alpha` are allowed tags. This PR adds in `next` as an allowed tag

#### Scope
Patch: Bug Fix
