### PR TITLE
docs(select): update example to render correctly

### DIFF
--- a/documentation-site/examples/select/with-many-options.tsx
+++ b/documentation-site/examples/select/with-many-options.tsx
@@ -64,7 +64,7 @@ const VirtualDropdown = React.forwardRef((props: any, ref) => {
   );
 
   return (
-    <StyledList $style={{height: height + 'px'}} ref={ref}>
+    <StyledList ref={ref}>
       <FixedSizeList
         width="100%"
         height={height}


### PR DESCRIPTION
Fixes #3991

Padding on the StyledList isn't accounted for with the react-window example, causing a small scroll effect on the containing element. Removing the style prop from the list fixes the issue. 

#### Scope
Doc update
