### PR TITLE
fix(list-item): missing type definition for overrides

### DIFF
--- a/src/list/index.d.ts
+++ b/src/list/index.d.ts
@@ -39,6 +39,12 @@ export interface ListOverrides {
   EndEnhancerContainer?: Override<{}>;
 }
 
+export interface LabelOverrides {
+  LabelContent?: Override<any>;
+  LabelDescription?: Override<any>;
+  LabelSublistContent?: Override<any>;
+}
+
 export interface PropsT {
   artwork?: React.ReactNode;
   artworkSize?: ArtworkSizesT | number;
@@ -53,6 +59,7 @@ export interface LabelPropsT {
   children: React.ReactNode;
   description?: React.ReactNode;
   sublist?: boolean;
+  overrides?: LabelOverrides;
 }
 
 export interface MenuAdapterPropsT extends PropsT {


### PR DESCRIPTION
* Related #4355

#### Description

This fix adds the missing typescript type definitions for `overrides` on the `ListItemLabel`.

The original error that led me to opening this PR:
```ts
Type '{ children: string; overrides: { LabelContent: { style: () => { backgroundColor: string; }; }; }; description: string | null; }' is not assignable to type 'IntrinsicAttributes & LabelPropsT & { children?: ReactNode; }'.
  Property 'overrides' does not exist on type 'IntrinsicAttributes & LabelPropsT & { children?: ReactNode; }'.ts(2322)
```

#### Scope
Patch: Bug Fix