### PR TITLE
fix(eslint-plugin-baseui): remove slider theme tokens currently in-use

### DIFF
--- a/packages/eslint-plugin-baseui/src/deprecated-theme-api.js
+++ b/packages/eslint-plugin-baseui/src/deprecated-theme-api.js
@@ -108,9 +108,6 @@ const deprecatedThemeProperties = {
   sliderTrackFillSelectedActive: {
     concern: 'colors',
   },
-  sliderHandleFill: {
-    concern: 'colors',
-  },
   sliderHandleFillHover: {
     concern: 'colors',
   },
@@ -124,9 +121,6 @@ const deprecatedThemeProperties = {
     concern: 'colors',
   },
   sliderHandleFillSelectedActive: {
-    concern: 'colors',
-  },
-  sliderHandleFillDisabled: {
     concern: 'colors',
   },
   sliderBorder: {


### PR DESCRIPTION
#### Description
Remove used color tokens for slider component from deprecated list
Link to [PR](https://github.com/uber/baseweb/pull/4249) where the colors tokens are used
