### PR TITLE
fix(timepicker): fix filtering by label (instead of id)

### DIFF
--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -332,6 +332,7 @@ class TimePicker<T = Date> extends React.Component<
               value={value ? [value] : value}
               clearable={false}
               backspaceRemoves={false}
+              valueKey="label"
               {...selectProps}
             />
           );


### PR DESCRIPTION
Fixes #4079 

#### Description
Configures the select to use the label as the valueKey to filter by. 

#### Scope
Patch: Bug Fix
