### PR TITLE
feat(select): keep dropdown options highlighted

### DIFF
--- a/src/menu/stateful-container.js
+++ b/src/menu/stateful-container.js
@@ -41,6 +41,7 @@ export default class MenuStatefulContainer extends React.Component<
     removeMenuFromNesting: () => {},
     getParentMenu: () => {},
     getChildMenu: () => {},
+    forceHighlight: false,
   };
 
   state: StatefulContainerStateT = {
@@ -114,6 +115,15 @@ export default class MenuStatefulContainer extends React.Component<
       }
     }
     var range = this.getItems().length;
+    if (
+      this.props.forceHighlight &&
+      this.state.highlightedIndex === -1 &&
+      range > 0
+    ) {
+      this.internalSetState(STATE_CHANGE_TYPES.enter, {
+        highlightedIndex: 0,
+      });
+    }
     if (range === 0 && this.state.highlightedIndex !== -1) {
       this.internalSetState(STATE_CHANGE_TYPES.enter, {
         highlightedIndex: -1,
@@ -330,7 +340,10 @@ export default class MenuStatefulContainer extends React.Component<
 
   handleMouseLeave = () => {
     const rootRef = this.props.rootRef ? this.props.rootRef : this.rootRef;
-    if (!this.props.getChildMenu || !this.props.getChildMenu(rootRef)) {
+    const childMenu =
+      this.props.getChildMenu && this.props.getChildMenu(rootRef);
+
+    if (!this.props.forceHighlight && !childMenu) {
       this.internalSetState(STATE_CHANGE_TYPES.mouseLeave, {
         highlightedIndex: -1,
       });
@@ -416,6 +429,7 @@ export default class MenuStatefulContainer extends React.Component<
       removeMenuFromNesting,
       getParentMenu,
       getChildMenu,
+      forceHighlight,
       ...restProps
     } = this.props;
 

--- a/src/menu/types.js
+++ b/src/menu/types.js
@@ -136,6 +136,7 @@ export type StatefulContainerPropsT = {
   getChildMenu?: (ref: {current: HTMLElement | null}) => ?{
     current: HTMLElement | null,
   },
+  forceHighlight: boolean,
 };
 
 export type MenuPropsT = {

--- a/src/select/dropdown.js
+++ b/src/select/dropdown.js
@@ -167,6 +167,7 @@ export default class SelectDropdown extends React.Component<DropdownPropsT> {
           }}
           typeAhead={false}
           keyboardControlNode={this.props.keyboardControlNode}
+          forceHighlight={true}
           overrides={mergeOverrides(
             {
               List: {


### PR DESCRIPTION
Fixes #4098

#### Description

Adds a "internal" forceHighlight prop to StatefulMenu that Dropdown can use.
The prop disables the mouseLeave highlight removal and sets the highlight to the first item if there are 1 or more items but no highlight.

<!-- Describe your changes below in as much detail as possible -->

#### Scope
Patch: Bug Fix

