### PR TITLE
fix(avatar): render avatar on client side to avoid broken images (#4306)

### DIFF
--- a/src/avatar/avatar.js
+++ b/src/avatar/avatar.js
@@ -32,9 +32,39 @@ export default class Avatar extends React.Component<PropsT, StateT> {
     size: 'scale1000',
   };
 
+  active: boolean;
+
   constructor(props: PropsT) {
     super(props);
     this.state = {noImageAvailable: !this.props.src};
+  }
+
+  componentDidMount() {
+    // using this approach instead of attaching onError to image to make sure that
+    // it works on server side too.
+    if (!this.props.src) {
+      return;
+    }
+    this.active = true;
+
+    const image = new Image();
+    image.onload = () => {
+      if (!this.active) {
+        return;
+      }
+      this.setState({noImageAvailable: false});
+    };
+    image.onerror = () => {
+      if (!this.active) {
+        return;
+      }
+      this.setState({noImageAvailable: true});
+    };
+    image.src = this.props.src;
+  }
+
+  componentWillUnmount() {
+    this.active = false;
   }
 
   componentDidUpdate(prevProps: PropsT, prevState: StateT) {
@@ -42,10 +72,6 @@ export default class Avatar extends React.Component<PropsT, StateT> {
       this.setState({noImageAvailable: !this.props.src});
     }
   }
-
-  handleError = () => {
-    this.setState({noImageAvailable: true});
-  };
 
   render() {
     const {noImageAvailable} = this.state;
@@ -71,13 +97,7 @@ export default class Avatar extends React.Component<PropsT, StateT> {
             {this.props.initials || getInitials(name)}
           </Initials>
         ) : (
-          <Avatar
-            alt={name}
-            onError={this.handleError}
-            src={src}
-            $size={size}
-            {...avatarProps}
-          />
+          <Avatar alt={name} src={src} $size={size} {...avatarProps} />
         )}
       </Root>
     );


### PR DESCRIPTION
Fixes #4306 

#### Description
onError does not work with server side rendering, so it renders the broken images some times instead of initials.

Before 
<img width="1749" alt="Screenshot 2021-06-11 at 4 29 35 PM" src="https://user-images.githubusercontent.com/22965398/121677313-551ff500-cad3-11eb-8fde-e50aff516f49.png">

After
<img width="1749" alt="Screenshot 2021-06-11 at 4 30 01 PM" src="https://user-images.githubusercontent.com/22965398/121677330-5a7d3f80-cad3-11eb-812f-230ff22d3c16.png">



#### Scope
<!-- Pick one:
Patch: Bug Fix
-->
