### PR TITLE
fix(button-group): move isSelected var to after null check

### DIFF
--- a/src/button-group/__tests__/button-group.test.js
+++ b/src/button-group/__tests__/button-group.test.js
@@ -113,6 +113,7 @@ describe('ButtonGroup', () => {
       );
     }
   });
+
   it('should respect isSelected value if the consumer passes the prop to Button', () => {
     const {queryByTitle} = render(
       <ButtonGroup>
@@ -125,5 +126,17 @@ describe('ButtonGroup', () => {
     expect(
       queryByTitle('testButton').getAttribute('aria-checked'),
     ).toBeTruthy();
+  });
+
+  it('should handle null children', () => {
+    const {container} = render(
+      <ButtonGroup>
+        <Button>one</Button>
+        <Button>two</Button>
+        {null}
+      </ButtonGroup>,
+    );
+
+    expect(container.querySelectorAll('button').length).toBe(2);
   });
 });

--- a/src/button-group/button-group.js
+++ b/src/button-group/button-group.js
@@ -68,12 +68,14 @@ export default class ButtonGroup extends React.Component<PropsT> {
             {...rootProps}
           >
             {React.Children.map(children, (child, index) => {
-              const isSelected =
-                child.props.isSelected ?? isIndexSelected(selected, index);
-
               if (!React.isValidElement(child)) {
                 return null;
               }
+
+              const isSelected = child.props.isSelected
+                ? child.props.isSelected
+                : isIndexSelected(selected, index);
+
               if (isRadio) {
                 this.childRefs[index] = React.createRef<HTMLButtonElement>();
               }


### PR DESCRIPTION
Fixes small error in https://github.com/uber/baseweb/commit/32198e946a584813553a2653d39f09627150ddb4

#### Scope
Patch: Bug Fix

