### PR TITLE
chore(alpha-test): test block step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -173,8 +173,7 @@ steps:
   - block: 'Alpha test?'
 
   - name: alpha-test-web-code
-    # command: 'node scripts/alpha-test-web-code.js'
-    command: 'echo alpha test'
+    command: 'node scripts/alpha-test-web-code.js'
     plugins:
       'docker-compose#v3.0.3':
         run: baseui

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -92,15 +92,6 @@ steps:
     agents:
       queue: workers
 
-  - name: alpha-test-web-code
-    command: 'node scripts/alpha-test-web-code.js'
-    if: build.branch != "master" && build.message =~ /^Release v[0-9]+\.[0-9]+\.[0-9]+/
-    plugins:
-      'docker-compose#v3.0.3':
-        run: baseui
-    agents:
-      queue: workers
-
   # vscode extension deployment disabled until we can refresh the azure token
   # - name: deploy-vscode
   #   command: './deploy-vscode.sh'
@@ -176,5 +167,16 @@ steps:
         pull:
           - e2e-server
           - e2e-server-healthy
+    agents:
+      queue: workers
+
+  - block: 'Alpha test?'
+
+  - name: alpha-test-web-code
+    # command: 'node scripts/alpha-test-web-code.js'
+    command: 'echo alpha test'
+    plugins:
+      'docker-compose#v3.0.3':
+        run: baseui
     agents:
       queue: workers


### PR DESCRIPTION
Converting the alpha test job to be available on any commit gated on a buildkite wait step. Verified that anonymous BK users and users not in team cannot trigger the step. One downside with this approach is that the alpha job waits for other jobs to finish