### PR TITLE
fix(slider): update handle color and size

### DIFF
--- a/src/slider/styled-components.js
+++ b/src/slider/styled-components.js
@@ -103,7 +103,7 @@ export const TickBar = styled<StylePropsT>('div', props => {
 TickBar.displayName = 'StyledTickBar';
 
 export const Thumb = styled<StylePropsT>('div', props => {
-  const {$theme, $value = [], $thumbIndex, $disabled} = props;
+  const {$theme, $value = [], $thumbIndex, $disabled, $isDragged} = props;
   let isLeft = $value.length === 2 && $thumbIndex === 0;
   let isRight = $value.length === 2 && $thumbIndex === 1;
 
@@ -113,8 +113,8 @@ export const Thumb = styled<StylePropsT>('div', props => {
   }
 
   return {
-    height: '24px',
-    width: '24px',
+    height: '28px',
+    width: '28px',
     borderTopLeftRadius: '24px',
     borderTopRightRadius: '24px',
     borderBottomLeftRadius: '24px',
@@ -124,11 +124,13 @@ export const Thumb = styled<StylePropsT>('div', props => {
     alignItems: 'center',
     backgroundColor: $disabled
       ? $theme.colors.sliderHandleFillDisabled
+      : $isDragged
+      ? $theme.colors.sliderHandleFillActive
       : $theme.colors.sliderHandleFill,
     outline: 'none',
     boxShadow: props.$isFocusVisible
       ? `0 0 0 3px ${$theme.colors.accent}`
-      : '0 1px 4px rgba(0, 0, 0, 0.12)',
+      : '0px 3px 8px rgba(0, 0, 0, 0.15), 0px 1px 1px rgba(0, 0, 0, 0.16), 0px 3px 1px rgba(0, 0, 0, 0.1)',
     cursor: $disabled ? 'not-allowed' : 'inherit',
   };
 });

--- a/src/themes/light-theme/color-component-tokens.js
+++ b/src/themes/light-theme/color-component-tokens.js
@@ -152,7 +152,7 @@ export default (
 
   // Slider/Toggle
   sliderTrackFill: 'transparent',
-  sliderHandleFill: themePrimitives.primaryA,
+  sliderHandleFill: themePrimitives.white,
   sliderHandleFillDisabled: themePrimitives.primary400,
   sliderHandleInnerFill: themePrimitives.primaryA,
 
@@ -163,7 +163,7 @@ export default (
   sliderTrackFillSelectedActive: themePrimitives.primary500,
   sliderTrackFillDisabled: themePrimitives.mono300,
   sliderHandleFillHover: themePrimitives.white,
-  sliderHandleFillActive: themePrimitives.white,
+  sliderHandleFillActive: themePrimitives.primaryA,
   sliderHandleFillSelected: themePrimitives.white,
   sliderHandleFillSelectedHover: themePrimitives.white,
   sliderHandleFillSelectedActive: themePrimitives.white,


### PR DESCRIPTION
#### Description

Update the slider so that it is up to spec:
- increase size of thumb/handle from 24px to 28px
- thumb should be white when enabled but not active
- thumb should be dark (theme.primaryA) when active/pressed

#### Scope
Patch: Bug Fix
