### PR TITLE
fix(datepicker): allow empty placeholder

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -407,8 +407,11 @@ export default class Datepicker<T = Date> extends React.Component<
     );
 
     const placeholder =
-      this.props.placeholder ||
-      (this.props.range ? 'YYYY/MM/DD – YYYY/MM/DD' : 'YYYY/MM/DD');
+      this.props.placeholder || this.props.placeholder === ''
+        ? this.props.placeholder
+        : this.props.range
+        ? 'YYYY/MM/DD – YYYY/MM/DD'
+        : 'YYYY/MM/DD';
 
     return (
       <LocaleContext.Consumer>


### PR DESCRIPTION
#### Description

This PR implements the ability to use an empty string as a placeholder in the datepicker. 

#### Scope
Patch: Bug Fix