### PR TITLE
fix(list): forward overrides on MenuAdapter

### DIFF
--- a/src/list/menu-adapter.js
+++ b/src/list/menu-adapter.js
@@ -10,6 +10,7 @@ import * as React from 'react';
 
 import ListItem from './list-item.js';
 import type {MenuAdapterPropsT} from './types.js';
+import {mergeOverrides} from '../helpers/overrides.js';
 
 const MenuAdapter = React.forwardRef<MenuAdapterPropsT, HTMLLIElement>(
   (props, ref) => {
@@ -20,17 +21,26 @@ const MenuAdapter = React.forwardRef<MenuAdapterPropsT, HTMLLIElement>(
         artwork={props.artwork}
         artworkSize={props.artworkSize}
         endEnhancer={props.endEnhancer}
-        overrides={{
-          Root: {
-            props: {onMouseEnter: props.onMouseEnter, onClick: props.onClick},
-            style: ({$theme}) => ({
-              backgroundColor: props.$isHighlighted
-                ? $theme.colors.menuFillHover
-                : null,
-              cursor: props.$disabled ? 'not-allowed' : 'pointer',
-            }),
-          },
-        }}
+        overrides={
+          // $FlowFixMe
+          mergeOverrides(
+            {
+              Root: {
+                props: {
+                  onMouseEnter: props.onMouseEnter,
+                  onClick: props.onClick,
+                },
+                style: ({$theme}) => ({
+                  backgroundColor: props.$isHighlighted
+                    ? $theme.colors.menuFillHover
+                    : null,
+                  cursor: props.$disabled ? 'not-allowed' : 'pointer',
+                }),
+              },
+            },
+            props.overrides,
+          )
+        }
       >
         {props.children}
       </ListItem>


### PR DESCRIPTION
Fixes #3986  <!-- remove the (`) quotes to link the issues -->

#### Description
Used mergeOverrides to merge the default and passed override
<!-- Describe your changes below in as much detail as possible -->

#### Scope
Patch: Bug Fix

#### Note
I was getting an error from Flow saying
```
Cannot create `ListItem` element because inexact  `OverridesT` [1] is incompatible with exact  `OverridesT` [2] in property `overrides`
```
So I've disabled flow, please look into it and let me know if I'm missing something.
