### PR TITLE
Publish 'next' tag with unique semver

### DIFF
--- a/scripts/publish-bleeding-edge.js
+++ b/scripts/publish-bleeding-edge.js
@@ -11,4 +11,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 
 const publishToNpm = require('./publish-to-npm.js');
-publishToNpm({tag: 'next'});
+publishToNpm({
+  tag: 'next',
+  commit: process.env.BUILDKITE_COMMIT,
+});

--- a/scripts/publish-to-npm.js
+++ b/scripts/publish-to-npm.js
@@ -88,18 +88,18 @@ module.exports = function publishToNpm(params /*: any */) {
     );
   }
 
-  if (tag === ALPHA_TAG) {
-    console.log('+++ Updating package.json version to alpha.');
+  if (tag === ALPHA_TAG || tag === NEXT_TAG) {
+    console.log(`+++ Updating package.json version to ${tag}.`);
     if (!commit) {
       throw new Error(
-        'Must provide a commit param to publish an alpha release.',
+        `Must provide a commit param to publish an ${tag} release.`,
       );
     }
     const packageJSON = readJSONFile(rootPackageJSONPath);
     const shortHash = commit.slice(-7);
-    packageJSON.version = `0.0.0-alpha-${shortHash}`;
+    packageJSON.version = `0.0.0-${tag}-${shortHash}`;
     console.log(
-      `Updated package.json version to ${packageJSON.version} for alpha release.`,
+      `Updated package.json version to ${packageJSON.version} for ${tag} release.`,
     );
     fs.writeFileSync(rootPackageJSONPath, JSON.stringify(packageJSON, null, 2));
   }


### PR DESCRIPTION
#### Description

Attempt 3 to get https://github.com/uber/baseweb/pull/4089 working properly...! (Sorry for the multiple PRs, this is inherently hard to test end-to-end)

So, apparently my understanding of `npm publish --tag x` was incorrect. Apparently, it just performs the normal publish flow, but then _also_ tags the end result. This means if that package version already exists, `npm publish` will result in a 403

This PR follows the same logic that the alpha release follows, ensuring that we create a unique package version for the release before hitting `npm publish`

#### Scope
Patch: Bug Fix
