### PR TITLE
Fix startEnhancer & endEnhancer zero render

### DIFF
--- a/src/input/input.js
+++ b/src/input/input.js
@@ -93,7 +93,7 @@ class Input extends React.Component<InputPropsT, InternalStateT> {
         $adjoined={getAdjoinedProp(startEnhancer, endEnhancer)}
         $hasIconTrailing={this.props.clearable || this.props.type == 'password'}
       >
-        {startEnhancer && (
+        {isEnhancer(startEnhancer) && (
           <StartEnhancer
             {...sharedProps}
             {...startEnhancerProps}
@@ -111,7 +111,7 @@ class Input extends React.Component<InputPropsT, InternalStateT> {
           onFocus={this.onFocus}
           onBlur={this.onBlur}
         />
-        {endEnhancer && (
+        {isEnhancer(endEnhancer) && (
           <EndEnhancer
             {...sharedProps}
             {...endEnhancerProps}
@@ -128,14 +128,18 @@ class Input extends React.Component<InputPropsT, InternalStateT> {
 }
 
 function getAdjoinedProp(startEnhancer, endEnhancer): AdjoinedT {
-  if (startEnhancer && endEnhancer) {
+  if (isEnhancer(startEnhancer) && isEnhancer(endEnhancer)) {
     return ADJOINED.both;
-  } else if (startEnhancer) {
+  } else if (isEnhancer(startEnhancer)) {
     return ADJOINED.left;
-  } else if (endEnhancer) {
+  } else if (isEnhancer(endEnhancer)) {
     return ADJOINED.right;
   }
   return ADJOINED.none;
+}
+
+function isEnhancer(enhancer): Boolean {
+  return enhancer || enhancer === 0;
 }
 
 export default Input;

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -138,8 +138,8 @@ function getAdjoinedProp(startEnhancer, endEnhancer): AdjoinedT {
   return ADJOINED.none;
 }
 
-function isEnhancer(enhancer): Boolean {
-  return enhancer || enhancer === 0;
+function isEnhancer(enhancer): boolean {
+  return Boolean(enhancer || enhancer === 0);
 }
 
 export default Input;

--- a/src/list/list-item.js
+++ b/src/list/list-item.js
@@ -81,7 +81,7 @@ const ListItem = React.forwardRef<PropsT, HTMLLIElement>(
         )}
         <Content $mLeft={!Artwork} $sublist={!!props.sublist} {...contentProps}>
           {props.children}
-          {EndEnhancer && (
+          {Boolean(EndEnhancer) && (
             <EndEnhancerContainer {...endEnhancerContainerProps}>
               <EndEnhancer />
             </EndEnhancerContainer>

--- a/src/list/list-item.js
+++ b/src/list/list-item.js
@@ -81,7 +81,7 @@ const ListItem = React.forwardRef<PropsT, HTMLLIElement>(
         )}
         <Content $mLeft={!Artwork} $sublist={!!props.sublist} {...contentProps}>
           {props.children}
-          {Boolean(EndEnhancer) && (
+          {EndEnhancer && EndEnhancer !== 0 && (
             <EndEnhancerContainer {...endEnhancerContainerProps}>
               <EndEnhancer />
             </EndEnhancerContainer>

--- a/src/tag/tag.js
+++ b/src/tag/tag.js
@@ -146,7 +146,7 @@ const Tag = React.forwardRef<PropsT, HTMLSpanElement>((props, ref) => {
       onFocus={forkFocus(rootProps, handleFocus)}
       onBlur={forkBlur(rootProps, handleBlur)}
     >
-      {StartEnhancer && (
+      {Boolean(StartEnhancer) && (
         <StartEnhancerContainer {...startEnhancerContainerProps}>
           <StartEnhancer />
         </StartEnhancerContainer>

--- a/src/tag/tag.js
+++ b/src/tag/tag.js
@@ -146,7 +146,7 @@ const Tag = React.forwardRef<PropsT, HTMLSpanElement>((props, ref) => {
       onFocus={forkFocus(rootProps, handleFocus)}
       onBlur={forkBlur(rootProps, handleBlur)}
     >
-      {Boolean(StartEnhancer) && (
+      {StartEnhancer && StartEnhancer !== 0 && (
         <StartEnhancerContainer {...startEnhancerContainerProps}>
           <StartEnhancer />
         </StartEnhancerContainer>


### PR DESCRIPTION
#### Description
Since React renders everything with the type of number, there is an unexpected behavior when passing `0` into `startEnhancer` or `endEnhancer`. 
The issue leads to zero number being showed as an unstyled element in the following components: `Input`, `Tag` and `ListItem`. 

Consider the screenshots: 
<img src="https://user-images.githubusercontent.com/4865430/129708573-37b830e0-09f8-4c3e-bafb-cf4f425854b9.png" width="500"/>
<img src="https://user-images.githubusercontent.com/4865430/129708639-de4e9d4a-885a-4842-9691-01677699fd13.png" width="500"/>
<img src="https://user-images.githubusercontent.com/4865430/129708729-0f8bbb18-693b-43fb-9851-10701547fedb.png" width="500"/>
---
The fix for Tag and ListItem would be to do an explicit check. 
However, for the Input enhancers, since it supports React.Nodes, the logic can be extended to show zero number as correct enhancer: 

**After fix:** 
<img src="https://user-images.githubusercontent.com/4865430/129709534-2c50a921-81c7-49bf-bd58-1cf881c0854a.png" width="500"/>

#### Scope
Patch: Bug Fix