### PR TITLE
docs(toast): update docs to no longer nest children in ToasterContainer

### DIFF
--- a/documentation-site/components/yard/config/toast.ts
+++ b/documentation-site/components/yard/config/toast.ts
@@ -1,3 +1,9 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
 import {toaster, ToasterContainer, PLACEMENT} from 'baseui/toast';
 import {Button, SIZE} from 'baseui/button';
 import {Block} from 'baseui/block';
@@ -9,7 +15,7 @@ const buttonProps = require('!!extract-react-types-loader!../../../../src/button
 const blockProps = require('!!extract-react-types-loader!../../../../src/block/block.js');
 
 const toastConfig: TConfig = {
-  componentName: 'ToasterContainer',
+  componentName: 'React.Fragment',
   imports: {
     'baseui/toast': {
       named: ['toaster', 'ToasterContainer'],
@@ -50,7 +56,8 @@ const toastConfig: TConfig = {
       },
     },
     children: {
-      value: `<Button onClick={()=>{
+      value: `<ToasterContainer />
+        <Button onClick={()=>{
           let toastKey;
           const msg = 'Use toaster.info(), toaster.positive(), toaster.warning(), or toaster.negative()';
           const ok = (

--- a/documentation-site/examples/toast/toast-close-from-outside.js
+++ b/documentation-site/examples/toast/toast-close-from-outside.js
@@ -16,11 +16,12 @@ export default function Example() {
   };
 
   return (
-    <ToasterContainer>
+    <React.Fragment>
+      <ToasterContainer />
       <Button onClick={showToast}>Show notification</Button>
       <Button disabled={!toastKey} onClick={closeToast}>
         Close notification
       </Button>
-    </ToasterContainer>
+    </React.Fragment>
   );
 }

--- a/documentation-site/examples/toast/toast-close-from-outside.tsx
+++ b/documentation-site/examples/toast/toast-close-from-outside.tsx
@@ -21,11 +21,12 @@ export default function Example() {
   };
 
   return (
-    <ToasterContainer>
+    <React.Fragment>
+      <ToasterContainer />
       <Button onClick={showToast}>Show notification</Button>
       <Button disabled={!toastKey} onClick={closeToast}>
         Close notification
       </Button>
-    </ToasterContainer>
+    </React.Fragment>
   );
 }

--- a/documentation-site/examples/toast/toast-notification.js
+++ b/documentation-site/examples/toast/toast-notification.js
@@ -1,12 +1,11 @@
 // @flow
 import * as React from 'react';
-import {Toast, KIND} from 'baseui/toast';
+import {Toast, KIND, ToasterContainer} from 'baseui/toast';
 import {
   Button,
   SIZE as BUTTON_SIZE,
   KIND as BUTTON_KIND,
 } from 'baseui/button';
-import {ToasterContainer} from '../../../src/toast';
 
 export default function Example() {
   return (

--- a/documentation-site/examples/toast/toast-notification.js
+++ b/documentation-site/examples/toast/toast-notification.js
@@ -6,10 +6,12 @@ import {
   SIZE as BUTTON_SIZE,
   KIND as BUTTON_KIND,
 } from 'baseui/button';
+import {ToasterContainer} from '../../../src/toast';
 
 export default function Example() {
   return (
     <React.Fragment>
+      <ToasterContainer />
       <Toast>Default info notification</Toast>
       <Toast kind={KIND.positive}>Positive notification</Toast>
       <Toast kind={KIND.warning}>Warning notification</Toast>

--- a/documentation-site/examples/toast/toast-notification.tsx
+++ b/documentation-site/examples/toast/toast-notification.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import {Toast, KIND} from 'baseui/toast';
+import {Toast, KIND, ToasterContainer} from 'baseui/toast';
 
 export default function Example() {
   return (
     <React.Fragment>
+      <ToasterContainer />
       <Toast>Default info notification</Toast>
       <Toast kind={KIND.positive}>Positive notification</Toast>
       <Toast kind={KIND.warning}>Warning notification</Toast>

--- a/documentation-site/examples/toast/toast-same-key-notification.js
+++ b/documentation-site/examples/toast/toast-same-key-notification.js
@@ -1,9 +1,8 @@
 // @flow
 import * as React from 'react';
-import {toaster} from 'baseui/toast';
+import {toaster, ToasterContainer} from 'baseui/toast';
 import {Button, SIZE} from 'baseui/button';
 import {Block} from 'baseui/block';
-import {ToasterContainer} from '../../../src/toast';
 
 export default function Example() {
   const [count, setCount] = React.useState(0);

--- a/documentation-site/examples/toast/toast-same-key-notification.js
+++ b/documentation-site/examples/toast/toast-same-key-notification.js
@@ -3,11 +3,13 @@ import * as React from 'react';
 import {toaster} from 'baseui/toast';
 import {Button, SIZE} from 'baseui/button';
 import {Block} from 'baseui/block';
+import {ToasterContainer} from '../../../src/toast';
 
 export default function Example() {
   const [count, setCount] = React.useState(0);
   return (
     <React.Fragment>
+      <ToasterContainer />
       <Button
         onClick={() => {
           setCount(count + 1);

--- a/documentation-site/examples/toast/toast-same-key-notification.tsx
+++ b/documentation-site/examples/toast/toast-same-key-notification.tsx
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import {toaster} from 'baseui/toast';
+import {toaster, ToasterContainer} from 'baseui/toast';
 import {Button, SIZE} from 'baseui/button';
 import {Block} from 'baseui/block';
 
@@ -8,6 +8,7 @@ export default function Example() {
   const [count, setCount] = React.useState(0);
   return (
     <React.Fragment>
+      <ToasterContainer />
       <Button
         onClick={() => {
           setCount(count + 1);


### PR DESCRIPTION
Updates the docs to no longer show examples of nesting elements within the ToasterContainer. The toaster container will re-render after being mounted, which can cause issues when server side rendered pages remount routes/components. 