### PR TITLE
Point the link to "export interface ThemePrimitives"

### DIFF
--- a/documentation-site/pages/guides/theming.mdx
+++ b/documentation-site/pages/guides/theming.mdx
@@ -162,7 +162,7 @@ const theme = createTheme(/* primitives */, /* overrides */);
 
 #### `primitives`
 
-Our theme object has a lot of properties. Most of these properties are assigned to a subset of reoccurring values. We call these reoccurring values, theme building `primitives`. Primitives are made up mostly of colors, (`primary`, `accent`, etc), gradients of those colors (`primary100`, `primary200`, etc) as well as a `primaryFontFamily`. To see the exact shape for `primitives`, reference the [Flow](https://github.com/uber/baseweb/blob/master/src/themes/types.js#L560) or [Typescript](https://github.com/uber/baseweb/blob/master/src/theme.ts#L733) definitions.
+Our theme object has a lot of properties. Most of these properties are assigned to a subset of reoccurring values. We call these reoccurring values, theme building `primitives`. Primitives are made up mostly of colors, (`primary`, `accent`, etc), gradients of those colors (`primary100`, `primary200`, etc) as well as a `primaryFontFamily`. To see the exact shape for `primitives`, reference the [Flow](https://github.com/uber/baseweb/blob/master/src/themes/types.js#L560) or [Typescript](https://github.com/uber/baseweb/blob/master/src/theme.ts#L777) definitions.
 
 These are passed as the first argument to `createTheme`.
 


### PR DESCRIPTION
Fixed the line number in the link. It now points to the correct interface.

#### Description

Previously the link was pointing to `export interface Border`.

#### Scope
Patch: Bug Fix
