### PR TITLE
Release v10.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baseui",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "description": "A React Component library implementing the Base design language",
   "keywords": [
     "react",


### PR DESCRIPTION
fixes release from https://github.com/uber/baseweb/pull/4518 (we probably should update the release scripts to handle no 'v' prefix)