### PR TITLE
docs(combobox): add popover overrides to combobox

### DIFF
--- a/documentation-site/components/yard/config/combobox.ts
+++ b/documentation-site/components/yard/config/combobox.ts
@@ -2,6 +2,9 @@ import {Combobox, SIZE} from 'baseui/combobox';
 import {PropTypes} from 'react-view';
 import {TConfig} from '../types';
 import inputConfig from './input';
+import popoverConfig from './popover';
+
+popoverConfig.componentName = 'Popover';
 
 const comboboxProps = require('!!extract-react-types-loader!../../../../src/combobox/combobox.js');
 
@@ -113,7 +116,14 @@ const ComboboxConfig: TConfig = {
       type: PropTypes.Custom,
       description: 'Lets you customize all aspects of the component.',
       custom: {
-        names: ['Root', inputConfig, 'InputContainer', 'ListBox', 'ListItem'],
+        names: [
+          'Root',
+          inputConfig,
+          'InputContainer',
+          'ListBox',
+          'ListItem',
+          popoverConfig,
+        ],
         sharedProps: {
           $isSelected: {
             type: PropTypes.Boolean,


### PR DESCRIPTION
#### Description

This PR updates the `Combobox` documentation to the reflect the fact that overrides are available for the `Popover` component.

There is no functionality change, it's just documenting an undocumented feature

The change of `componentName` is not ideal as it's mutating the object but the default value exported is `StatefulPopover` and won't work if left unchanged, I'm more than happy to update the PR with some guidance

<img width="572" alt="Screenshot 2021-04-25 at 22 20 18" src="https://user-images.githubusercontent.com/3579758/116010287-fdf2bd80-a615-11eb-84c8-66783ac82f7a.png">
<img width="590" alt="Screenshot 2021-04-25 at 22 20 25" src="https://user-images.githubusercontent.com/3579758/116010290-ffbc8100-a615-11eb-9f0e-5d27524ab637.png">


#### Scope
Patch: Docs Fix
