### PR TITLE
fix(textarea): remove "value" in defaultProps

### DIFF
--- a/src/textarea/textarea.js
+++ b/src/textarea/textarea.js
@@ -32,7 +32,6 @@ class Textarea extends React.Component<TextareaPropsT, {isFocused: boolean}> {
     required: false,
     rows: 3,
     size: SIZE.default,
-    value: '',
   };
 
   state = {


### PR DESCRIPTION
#### Description

<!-- Describe your changes below in as much detail as possible -->

Remove `value: ''` in `defaultProps` for uncontrolled `<Textarea />`.

##### current `<Textarea />`

![2021-09-13 14-46-33 2021-09-13 14_46_59](https://user-images.githubusercontent.com/42956032/133039932-deb08578-0d4d-4e94-8cac-4d37274a6dbe.gif)


##### pr `<Textarea />`

![2021-09-13 14-47-23 2021-09-13 14_47_54](https://user-images.githubusercontent.com/42956032/133039975-8fde89de-2f62-47b0-98a6-1efcf872525c.gif)


#### Scope

Patch: Bug Fix
