### PR TITLE
chore(domain): fix old versions not being deployed

### DIFF
--- a/documentation-site/next.config.js
+++ b/documentation-site/next.config.js
@@ -60,7 +60,6 @@ module.exports = withTM(
     withImages({
       images: {
         loader: 'imgix',
-        path: '',
       },
       typescript: {
         ignoreBuildErrors: true,

--- a/documentation-site/next.config.js
+++ b/documentation-site/next.config.js
@@ -59,7 +59,7 @@ module.exports = withTM(
   withMDX(
     withImages({
       images: {
-        loader: 'ls',
+        loader: 'imgix',
         path: '',
       },
       typescript: {

--- a/documentation-site/next.config.js
+++ b/documentation-site/next.config.js
@@ -58,6 +58,10 @@ const withTM = require('next-transpile-modules')([
 module.exports = withTM(
   withMDX(
     withImages({
+      images: {
+        loader: 'ls',
+        path: '',
+      },
       typescript: {
         ignoreBuildErrors: true,
       },


### PR DESCRIPTION
Related: #4265 
Fixes the next configuration to use a different image loader for v10, as next-images no longer support image optimization for exporting (only supports runtime optimization) 

https://nextjs.org/docs/messages/export-image-api
