### PR TITLE
fix(select): trim value in filter options(uber#4531)

### DIFF
--- a/src/select/select-component.js
+++ b/src/select/select-component.js
@@ -867,7 +867,7 @@ class Select extends React.Component<PropsT, SelectStateT> {
   }
 
   filterOptions(excludeOptions: ?ValueT) {
-    const filterValue = this.state.inputValue;
+    const filterValue = this.state.inputValue.trim();
     // apply filter function
     if (this.props.filterOptions) {
       this.options = this.props.filterOptions(


### PR DESCRIPTION
Fixes #4531

#### Description

Trim the internal state inputValue while filtering options in order to prevent leading and trailing spaces to be rendered as a creatable option.

<img width="581" alt="Screenshot 2021-09-17 at 12 02 31 PM" src="https://user-images.githubusercontent.com/38891571/133735532-38c8526d-b117-4edb-b57d-126c3fe996a8.png">
 

#### Scope
Patch: Bug Fix