### PR TITLE
fix(select): test parameterized option type

### DIFF
--- a/src/select/__tests__/select-typed-options.scenario.js
+++ b/src/select/__tests__/select-typed-options.scenario.js
@@ -20,8 +20,14 @@ export default function Scenario() {
   return (
     <SelectFunctional
       options={options}
+      // inspecting 'value' below in IDE shows a ValueT<empty> type
       onChange={({value}) => {
+        // passes flow check
         console.log(value[0].title);
+
+        // passes flow check, but should not
+        console.log(value[0].does_not_exist);
+
         setValue(value);
       }}
       value={value}

--- a/src/select/__tests__/select-typed-options.scenario.js
+++ b/src/select/__tests__/select-typed-options.scenario.js
@@ -1,0 +1,32 @@
+// @flow
+
+import * as React from 'react';
+
+import SelectFunctional from '../select-component-functional.js';
+
+type OptionT = {title: string, hex: string};
+
+const options: OptionT[] = [
+  {title: 'AliceBlue', hex: '#F0F8FF'},
+  {title: 'AntiqueWhite', hex: '#FAEBD7'},
+  {title: 'Aqua', hex: '#00FFFF'},
+  {title: 'Aquamarine', hex: '#7FFFD4'},
+  {title: 'Azure', hex: '#F0FFFF'},
+  {title: 'Beige', hex: '#F5F5DC'},
+];
+
+export default function Scenario() {
+  const [value, setValue] = React.useState([]);
+  return (
+    <SelectFunctional
+      options={options}
+      onChange={({value}) => {
+        console.log(value[0].title);
+        setValue(value);
+      }}
+      value={value}
+      labelKey="title"
+      valueKey="hex"
+    />
+  );
+}

--- a/src/select/dropdown-functional.js
+++ b/src/select/dropdown-functional.js
@@ -1,0 +1,224 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+
+import {
+  StyledDropdownContainer,
+  StyledDropdown,
+  StyledDropdownListItem,
+  StyledOptionContent,
+} from './styled-components.js';
+import {StatefulMenu} from '../menu/index.js';
+import type {DropdownPropsT, OptionT, ValueT} from './types-next.js';
+import {getOverrides, mergeOverrides} from '../helpers/overrides.js';
+
+function groupOptions(options) {
+  return options.reduce(
+    (groups, option) => {
+      if (option.__optgroup) {
+        if (!groups[option.__optgroup]) {
+          groups[option.__optgroup] = [];
+        }
+        groups[option.__optgroup].push(option);
+      } else {
+        groups.__ungrouped.push(option);
+      }
+      return groups;
+    },
+    {__ungrouped: []},
+  );
+}
+
+export default function SelectDropdown<P>(props: DropdownPropsT<P>) {
+  const {
+    error,
+    getOptionLabel,
+    id,
+    innerRef,
+    isLoading,
+    keyboardControlNode,
+    maxDropdownHeight,
+    multi,
+    noResultsMsg,
+    onActiveDescendantChange = _ => {},
+    onItemSelect,
+    options = [],
+    overrides = {},
+    required,
+    searchable,
+    size,
+    type,
+    value,
+    valueKey,
+    width,
+  } = props;
+
+  const [DropdownContainer, dropdownContainerProps] = getOverrides(
+    overrides.DropdownContainer,
+    StyledDropdownContainer,
+  );
+  const [ListItem, listItemProps] = getOverrides(
+    overrides.DropdownListItem,
+    StyledDropdownListItem,
+  );
+  const [
+    OverriddenStatefulMenu,
+    // $FlowFixMe
+    {overrides: statefulMenuOverrides = {}, ...restStatefulMenuProps},
+  ] = getOverrides(overrides.StatefulMenu, StatefulMenu);
+  const [OptionContent, optionContentProps] = getOverrides(
+    overrides.OptionContent,
+    StyledOptionContent,
+  );
+
+  const sharedProps = {
+    $error: error,
+    $isLoading: isLoading,
+    $multi: multi,
+    $required: required,
+    $searchable: searchable,
+    $size: size,
+    $type: type,
+    $width: width,
+  };
+
+  const getItemLabel = React.useCallback(
+    option => {
+      let $selected;
+      if (Array.isArray(value)) {
+        $selected = !!value.find(
+          selected => selected && selected[valueKey] === option[valueKey],
+        );
+      } else {
+        $selected = value[valueKey] === option[valueKey];
+      }
+
+      const optionSharedProps = {
+        $selected,
+        $disabled: option.disabled,
+        $isHighlighted: option.isHighlighted,
+      };
+      return (
+        <OptionContent
+          aria-readonly={option.disabled}
+          aria-selected={$selected}
+          key={option[valueKey]}
+          {...sharedProps}
+          {...optionSharedProps}
+          {...optionContentProps}
+        >
+          {getOptionLabel({option, optionState: optionSharedProps})}
+        </OptionContent>
+      );
+    },
+    [overrides, value, valueKey],
+  );
+
+  const onMouseDown = React.useCallback(event => {
+    event.nativeEvent.stopImmediatePropagation();
+  }, []);
+
+  const highlightedIndex = React.useMemo(() => {
+    // Highlight only first value as menu supports only a single highlight index
+    let firstValue = {};
+
+    if (Array.isArray(value) && value.length > 0) {
+      firstValue = value[0];
+    } else if (!(value instanceof Array)) {
+      firstValue = value;
+    }
+
+    if (Object.keys(firstValue).length > 0) {
+      const a = options.findIndex(
+        option => option && option[valueKey] === firstValue[valueKey],
+      );
+      return a === -1 ? 0 : a;
+    }
+    return 0;
+  }, [options, value, valueKey]);
+
+  const groupedOptions = React.useMemo(() => {
+    return options.reduce(
+      (groups, option) => {
+        if (option.__optgroup) {
+          if (!groups[option.__optgroup]) {
+            groups[option.__optgroup] = [];
+          }
+          groups[option.__optgroup].push(option);
+        } else {
+          groups.__ungrouped.push(option);
+        }
+        return groups;
+      },
+      {__ungrouped: []},
+    );
+  }, [options]);
+
+  return (
+    <DropdownContainer
+      data-no-focus-lock
+      ref={innerRef}
+      {...sharedProps}
+      {...dropdownContainerProps}
+    >
+      <OverriddenStatefulMenu
+        noResultsMsg={noResultsMsg}
+        onActiveDescendantChange={onActiveDescendantChange}
+        onItemSelect={onItemSelect}
+        items={groupedOptions}
+        size={size}
+        initialState={{
+          isFocused: true,
+          highlightedIndex: highlightedIndex,
+        }}
+        typeAhead={false}
+        keyboardControlNode={keyboardControlNode}
+        forceHighlight={true}
+        overrides={mergeOverrides(
+          {
+            List: {
+              component: StyledDropdown,
+              style: p => ({
+                maxHeight: p.$maxHeight || null,
+              }),
+              props: {
+                id: id ? id : null,
+                $maxHeight: maxDropdownHeight,
+                'aria-multiselectable': multi,
+              },
+            },
+            Option: {
+              props: {
+                getItemLabel,
+                onMouseDown,
+                overrides: {
+                  ListItem: {
+                    component: ListItem,
+                    props: {...listItemProps, role: 'option'},
+                    // slightly hacky way to handle the list item style overrides
+                    // since the menu component doesn't provide a top level overrides for it
+                    // $FlowFixMe
+                    style: listItemProps.$style,
+                  },
+                },
+                renderHrefAsAnchor: false,
+              },
+            },
+          },
+          {
+            List: overrides.Dropdown || {},
+            Option: overrides.DropdownOption || {},
+            ...statefulMenuOverrides,
+          },
+        )}
+        {...restStatefulMenuProps}
+      />
+    </DropdownContainer>
+  );
+}

--- a/src/select/select-component-functional.js
+++ b/src/select/select-component-functional.js
@@ -1,0 +1,602 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+
+import {getOverrides} from '../helpers/overrides.js';
+import DeleteAlt from '../icon/delete-alt.js';
+import TriangleDownIcon from '../icon/triangle-down.js';
+import SearchIconComponent from '../icon/search.js';
+import {LocaleContext} from '../locale/index.js';
+import type {LocaleT} from '../locale/types.js';
+import {Popover, PLACEMENT} from '../popover/index.js';
+import {Spinner} from '../spinner/index.js';
+import getBuiId from '../utils/get-bui-id.js';
+
+import AutosizeInput from './autosize-input.js';
+import {TYPE, STATE_CHANGE_TYPE} from './constants.js';
+import SelectDropdown from './dropdown-functional.js';
+import {
+  StyledRoot,
+  StyledControlContainer,
+  StyledPlaceholder,
+  StyledValueContainer,
+  StyledInputContainer,
+  StyledIconsContainer,
+  StyledSelectArrow,
+  StyledClearIcon,
+  getLoadingIconStyles,
+  StyledSearchIconContainer,
+} from './styled-components.js';
+import type {PropsT, ValueT, OptionT} from './types-next.js';
+import {expandValue, normalizeOptions} from './utils/index.js';
+
+const isClick = event => event.type === 'click';
+const isLeftClick = event => {
+  return (
+    event.button !== null && event.button !== undefined && event.button === 0
+  );
+};
+const containsNode = (parent, child) => {
+  if (__BROWSER__) {
+    // eslint-disable-next-line flowtype/no-weak-types
+    return child && parent && parent.contains((child: any));
+  }
+};
+function isInteractive(rootTarget: EventTarget, rootElement: Element) {
+  if (rootTarget instanceof Element) {
+    let target: ?Element = rootTarget;
+    while (target && target !== rootElement) {
+      const role = target.getAttribute('role');
+      if (role === 'button' || role === 'link') {
+        return true;
+      }
+      if (target.tagName) target = target.parentElement;
+    }
+  }
+  return false;
+}
+
+export default function SelectFunctional<P>(props: PropsT<P>) {
+  const {
+    autoFocus,
+    backspaceClearsInputValue,
+    backspaceRemoves,
+    clearable,
+    closeOnSelect,
+    creatable,
+    deleteRemoves,
+    disabled,
+    error,
+    escapeClearsValue,
+    getOptionLabel,
+    getValueLabel,
+    isLoading,
+    labelKey,
+    maxDropdownHeight,
+    mountNode,
+    multi,
+    noResultsMsg,
+    onBlur = _ => {},
+    onChange = _ => {},
+    onBlurResetsInput,
+    onCloseResetsInput,
+    onSelectResetsInput,
+    openOnClick,
+    options: denormalizedOptions,
+    overrides = {},
+    placeholder,
+    positive,
+    required,
+    searchable,
+    size,
+    startOpen,
+    type,
+    value,
+    valueKey,
+  } = props;
+
+  // anchor is a ref that refers to the outermost element rendered when the dropdown menu is not
+  // open. This is required so that we can check if clicks are on/off the anchor element.
+  const anchorRef = React.useRef();
+  // dropdown is a ref that refers to the popover element. This is required so that we can check if
+  // clicks are on/off the dropdown element.
+  const dropdownRef = React.useRef();
+  // used to focus the input element
+  const inputRef = React.useRef();
+  // focusAfterClear is a flag to indicate that the dropdowm menu should open after a selected
+  // option has been cleared.
+  const focusAfterClear = React.useRef();
+  // openAfterFocus is a flag to indicate that the dropdown menu should open when the component is
+  // focused. Developers have the option to disable initial clicks opening the dropdown menu. If not
+  // disabled, clicks will set this flag to true. Upon focusing, look to this to see if the menu should
+  // be opened, or only focus.
+  const openAfterFocus = React.useRef();
+  // id generated for the listbox. used by screenreaders to associate the input with the menu it controls
+  const listboxId = React.useMemo(() => getBuiId(), []);
+  // dragging is a flag to track whether a mobile device is currently scrolling versus clicking.
+  const dragging = React.useRef();
+  const isMounted = React.useRef(false);
+
+  const locale = React.useContext(LocaleContext);
+  const [activeDescendant, setActiveDescendant] = React.useState(null);
+  const [isOpen, setIsOpen] = React.useState(startOpen);
+  const [inputValue, setInputValue] = React.useState('');
+  const [isFocused, setIsFocused] = React.useState(false);
+  const [isPseudoFocused, setIsPseudoFocused] = React.useState(false);
+
+  React.useEffect(() => {
+    if (autoFocus) {
+      focusInputElement();
+    }
+    isMounted.current = true;
+  }, []);
+
+  const options = React.useMemo(() => {
+    return normalizeOptions(denormalizedOptions);
+  }, [denormalizedOptions]);
+
+  const valueArray = React.useMemo(() => {
+    if (value === null || value === undefined) {
+      return [];
+    }
+
+    if (!Array.isArray(value)) {
+      return [expandValue(value, denormalizedOptions, valueKey)];
+    }
+
+    return value.map(v => expandValue(v, denormalizedOptions, valueKey));
+  }, [value, denormalizedOptions, valueKey]);
+
+  const focusInputElement = React.useCallback(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [inputRef]);
+
+  const renderLabel = React.useCallback(
+    ({option}) => {
+      if (getValueLabel) {
+        return getValueLabel({option});
+      }
+      return option[labelKey];
+    },
+    [getValueLabel, labelKey],
+  );
+
+  const popValue = React.useCallback(() => {
+    const valueArray = [...value];
+    const valueLength = valueArray.length;
+    if (!valueLength || valueArray[valueLength - 1].clearableValue === false) {
+      return;
+    }
+
+    const option = valueArray.pop();
+    // onChange({value: valueArray, option, type: STATE_CHANGE_TYPE.remove});
+    return option;
+  }, [value]);
+
+  const backspaceValue = React.useCallback(() => {
+    const item = popValue();
+    if (!item) {
+      return;
+    }
+    const valueLength = value.length;
+    const labelForInput = renderLabel({option: item, index: valueLength - 1});
+    // label might not be a string, it might be a Node of another kind.
+    if (!backspaceClearsInputValue && typeof labelForInput === 'string') {
+      const remainingInput = labelForInput.slice(0, -1);
+      setInputValue(remainingInput);
+      setIsOpen(true);
+    }
+  }, [popValue, renderLabel, value]);
+
+  const clearValue = React.useCallback(
+    event => {
+      if (isClick(event) && !isLeftClick(event)) return;
+
+      if (value) {
+        const resetValue = value.filter(item => item.clearableValue === false);
+        // onChange({
+        //   value: resetValue,
+        //   option: null,
+        //   type: STATE_CHANGE_TYPE.clear,
+        // });
+      }
+
+      setInputValue('');
+      setIsOpen(false);
+
+      focusInputElement();
+      focusAfterClear.current = true;
+    },
+    [value, onChange, focusInputElement, focusAfterClear],
+  );
+
+  const closeMenu = React.useCallback(() => {
+    if (onCloseResetsInput) {
+      setInputValue('');
+    }
+    setIsOpen(false);
+    setIsPseudoFocused(isFocused && !multi);
+  }, [onCloseResetsInput, isFocused, multi]);
+
+  const getDropdownOptionLabel = React.useCallback(
+    ({option, optionState}) => {
+      if (getOptionLabel) {
+        // TODO: dropdown component needs generic parameter
+        return getOptionLabel({option, optionState});
+      }
+      if (option.isCreatable) {
+        return `${locale.select.create} “${option[labelKey]}”`;
+      }
+      return option[labelKey];
+    },
+    [locale, labelKey],
+  );
+
+  // Popover does not provide ability to forward refs through, and if we were to simply
+  // apply the ref to the Root component below it would be overwritten before the popover
+  // renders it. Using this strategy, we will get a ref to the popover, then reuse its
+  // anchorRef so we can check if clicks are on the select component or not.
+  const receivePopoverAnchorRef = React.useCallback(ref => {
+    if (ref) {
+      // $FlowFixMe - ref arg is mixed type
+      anchorRef.current = ref.anchorRef;
+    }
+  }, []);
+
+  const handleActiveDescendantChange = React.useCallback(id => {
+    if (id) {
+      setActiveDescendant(id);
+    } else {
+      setActiveDescendant(null);
+    }
+  }, []);
+
+  const handleBlur = React.useCallback(
+    event => {
+      if (event.relatedTarget) {
+        if (
+          containsNode(anchorRef.current, event.relatedTarget) ||
+          containsNode(dropdownRef.current, event.relatedTarget)
+        ) {
+          return;
+        }
+      } else if (containsNode(anchorRef.current, event.target)) {
+        return;
+      }
+
+      onBlur(event);
+
+      if (isMounted.current) {
+        if (onBlurResetsInput) {
+          setInputValue('');
+        }
+
+        setIsFocused(false);
+        setIsOpen(false);
+        setIsPseudoFocused(false);
+      }
+    },
+    [anchorRef, dropdownRef, isMounted, onBlurResetsInput],
+  );
+
+  const handleItemSelect = React.useCallback(
+    ({item}) => {
+      // if (item.disabled) {
+      //   return;
+      // }
+      // const nextInputValue = onSelectResetsInput ? '' : inputValue;
+      // if (multi) {
+      //   // TODO: handle multi selection
+      // } else {
+      //   focusInputElement();
+      //   setInputValue(nextInputValue);
+      //   setIsOpen(!closeOnSelect);
+      //   setIsFocused(true);
+      //   setIsPseudoFocused(false);
+      //   onChange({
+      //     value: [item],
+      //     option: item,
+      //     type: STATE_CHANGE_TYPE.select,
+      //   });
+      // }
+    },
+    [onSelectResetsInput, closeOnSelect, inputValue],
+  );
+
+  const handleKeyDown = React.useCallback(
+    event => {
+      if (this.props.disabled) {
+        return;
+      }
+
+      switch (event.keyCode) {
+        case 8: // backspace
+          if (!inputValue && backspaceRemoves) {
+            event.preventDefault();
+            backspaceValue();
+          }
+          break;
+        case 9: // tab
+          setIsPseudoFocused(false);
+          setIsFocused(false);
+          setIsOpen(false);
+          if (!onCloseResetsInput || !onBlurResetsInput) {
+            setInputValue('');
+          }
+          break;
+        case 27: // escape
+          if (!isOpen && clearable && escapeClearsValue) {
+            clearValue(event);
+            setIsFocused(false);
+            setIsPseudoFocused(false);
+          }
+          break;
+        case 32: // space
+          if (searchable) {
+            break;
+          }
+          event.preventDefault();
+          setIsOpen(true);
+          break;
+        case 38: // up
+          event.preventDefault();
+          setIsOpen(true);
+          break;
+        case 40: // down
+          event.preventDefault();
+          setIsOpen(true);
+          break;
+        case 33: // page up
+          event.preventDefault();
+          setIsOpen(true);
+          break;
+        case 34: // page down
+          event.preventDefault();
+          setIsOpen(true);
+          break;
+        case 35: // end key
+          if (event.shiftKey) {
+            break;
+          }
+          event.preventDefault();
+          setIsOpen(true);
+          break;
+        case 36: // home key
+          if (event.shiftKey) {
+            break;
+          }
+          event.preventDefault();
+          setIsOpen(true);
+          break;
+        case 46: // delete
+          if (!inputValue && deleteRemoves) {
+            event.preventDefault();
+            popValue();
+          }
+          break;
+      }
+    },
+    [backspaceRemoves, inputValue, popValue],
+  );
+
+  const handleClick = React.useCallback(
+    event => {
+      if (disabled || (!isClick(event) && !isLeftClick(event))) {
+        return;
+      }
+
+      // Case comes up when text has been typed into the input field. If no text provided,
+      // the 'input' element will have essentially 0 width therefore will not be clickable.
+      // When click outside does not reset input, text provided will stay rendered after clicks away
+      // from the select component. Upon subsequent clicks on the provided text, open the dropdown
+      // menu, in addition to text edit operations.
+      if (event.target === inputRef.current) {
+        if (!isFocused) {
+          openAfterFocus.current = Boolean(openOnClick);
+          focusInputElement();
+          return;
+        }
+
+        if (!isOpen) {
+          setIsOpen(true);
+          setIsPseudoFocused(true);
+          return;
+        }
+      }
+
+      // Ensures that interactive elements within the Select component do not trigger the outer click
+      // handler. For example, after an option is selected clicks on the 'clear' icon call here. We
+      // should ignore those events. This comes after case where click is on input element, so that
+      // those are handled on their own.
+      if (inputRef.current && isInteractive(event.target, inputRef.current)) {
+        return;
+      }
+
+      // For the simple case where clicking on the Select does not allow for providing
+      // text input to filter the dropdown options.
+      if (!searchable) {
+        focusInputElement();
+        setIsOpen(prev => !prev);
+        return;
+      }
+
+      // Cases below only apply to searchable Select component.
+      if (isFocused) {
+        // iOS ignores programmatic calls to input.focus() that were not triggered by a click event.
+        // This component can get into a state where isFocused is true, but the DOM node is not
+        // focused. Call focus here again to ensure.
+        focusInputElement();
+
+        // Case comes up when click outside does not reset input - once text has been provided to
+        // the input, and the user closes the dropdown menu the provided text is maintained. After
+        // this, if the user focuses back into the select component then clicks on the component,
+        // the provided text highlights rather than position's the cursor at the end of the input.
+        if (inputRef.current) {
+          inputRef.current.value = '';
+        }
+
+        setIsOpen(prev => focusAfterClear.current && !prev);
+        setIsPseudoFocused(false);
+
+        focusAfterClear.current = false;
+      } else {
+        // When clear button is clicked, need to click twice to open control container - https://github.com/uber/baseweb/issues/4285
+        // Setting focusAfterClear to false, resolves the issue
+        focusAfterClear.current = false;
+        openAfterFocus.current = Boolean(openOnClick);
+        focusInputElement();
+      }
+    },
+    [
+      disabled,
+      isFocused,
+      openOnClick,
+      focusInputElement,
+      setIsOpen,
+      setIsPseudoFocused,
+      inputRef,
+      focusAfterClear,
+      openAfterFocus,
+    ],
+  );
+
+  const handleTouchEnd = React.useCallback(
+    event => {
+      if (!dragging.current) {
+        handleClick(event);
+      }
+    },
+    [dragging, handleClick],
+  );
+
+  const handleTouchMove = React.useCallback(() => {
+    dragging.current = true;
+  }, [dragging]);
+
+  const handleTouchStart = React.useCallback(() => {
+    dragging.current = false;
+  }, [dragging]);
+
+  const [Root, rootProps] = getOverrides(overrides.Root, StyledRoot);
+  const [ControlContainer, controlContainerProps] = getOverrides(
+    overrides.ControlContainer,
+    StyledControlContainer,
+  );
+  const [ValueContainer, valueContainerProps] = getOverrides(
+    overrides.ValueContainer,
+    StyledValueContainer,
+  );
+  const [IconsContainer, iconsContainerProps] = getOverrides(
+    overrides.IconsContainer,
+    StyledIconsContainer,
+  );
+  const [PopoverOverride, popoverProps] = getOverrides(
+    overrides.Popover,
+    Popover,
+  );
+  const [Placeholder, placeholderProps] = getOverrides(
+    overrides.Placeholder,
+    StyledPlaceholder,
+  );
+
+  const sharedProps = {
+    $clearable: clearable,
+    $creatable: creatable,
+    $disabled: disabled,
+    $error: error,
+    $positive: positive,
+    $isFocused: isFocused,
+    $isLoading: isLoading,
+    $isOpen: isOpen,
+    $isPseudoFocused: isPseudoFocused,
+    $multi: multi,
+    $required: required,
+    $searchable: searchable,
+    $size: size,
+    $type: type,
+    $isEmpty: !valueArray.length,
+  };
+
+  return (
+    <PopoverOverride
+      ref={receivePopoverAnchorRef}
+      focusLock={false}
+      mountNode={mountNode}
+      onEsc={closeMenu}
+      isOpen={isOpen}
+      popoverMargin={0}
+      content={() => {
+        const dropdownProps = {
+          error,
+          positive,
+          getOptionLabel: getDropdownOptionLabel,
+          id: listboxId,
+          isLoading,
+          labelKey,
+          maxDropdownHeight,
+          multi,
+          noResultsMsg,
+          onActiveDescendantChange: handleActiveDescendantChange,
+          onItemSelect: handleItemSelect,
+          options,
+          overrides,
+          required,
+          searchable,
+          size,
+          type,
+          value: valueArray,
+          valueKey,
+          width: anchorRef.current ? anchorRef.current.clientWidth : null,
+          keyboardControlNode: anchorRef,
+        };
+
+        return <SelectDropdown innerRef={dropdownRef} {...dropdownProps} />;
+      }}
+      placement={PLACEMENT.bottom}
+      {...popoverProps}
+    >
+      <Root
+        onBlur={handleBlur}
+        data-baseweb="select"
+        {...sharedProps}
+        {...rootProps}
+      >
+        <ControlContainer
+          onKeyDown={handleKeyDown}
+          onClick={handleClick}
+          onTouchEnd={handleTouchEnd}
+          onTouchMove={handleTouchMove}
+          onTouchStart={handleTouchStart}
+          {...sharedProps}
+          {...controlContainerProps}
+        >
+          {/* {type === TYPE.search ? this.renderSearch() : null} */}
+          <ValueContainer {...sharedProps} {...valueContainerProps}>
+            {/* {this.renderValue(valueArray, isOpen, locale)}
+            {this.renderInput()}
+            {this.shouldShowPlaceholder() ? (
+              <Placeholder {...sharedProps} {...placeholderProps}>
+                {typeof placeholder !== 'undefined'
+                  ? placeholder
+                  : locale.select.placeholder}
+              </Placeholder>
+            ) : null} */}
+          </ValueContainer>
+          <IconsContainer {...sharedProps} {...iconsContainerProps}>
+            {/* {this.renderLoading()}
+            {this.renderClear()}
+            {type === TYPE.select ? this.renderArrow() : null} */}
+          </IconsContainer>
+        </ControlContainer>
+      </Root>
+    </PopoverOverride>
+  );
+}

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 import * as React from 'react';
-import SelectComponent from './select-component.js';
+import SelectComponent from './select-component-functional.js';
 import MultiValue from './multi-value.js';
 import SingleValue from './value.js';
 

--- a/src/select/types-next.js
+++ b/src/select/types-next.js
@@ -1,0 +1,207 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+import type {OverrideT} from '../helpers/overrides.js';
+import {STATE_CHANGE_TYPE, SIZE, TYPE} from './constants.js';
+
+export type OptionT<ProvidedOptionT> = {
+  ...ProvidedOptionT,
+  id?: string | number,
+  label?: React.Node,
+  disabled?: boolean,
+  clearableValue?: boolean,
+  isCreatable?: boolean,
+  __optgroup?: string,
+};
+
+export type ValueT<P> = Array<OptionT<P>>;
+export type OptgroupsT<P> = {__ungrouped: ValueT<P>, [string]: ValueT<P>};
+export type OptionsT<P> = ?ValueT<P> | OptgroupsT<P>;
+
+export type PropsT<P> = {
+  'aria-label'?: ?string,
+  'aria-describedby'?: ?string,
+  'aria-errormessage'?: ?string,
+  'aria-labelledby'?: ?string,
+  /** Defines if select element is focused on the first mount. */
+  autoFocus?: boolean,
+  /** Defines if options can be removed by pressing backspace. If you have customized labels, it will remove the option entirely, otherwise, it starts removing characters from the end of the string. */
+  backspaceRemoves?: boolean,
+  /** By default, backspace will only remove the last character of the input value. If true, the input value will be cleared. */
+  backspaceClearsInputValue?: boolean,
+  /** Defines if the select value can be cleared. If true a clear icon is rendered when a value is set. */
+  clearable?: boolean,
+  /** Defines if the menu closes after a selection if made. */
+  closeOnSelect?: boolean,
+  /** Defines if new options can be created along with choosing existing options. */
+  creatable?: boolean,
+  /** Defines if options can be removed by pressing backspace. */
+  deleteRemoves?: boolean,
+  /** Defines if the control is disabled. */
+  disabled?: boolean,
+  /** Defines if the control is in error state. */
+  error?: boolean,
+  /** Defines if the control is in positive state. */
+  positive?: boolean,
+  /** Defines if the value is cleared when escape is pressed and the dropdown is closed. */
+  escapeClearsValue?: boolean,
+  /** Defaults to filterOptions that excludes selected options for
+   * multi select. A custom method to filter options to be displayed in the dropdown. */
+  filterOptions?: ?(
+    options: ValueT<P>,
+    filterValue: string,
+    excludeOptions: ?ValueT<P>,
+    {valueKey: string, labelKey: string},
+  ) => ValueT<P>,
+  /** Defines if currently selected options are filtered out in the dropdown options. */
+  filterOutSelected?: boolean,
+  /** A custom method to get a display value for a dropdown option. */
+  getOptionLabel?: ?({
+    option: OptionT<P>,
+    optionState: {
+      $selected: boolean,
+      $disabled: boolean,
+      $isHighlighted: boolean,
+    },
+  }) => React.Node,
+  /** A custom method to get a display value for a selected option. */
+  getValueLabel?: ?({option: OptionT<P>}) => React.Node,
+  /** Sets the id attribute of the internal input element. Allows for usage with labels. */
+  id?: string,
+  /** Defines if the comparison for a new creatable value should be case-insensitive. */
+  ignoreCase?: boolean,
+  /** A ref to access the input element powering the select if it's a search select, or the container div if it isn't. */
+  controlRef?: React.ElementRef<*>,
+  /** Defines if the select is in a loading (async) state. */
+  isLoading?: boolean,
+  /** Defines an option key for a default label value. */
+  labelKey: string,
+  /** Sets max height of the dropdown list. */
+  maxDropdownHeight?: string,
+  /** Defines if multiple options can be selected. */
+  multi?: boolean,
+  /** Message to be displayed if no options is found for a search query. */
+  noResultsMsg?: React.Node,
+  onBlur?: (e: Event) => mixed,
+  /** Defines if the input value is reset to an empty string when a blur event happens on the select. */
+  onBlurResetsInput?: boolean,
+  /** change handler of the select to be called when a value is changed. */
+  onChange?: (params: {
+    value: ValueT<P>,
+    option: ?OptionT<P>,
+    type: $Keys<typeof STATE_CHANGE_TYPE>,
+  }) => mixed,
+  onFocus?: (e: SyntheticEvent<HTMLElement>) => mixed,
+  onInputChange?: (e: SyntheticInputEvent<HTMLInputElement>) => mixed,
+  /** Defines if the input value is reset to an empty string when dropdown is closed. */
+  onCloseResetsInput?: boolean,
+  /** Defines if the input value is reset to an empty string when a selection is made. */
+  onSelectResetsInput?: boolean,
+  /** A function that is called when the dropdown opens. */
+  onOpen?: () => mixed,
+  /** A function that is called when the dropdown closes. */
+  onClose?: () => mixed,
+  /** Defines if the dropdown opens on a click event on the select. */
+  openOnClick?: boolean,
+  /** If true, opens the dropdown when the select mounts. */
+  startOpen?: boolean,
+  /** Options to be displayed in the dropdown. If an option has a
+   * disabled prop value set to true it will be rendered as a disabled option in the dropdown. */
+  options: OptionsT<P>,
+  overrides?: {
+    Root?: OverrideT,
+    ControlContainer?: OverrideT,
+    Placeholder?: OverrideT,
+    ValueContainer?: OverrideT,
+    SingleValue?: OverrideT,
+    MultiValue?: OverrideT,
+    Tag?: OverrideT,
+    InputContainer?: OverrideT,
+    Input?: OverrideT,
+    IconsContainer?: OverrideT,
+    SelectArrow?: OverrideT,
+    ClearIcon?: OverrideT,
+    LoadingIndicator?: OverrideT,
+    SearchIconContainer?: OverrideT,
+    SearchIcon?: OverrideT,
+    Popover?: OverrideT,
+    DropdownContainer?: OverrideT,
+    Dropdown?: OverrideT,
+    DropdownOption?: OverrideT,
+    DropdownListItem?: OverrideT,
+    OptionContent?: OverrideT,
+    StatefulMenu?: OverrideT,
+  },
+  /** Sets the placeholder. */
+  placeholder?: React.Node,
+  /** Defines if the select field is required to have a selection. */
+  required?: boolean,
+  /** Defines if the search functionality is enabled. */
+  searchable?: boolean,
+  /** Defines the size (scale) of dropdown menu items. See the Menu component API. */
+  size?: $Keys<typeof SIZE>,
+  /** Defines type of the component to be in select or search mode.
+   * When set to TYPE.search the search icon is rendered on the
+   * left and the select arrow icon is not rendered. */
+  type?: $Keys<typeof TYPE>,
+  /** A current selected value(s). If a selected value has a clearableValue
+   * prop set to true it will be rendered as a disabled selected option that can't be cleared. */
+  value: ValueT<P>,
+  // eslint-disable-next-line flowtype/no-weak-types
+  valueComponent?: React.ComponentType<any>,
+  /** Defines a key name for an option's unique identifier value.
+   * The value of the `valueKey` prop is used to identify what options are selected
+   * or removed from the selection, it also used for default filtering out the
+   * selected options from the dropdown list. */
+  valueKey: string,
+  /** Where to mount the popover */
+  mountNode?: HTMLElement,
+};
+
+export type DropdownPropsT<P> = {
+  error: boolean,
+  getOptionLabel: ({
+    option: OptionT<P>,
+    optionState: {
+      $selected: boolean,
+      $disabled: boolean,
+      $isHighlighted: boolean,
+    },
+  }) => React.Node,
+  id?: string,
+  innerRef: React.ElementRef<*>,
+  isLoading: boolean,
+  labelKey: string,
+  maxDropdownHeight: string,
+  multi: boolean,
+  noResultsMsg?: React.Node,
+  onActiveDescendantChange?: (id?: string) => mixed,
+  onItemSelect: ({
+    item: OptionT<P>,
+    event?: SyntheticEvent<HTMLElement> | KeyboardEvent,
+  }) => mixed,
+  options: ValueT<P>,
+  overrides?: {
+    DropdownContainer?: OverrideT,
+    Dropdown?: OverrideT,
+    // Not a styled component
+    DropdownOption?: OverrideT,
+    DropdownListItem?: OverrideT,
+    OptionContent?: OverrideT,
+    StatefulMenu?: OverrideT,
+  },
+  required: boolean,
+  searchable: boolean,
+  size: $Keys<typeof SIZE>,
+  type: $Keys<typeof TYPE>,
+  value: ValueT<P>,
+  valueKey: string,
+  width: ?number,
+  keyboardControlNode?: React.ElementRef<*>,
+};

--- a/src/select/utils/index.js
+++ b/src/select/utils/index.js
@@ -5,49 +5,43 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import type {PropsT, OptionT, OptionsT, OptgroupsT, ValueT} from '../types.js';
+import type {PropsT, OptionT, OptionsT, ValueT} from '../types-next.js';
 
-function groupedOptionsToArray(groupedOptions: OptgroupsT): ValueT {
-  return Object.keys(groupedOptions).reduce((arr, optgroup) => {
-    const optgroupOptions = groupedOptions[optgroup];
-    return arr.concat(
-      optgroupOptions.map(option => {
-        return {
-          ...option,
-          __optgroup: optgroup,
-        };
-      }),
-    );
-  }, []);
-}
-
-export function normalizeOptions(options: OptionsT): ValueT {
+export function normalizeOptions<P>(options: OptionsT<P>): ValueT<P> {
   if (options) {
     if (Array.isArray(options)) {
       return options;
     } else {
-      return groupedOptionsToArray(options);
+      return Object.keys(options).reduce((arr, optgroup) => {
+        const optgroupOptions = options[optgroup];
+        return arr.concat(
+          optgroupOptions.map(option => {
+            return {
+              ...option,
+              __optgroup: optgroup,
+            };
+          }),
+        );
+      }, []);
     }
   }
-
   return [];
 }
 
-export const expandValue = (
-  // eslint-disable-next-line flowtype/no-weak-types
-  value: OptionT,
-  props: $Shape<PropsT>,
-): OptionT => {
-  if (!props.options) return value;
+export function expandValue<P>(
+  value: OptionT<P>,
+  options: OptionsT<P>,
+  valueKey: string,
+): OptionT<P> {
+  if (!options) {
+    return value;
+  }
 
-  const normalizedOptions = normalizeOptions(props.options);
+  const normalizedOptions = normalizeOptions(options);
   for (let i = 0; i < normalizedOptions.length; i++) {
-    if (
-      String(normalizedOptions[i][props.valueKey]) ===
-      String(value[props.valueKey])
-    ) {
+    if (String(normalizedOptions[i][valueKey]) === String(value[valueKey])) {
       return normalizedOptions[i];
     }
   }
   return value;
-};
+}


### PR DESCRIPTION
https://github.com/uber/baseweb/issues/3818

`val` in [this example](https://flow.org/try/#0PTAEAEDMBsHsHcBQiAuBPADgU1AQQDwDmAfKALygDeiotoAdI4QDQ12SywBcoAzigCcAlgDsWiAL4BuZJACuIgMYohsEaEWwAthjVYRKIsQAUGAbAy8elNQGEAFgEMxWHsYIkAlOVJahADywAE2ZQCxU1KzwjAG0AXQlvSglkdGxQAHlyKjZaPR5+YTFWOlAUeG5QETktACMsAVZpRE0RfjCMCLaeDPjsmNyqfNAAcgBGEdDyyoAmCVY4mU0dPQNjalK7Jxc3ADdHaG8yUg3SulbeWGgsejhCY33oej1PGTPzyKubu4eD+hR7AIsFhXoN5oNwqo2k1PEA) resolves to `A<empty>` 