### PR TITLE
fix(combobox): change options type to an array

### DIFF
--- a/src/combobox/index.d.ts
+++ b/src/combobox/index.d.ts
@@ -29,7 +29,7 @@ export type PropsT<OptionT = unknown> = {
   onChange?: (value: string, option: OptionT | null) => any;
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => any;
   onSubmit?: (params: {closeListbox: () => void; value: string}) => any;
-  options: OptionT;
+  options: OptionT[];
   overrides?: ComboboxOverrides;
   size?: SIZE[keyof SIZE];
   value: string;


### PR DESCRIPTION
#### Description

I found that the `options` type was `OptionT`, but `options` should be an array. So I changed this type and opened a pull request.

#### Scope

Patch: Bug Fix
