### PR TITLE
feat(combobox): adds inputRef to <Combobox/>

### DIFF
--- a/documentation-site/components/yard/config/combobox.ts
+++ b/documentation-site/components/yard/config/combobox.ts
@@ -102,6 +102,11 @@ const ComboboxConfig: TConfig = {
       description: 'Name attribute.',
       hidden: true,
     },
+    inputRef: {
+      value: undefined,
+      type: PropTypes.Ref,
+      description: 'A ref to access the input element.',
+    },
 
     overrides: {
       value: undefined,

--- a/documentation-site/examples/combobox/focus.js
+++ b/documentation-site/examples/combobox/focus.js
@@ -1,0 +1,56 @@
+// @flow
+
+import * as React from 'react';
+
+import {useStyletron} from 'baseui';
+import {Combobox} from 'baseui/combobox';
+import {FormControl} from 'baseui/form-control';
+import {Button} from 'baseui/button';
+
+type OptionT = {label: string, id: string};
+const options: OptionT[] = [
+  {label: 'AliceBlue', id: '#F0F8FF'},
+  {label: 'AntiqueWhite', id: '#FAEBD7'},
+  {label: 'Aqua', id: '#00FFFF'},
+  {label: 'Aquamarine', id: '#7FFFD4'},
+  {label: 'Azure', id: '#F0FFFF'},
+  {label: 'Beige', id: '#F5F5DC'},
+];
+
+function Example() {
+  const [css, theme] = useStyletron();
+  const [value, setValue] = React.useState('');
+  const inputRef = React.useRef(null);
+  return (
+    <div className={css({display: 'flex', flexDirection: 'row'})}>
+      <span>
+        <FormControl label="Color">
+          <Combobox
+            value={value}
+            onChange={setValue}
+            mapOptionToString={o => o.label}
+            options={options}
+            inputRef={inputRef}
+            overrides={{
+              Root: {
+                style: {
+                  width: '375px',
+                  marginRight: theme.sizing.scale600,
+                },
+              },
+            }}
+          />
+        </FormControl>
+      </span>
+      <Button
+        onClick={() => {
+          inputRef.current && inputRef.current.focus();
+        }}
+      >
+        Click to focus
+      </Button>
+    </div>
+  );
+}
+
+export default Example;

--- a/documentation-site/examples/combobox/focus.tsx
+++ b/documentation-site/examples/combobox/focus.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import {useStyletron} from 'baseui';
+import {Combobox} from 'baseui/combobox';
+import {FormControl} from 'baseui/form-control';
+import {Button} from 'baseui/button';
+
+type OptionT = {label: string; id: string};
+const options: OptionT[] = [
+  {label: 'AliceBlue', id: '#F0F8FF'},
+  {label: 'AntiqueWhite', id: '#FAEBD7'},
+  {label: 'Aqua', id: '#00FFFF'},
+  {label: 'Aquamarine', id: '#7FFFD4'},
+  {label: 'Azure', id: '#F0FFFF'},
+  {label: 'Beige', id: '#F5F5DC'},
+];
+
+function Example() {
+  const [css, theme] = useStyletron();
+  const [value, setValue] = React.useState('');
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  return (
+    <div className={css({display: 'flex', flexDirection: 'row'})}>
+      <span>
+        <FormControl label="Color">
+          <Combobox
+            value={value}
+            onChange={setValue}
+            mapOptionToString={o => o.label}
+            options={options}
+            inputRef={inputRef}
+            overrides={{
+              Root: {
+                style: {
+                  width: '375px',
+                  marginRight: theme.sizing.scale600,
+                },
+              },
+            }}
+          />
+        </FormControl>
+      </span>
+      <Button
+        onClick={() => {
+          inputRef.current && inputRef.current.focus();
+        }}
+      >
+        Click to focus
+      </Button>
+    </div>
+  );
+}
+
+export default Example;

--- a/documentation-site/pages/components/combobox.mdx
+++ b/documentation-site/pages/components/combobox.mdx
@@ -19,6 +19,7 @@ import AsyncOptions from 'examples/combobox/async-options.js';
 import FilteredOptions from 'examples/combobox/filtered-options.js';
 import ReplacementNode from 'examples/combobox/replacement-node.js';
 import InputOverrides from 'examples/combobox/input-overrides.js';
+import Focus from 'examples/combobox/focus.js';
 
 export default Layout;
 
@@ -58,6 +59,10 @@ to provide a placeholder, but can be applied to any Input props.
 
 <Example title="Input props" path="combobox/input-overrides.js">
   <InputOverrides />
+</Example>
+
+<Example title="Focus and inputRef" path="combobox/focus.js">
+  <Focus />
 </Example>
 
 ## API

--- a/src/combobox/__tests__/combobox.test.js
+++ b/src/combobox/__tests__/combobox.test.js
@@ -378,4 +378,28 @@ describe('combobox', () => {
     const closed = container.querySelector('ul');
     expect(closed).toBeNull();
   });
+
+  it('forwards inputRef from props', () => {
+    const inputRef = React.createRef();
+    let isFocused = false;
+    const onFocus = () => {
+      isFocused = true;
+    };
+    render(
+      <TestBaseProvider>
+        <Combobox
+          mapOptionToString={o => o}
+          onChange={() => {}}
+          options={options}
+          value={''}
+          inputRef={inputRef}
+          onFocus={onFocus}
+        />
+      </TestBaseProvider>,
+    );
+
+    expect(inputRef.current).toBeDefined();
+    if (inputRef.current) inputRef.current.focus();
+    expect(isFocused).toBeTruthy();
+  });
 });

--- a/src/combobox/combobox.js
+++ b/src/combobox/combobox.js
@@ -45,6 +45,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
     options,
     overrides = {},
     positive = false,
+    inputRef: forwardInputRef,
     size = SIZE.default,
     value,
   } = props;
@@ -199,6 +200,17 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
     setTempValue(event.target.value);
   }
 
+  function handleInputRef(input) {
+    inputRef.current = input;
+    if (forwardInputRef) {
+      if (typeof forwardInputRef === 'function') {
+        forwardInputRef(input);
+      } else {
+        forwardInputRef.current = input;
+      }
+    }
+  }
+
   function handleOptionClick(index) {
     let clickedOption = options[index];
     if (clickedOption) {
@@ -303,7 +315,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
           {...inputContainerProps}
         >
           <OverriddenInput
-            inputRef={inputRef}
+            inputRef={handleInputRef}
             aria-activedescendant={
               selectionIndex >= 0 ? activeDescendantId : undefined
             }

--- a/src/combobox/index.d.ts
+++ b/src/combobox/index.d.ts
@@ -24,6 +24,7 @@ export type PropsT<OptionT = unknown> = {
   mapOptionToString: (OptionT) => string;
   id?: string;
   name?: string;
+  inputRef?: React.Ref<HTMLInputElement>;
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => any;
   onChange?: (value: string, option: OptionT | null) => any;
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => any;

--- a/src/combobox/types.js
+++ b/src/combobox/types.js
@@ -28,6 +28,8 @@ export type PropsT<OptionT = mixed> = {|
   mapOptionToString: OptionT => string,
   id?: string,
   name?: string,
+  // A ref to access the inner Input component.
+  inputRef?: React.ElementRef<*>,
   // Called when input loses focus.
   onBlur?: (SyntheticInputEvent<HTMLInputElement>) => mixed,
   // Called when input value changes or option is selected. If user selects a


### PR DESCRIPTION
#### Description

Adds a ref to the Combobox's inner input. This is useful if you want to give focus to the Combobox or manipulate the inner Input control in other ways.

#### Scope

Minor: New Feature
