### PR TITLE
fix(option-profile): forward ref

### DIFF
--- a/documentation-site/components/overrides.js
+++ b/documentation-site/components/overrides.js
@@ -52,7 +52,7 @@ class Overrides extends React.Component {
           <DocLink href="/guides/theming">fully customize</DocLink> any part of
           the <strong>{name}</strong> through the <strong>overrides</strong>{' '}
           prop. The {name} consists of multiple subcomponents that are listed
-          bellow and you can override each one of them. To help you identify the
+          below and you can override each one of them. To help you identify the
           names of these subcomponents,{' '}
           <strong>you can highlight them through this selector:</strong>
         </Block>

--- a/documentation-site/pages/components/menu.mdx
+++ b/documentation-site/pages/components/menu.mdx
@@ -124,11 +124,11 @@ The provided id will be set as a value for the item container's `id` attribute t
       <p>
         <b>Note:</b> <i>baseui/menu</i> supports and exports two types of
         options: <b>OptionList</b> (default) and <b>OptionProfile</b>. You can
-        opt-in into OptionProfile (example rendered bellow) by overriding the{' '}
+        opt-in into OptionProfile (example rendered below) by overriding the{' '}
         <strong>Option</strong> key. Since each override is an another
         component, you can pass additional overrides (
         <strong>all Profile* components</strong>) to it as well and that's what
-        we do bellow.
+        we do below.
       </p>
       <StatefulMenu
         items={[...new Array(4)].map(() => ({

--- a/src/menu/__tests__/menu-profile-menu.scenario.js
+++ b/src/menu/__tests__/menu-profile-menu.scenario.js
@@ -1,0 +1,44 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+import {StatefulMenu, OptionProfile} from '../index.js';
+
+const ITEMS = Array.from({length: 4}, () => ({
+  title: 'David Smith',
+  subtitle: 'Senior Engineering Manager',
+  body: 'Uber Everything',
+  imgUrl: 'https://via.placeholder.com/60x60',
+}));
+
+export default function Scenario() {
+  return (
+    <StatefulMenu
+      items={ITEMS}
+      overrides={{
+        List: {
+          style: {
+            width: '350px',
+          },
+        },
+        Option: {
+          component: OptionProfile,
+          props: {
+            getProfileItemLabels: ({title, subtitle, body}) => ({
+              title,
+              subtitle,
+              body,
+            }),
+            getProfileItemImg: item => item.imgUrl,
+            getProfileItemImgText: item => item.title,
+          },
+        },
+      }}
+    />
+  );
+}

--- a/src/menu/__tests__/menu.stories.js
+++ b/src/menu/__tests__/menu.stories.js
@@ -16,6 +16,7 @@ import MenuPropagation from './menu-propagation.scenario.js';
 import MenuStateful from './menu-stateful.scenario.js';
 import MenuVirtualized from './menu-virtualized.scenario.js';
 import MenuDefault from './menu.scenario.js';
+import MenuProfileMenu from './menu-profile-menu.scenario.js';
 
 export const ChildInPopover = () => <MenuChildInPopover />;
 export const ChildRenderAll = () => <MenuChildRenderAll />;
@@ -26,3 +27,4 @@ export const Propagation = () => <MenuPropagation />;
 export const Stateful = () => <MenuStateful />;
 export const Virtualized = () => <MenuVirtualized />;
 export const Menu = () => <MenuDefault />;
+export const ProfileMenu = () => <MenuProfileMenu />;

--- a/src/menu/option-profile.js
+++ b/src/menu/option-profile.js
@@ -22,7 +22,7 @@ import {getOverrides} from '../helpers/overrides.js';
 // Types
 import type {OptionProfilePropsT} from './types.js';
 
-export default function OptionProfile(props: OptionProfilePropsT) {
+function OptionProfile(props: OptionProfilePropsT, ref: React.ElementRef<*>) {
   const {
     item,
     getChildMenu,
@@ -105,3 +105,10 @@ export default function OptionProfile(props: OptionProfilePropsT) {
     </MaybeChildMenu>
   );
 }
+
+const forwarded = React.forwardRef<OptionProfilePropsT, HTMLElement>(
+  OptionProfile,
+);
+forwarded.displayName = 'OptionProfile';
+
+export default forwarded;


### PR DESCRIPTION
Fixes #4027   

#### Description

The "Menu with Profile Menu" example now correctly forward ref to the `option-profile` component.

#### Scope
Patch: Bug Fix
