### PR TITLE
chore(deploy-script): add yarn due to now command not found

### DIFF
--- a/deploy-versioned-docs.sh
+++ b/deploy-versioned-docs.sh
@@ -5,7 +5,7 @@ set -e
 
 # deploy to now the versioned docs site
 FORCE_EXTRACT_REACT_TYPES=true yarn documentation:build
-now --scope=uber-ui-platform --token=$ZEIT_NOW_TOKEN --public --no-clipboard deploy ./public > deployment.txt
+yarn now --scope=uber-ui-platform --token=$ZEIT_NOW_TOKEN --public --no-clipboard deploy ./public > deployment.txt
 deployment=`cat deployment.txt`
 version=$(echo $BUILDKITE_MESSAGE | cut -d' ' -f 2)
 cname="${version//./-}"
@@ -13,5 +13,5 @@ curl -X POST "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records
     -H "Authorization: Bearer $CF_API_KEY" \
     -H "Content-Type: application/json" \
     --data "{\"type\":\"CNAME\",\"name\":\"$cname.baseweb.design\",\"content\":\"cname.vercel-dns.com\",\"ttl\":1,\"priority\":10,\"proxied\":false}"
-now --scope=uber-ui-platform --token=$ZEIT_NOW_TOKEN alias $deployment "$cname.baseweb.design"
+yarn now --scope=uber-ui-platform --token=$ZEIT_NOW_TOKEN alias $deployment "$cname.baseweb.design"
 


### PR DESCRIPTION
Use yarn to run now command, since it is no longer installed globally as part of #4073 . 
https://buildkite.com/uberopensource/baseweb/builds/18683#d65f6cc8-9c73-410f-88e7-6bb7c307a4c6/176-513