### PR TITLE
Fix a typo in understanding-overrides.mdx

### DIFF
--- a/documentation-site/pages/guides/understanding-overrides.mdx
+++ b/documentation-site/pages/guides/understanding-overrides.mdx
@@ -146,7 +146,7 @@ Let's use `$isDragged` to change the Label color when dragged:
 />
 ```
 
-The result is that the Label turns blue when it's dragged:
+The result is that the Label turns black when it's dragged:
 
 <DndListExampleStateProps />
 


### PR DESCRIPTION
The label becomes black when dragged.

#### Description

Fixes a typo.

#### Scope
Patch: Bug Fix
