### PR TITLE
fix(button-group): add example for responsive styling

### DIFF
--- a/documentation-site/examples/button-group/wrappable.js
+++ b/documentation-site/examples/button-group/wrappable.js
@@ -1,0 +1,20 @@
+// @flow
+import * as React from 'react';
+import {Button} from 'baseui/button';
+import {ButtonGroup} from 'baseui/button-group';
+
+export default function Example() {
+  return (
+    <ButtonGroup
+      overrides={{
+        Root: {
+          style: {flexWrap: 'wrap'},
+        },
+      }}
+    >
+      <Button>Label</Button>
+      <Button>Label</Button>
+      <Button>Label</Button>
+    </ButtonGroup>
+  );
+}

--- a/documentation-site/examples/button-group/wrappable.tsx
+++ b/documentation-site/examples/button-group/wrappable.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import {Button} from 'baseui/button';
+import {ButtonGroup} from 'baseui/button-group';
+
+export default function Example() {
+  return (
+    <ButtonGroup
+      overrides={{
+        Root: {
+          style: {flexWrap: 'wrap'},
+        },
+      }}
+    >
+      <Button>Label</Button>
+      <Button>Label</Button>
+      <Button>Label</Button>
+    </ButtonGroup>
+  );
+}

--- a/documentation-site/pages/components/button-group.mdx
+++ b/documentation-site/pages/components/button-group.mdx
@@ -20,6 +20,7 @@ import DisabledButton from 'examples/button-group/disabled-button.js';
 import Dropdown from 'examples/button-group/dropdown.js';
 import StatefulRadio from 'examples/button-group/stateful-radio.js';
 import StatefulCheckbox from 'examples/button-group/stateful-checkbox.js';
+import Wrappable from 'examples/button-group/wrappable.js';
 
 import {Button} from 'baseui/button';
 import {ButtonGroup} from 'baseui/button-group';
@@ -86,6 +87,12 @@ You can disable the entire button group as in the example above. Or you can disa
 <Example title="With a dropdown" path="button-group/dropdown.js">
   <Dropdown />
 </Example>
+
+<Example title="Wrappable button group" path="button-group/wrappable.js">
+  <Wrappable />
+</Example>
+
+You can add the override `flex-wrap: wrap` to button group so as to make it wrap on smaller screens as in the example above.
 
 <Example
   title="Stateful (uncontrolled) with radio mode"


### PR DESCRIPTION
Fixes #3448

#### Description
Added an example using flex-wrap property to button-group so that the buttons can wrap on small screens

#### Scope
Minor: Docs
