### PR TITLE
fix(toast): fix container to render portal if mounted and in browser

### DIFF
--- a/src/toast/toaster.js
+++ b/src/toast/toaster.js
@@ -204,28 +204,20 @@ export class ToasterContainer extends React.Component<
         {toastsToRender}
       </Root>
     );
-    if (this.props.usePortal) {
-      //Only render the portal in the browser, otherwise just render the children
-      return (
-        <>
-          {this.state.isMounted && __BROWSER__
-            ? ReactDOM.createPortal(
-                root,
-                // $FlowFixMe
-                document.body,
-              )
-            : null}
-          {this.props.children}
-        </>
-      );
-    } else {
-      return (
-        <>
-          {root}
-          {this.props.children}
-        </>
-      );
-    }
+
+    //Only render the portal in the browser, otherwise render the toasts and children
+    return (
+      <>
+        {this.props.usePortal && this.state.isMounted && __BROWSER__
+          ? ReactDOM.createPortal(
+              root,
+              // $FlowFixMe
+              document.body,
+            )
+          : root}
+        {this.props.children}
+      </>
+    );
   }
 }
 

--- a/src/toast/toaster.js
+++ b/src/toast/toaster.js
@@ -207,18 +207,22 @@ export class ToasterContainer extends React.Component<
     );
 
     //Only render the portal in the browser, otherwise render the toasts and children
-    return (
-      <>
-        {this.props.usePortal && this.state.isMounted && __BROWSER__
-          ? ReactDOM.createPortal(
-              root,
-              // $FlowFixMe
-              document.body,
-            )
-          : root}
-        {this.props.children}
-      </>
-    );
+    if (this.state.isMounted) {
+      return (
+        <>
+          {this.props.usePortal && __BROWSER__
+            ? ReactDOM.createPortal(
+                root,
+                // $FlowFixMe
+                document.body,
+              )
+            : root}
+          {this.props.children}
+        </>
+      );
+    } else {
+      return <>{this.props.children}</>;
+    }
   }
 }
 

--- a/src/toast/toaster.js
+++ b/src/toast/toaster.js
@@ -208,7 +208,7 @@ export class ToasterContainer extends React.Component<
       //Only render the portal in the browser, otherwise just render the children
       return (
         <>
-          {__BROWSER__
+          {this.state.isMounted && __BROWSER__
             ? ReactDOM.createPortal(
                 root,
                 // $FlowFixMe

--- a/src/toast/toaster.js
+++ b/src/toast/toaster.js
@@ -44,6 +44,8 @@ export class ToasterContainer extends React.Component<
 
   constructor(props: ToasterPropsT) {
     super(props);
+
+    toasterRef = this;
   }
 
   state = {
@@ -56,7 +58,6 @@ export class ToasterContainer extends React.Component<
   toastId: number = 0;
 
   componentDidMount() {
-    toasterRef = this;
     this.setState({isMounted: true});
   }
 


### PR DESCRIPTION
Reopens #3414 since moving this to componentDidMount prevents toast messages from being triggered on initial render. 