### PR TITLE
fix(popover): fix onClickOutside event handler for web component

### DIFF
--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -251,7 +251,8 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
   };
 
   onDocumentClick = (evt: MouseEvent) => {
-    const target = evt.target;
+    //$FlowFixMe
+    const target = evt.composedPath ? evt.composedPath()[0] : evt.target;
     const popper = this.popperRef.current;
     const anchor = this.anchorRef.current;
     // Ignore document click if it came from popover or anchor


### PR DESCRIPTION
Fixes #4181 

#### Description

I have fixed the firing of `onClickOutside` when the user clicks on a popover target or a content in a web component with the approach mentioned in the issue. I have tested this in a web component.

#### Scope
Patch: Bug Fix