### PR TITLE
Remove duplicate import from Snackbar types

### DIFF
--- a/src/snackbar/index.d.ts
+++ b/src/snackbar/index.d.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import {Override} from '../overrides';
 import {DURATION, PLACEMENT} from './constants.js';
-export {DURATION, PLACEMENT} from './constants.js';
 
 export type DurationT =
   | typeof DURATION.infinite


### PR DESCRIPTION
#### Description

The removed import seems to be duplicate of the above one

#### Scope
<!-- Pick one:
Patch: Bug Fix
-->
