### PR TITLE
fix(textarea): add vertical resizing

### DIFF
--- a/documentation-site/components/yard/config/textarea.ts
+++ b/documentation-site/components/yard/config/textarea.ts
@@ -27,6 +27,11 @@ const TextareaConfig: TConfig = {
       'inputMode',
       'autoComplete',
     ]),
+    resize: {
+      value: false,
+      type: PropTypes.Boolean,
+      description: 'If true, adds vertical resizability to textarea component.',
+    },
     overrides: {
       value: undefined,
       type: PropTypes.Custom,

--- a/src/input/base-input.js
+++ b/src/input/base-input.js
@@ -365,6 +365,11 @@ class BaseInput<T: EventTarget> extends React.Component<
               ? this.props.rows
               : null
           }
+          $resize={
+            this.props.type === CUSTOM_INPUT_TYPE.textarea
+              ? this.props.resize
+              : null
+          }
           {...sharedProps}
           {...inputProps}
         >

--- a/src/input/index.d.ts
+++ b/src/input/index.d.ts
@@ -67,6 +67,7 @@ export interface BaseInputProps<T> {
   type?: string;
   value?: string | number;
   rows?: number;
+  resize?: boolean;
   min?: number;
   max?: number;
   step?: number;

--- a/src/input/types.js
+++ b/src/input/types.js
@@ -142,7 +142,10 @@ export type BaseInputPropsT<T> = {|
   type?: string,
   /** Input value attribute. */
   value?: string | number,
+  /** Textarea rows attribute */
   rows?: number,
+  /** vertical resizing in textarea */
+  resize?: boolean,
   /** min value when used as input type=number */
   min?: number,
   /** max value when used as input type=number */

--- a/src/textarea/index.d.ts
+++ b/src/textarea/index.d.ts
@@ -10,6 +10,7 @@ import {
 
 export interface TextareaProps extends BaseInputProps<HTMLTextAreaElement> {
   rows?: number;
+  resize?: boolean;
   maxLength?: number;
 }
 

--- a/src/textarea/styled-components.js
+++ b/src/textarea/styled-components.js
@@ -29,5 +29,5 @@ export const StyledTextareaContainer = styled<SharedStylePropsT>(
 // $FlowFixMe https://github.com/facebook/flow/issues/7745
 export const StyledTextarea = styled<SharedStylePropsT>('textarea', props => ({
   ...getInputStyles(props),
-  resize: 'none',
+  resize: props.$resize ? 'vertical' : 'none',
 }));

--- a/src/textarea/textarea.js
+++ b/src/textarea/textarea.js
@@ -31,6 +31,7 @@ class Textarea extends React.Component<TextareaPropsT, {isFocused: boolean}> {
     placeholder: '',
     required: false,
     rows: 3,
+    resize: false,
     size: SIZE.default,
   };
 

--- a/src/textarea/types.js
+++ b/src/textarea/types.js
@@ -38,6 +38,7 @@ export type TextareaPropsT = {
   /** Sets the size and number of visible text lines
    of the textarea element. */
   rows?: number,
+  resize?: boolean,
   maxLength?: number,
 };
 


### PR DESCRIPTION
Fixes #4054  <!-- remove the (`) quotes to link the issues -->

#### Description
Changed `resize: none` to 'resize: vertical` so as to enable auto-sizing in textarea component

#### Scope
Patch: Bug Fix
