### PR TITLE
fix(docs): list-item-label sharedProps error

### DIFF
--- a/documentation-site/components/yard/config/list-item-label.ts
+++ b/documentation-site/components/yard/config/list-item-label.ts
@@ -37,6 +37,11 @@ const ListItemLabelConfig: TConfig = {
       description: 'Lets you customize all aspects of the component.',
       custom: {
         names: ['LabelContent', 'LabelDescription', 'LabelSublistContent'],
+        sharedProps: {
+          $labelContent: 'LabelContent',
+          $labelDescription: 'LabelDescription',
+          $labelSublistContent: 'LabelSublistContent',
+        },
       },
     },
   },


### PR DESCRIPTION
- error when open list-item-label override
- related #4341

#### Description
<img width="1679" alt="스크린샷 2021-06-27 오후 9 01 55" src="https://user-images.githubusercontent.com/17137872/123543727-ea391400-d78a-11eb-9cb7-c8cd080a6113.png">
