### PR TITLE
fix(datepicker): add prop to always render 6 rows in datepicker (#4465)

### DIFF
--- a/documentation-site/components/yard/config/datepicker.ts
+++ b/documentation-site/components/yard/config/datepicker.ts
@@ -257,6 +257,13 @@ const DatepickerConfig: TConfig = {
         'Defines if dates outside of the range of the current month are displayed.',
       hidden: true,
     },
+    fixedHeight: {
+      value: undefined,
+      type: PropTypes.Boolean,
+      description:
+        'Defines if 6 rows should always be displayed for all the months.',
+      hidden: true,
+    },
     timeSelectStart: {
       value: undefined,
       type: PropTypes.Boolean,

--- a/src/datepicker/calendar.js
+++ b/src/datepicker/calendar.js
@@ -466,6 +466,7 @@ export default class Calendar<T = Date> extends React.Component<
             overrides={overrides}
             value={this.props.value}
             peekNextMonth={this.props.peekNextMonth}
+            fixedHeight={this.props.fixedHeight}
           />
         </CalendarContainer>,
       );

--- a/src/datepicker/index.d.ts
+++ b/src/datepicker/index.d.ts
@@ -77,6 +77,7 @@ export interface CalendarProps {
   timeSelectEnd?: boolean;
   trapTabbing?: boolean;
   value?: Date | Date[] | null;
+  fixedHeight?: boolean;
 }
 export interface CalendarState {
   highlightedDate: Date;

--- a/src/datepicker/month.js
+++ b/src/datepicker/month.js
@@ -34,6 +34,8 @@ const defaultProps = {
   value: null,
 };
 
+const CALENDAR_MAX_ROWS = 6;
+
 export default class CalendarMonth<T = Date> extends React.Component<
   MonthPropsT<T>,
 > {
@@ -68,7 +70,12 @@ export default class CalendarMonth<T = Date> extends React.Component<
     let i = 0;
     let isWithinMonth = true;
 
-    while (isWithinMonth) {
+    while (
+      isWithinMonth ||
+      (this.props.fixedHeight &&
+        this.props.peekNextMonth &&
+        i < CALENDAR_MAX_ROWS)
+    ) {
       weeks.push(
         <Week
           adapter={this.props.adapter}

--- a/src/datepicker/types.js
+++ b/src/datepicker/types.js
@@ -116,7 +116,9 @@ export type WeekPropsT<T = Date> = {
   value: ?T | Array<T>,
 };
 
-export type MonthPropsT<T = Date> = WeekPropsT<T>;
+export type MonthPropsT<T = Date> = WeekPropsT<T> & {
+  fixedHeight?: boolean,
+};
 
 export type CalendarInternalState<T = Date> = {
   highlightedDate: T,
@@ -186,6 +188,7 @@ export type CalendarPropsT<T = Date> = {
   trapTabbing?: boolean,
   /** Currently selected date. */
   value?: ?T | Array<T>,
+  fixedHeight?: boolean,
 };
 
 export type HeaderPropsT<T = Date> = CalendarPropsT<T> & {


### PR DESCRIPTION
Fixes #4465 

#### Description
Added prop named `fixedHeight` in datepicker to always render 6 rows in calendar

#### Scope
Minor: New Feature
