### PR TITLE
fix(alpha-test): unhandled exceptions should exit with non-zero

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -174,7 +174,7 @@ steps:
     blocked_state: 'passed'
 
   - name: alpha-test-web-code
-    command: 'node scripts/alpha-test-web-code.js'
+    command: 'node --unhandled-rejections=strict scripts/alpha-test-web-code.js'
     plugins:
       'docker-compose#v3.0.3':
         run: baseui


### PR DESCRIPTION
Alpha test was green yesterday even though one project unit-tests failed. The `--unhandled-rejections=strict` option ensures that node will exit with a non-zero code and reflects future behavior