### PR TITLE
fix(table-semantic): add size prop to TableBuilderProps type definition

### DIFF
--- a/src/table-semantic/index.d.ts
+++ b/src/table-semantic/index.d.ts
@@ -57,6 +57,7 @@ export interface TableBuilderProps<RowT> {
   isLoading?: boolean;
   loadingMessage?: React.ReactNode | (() => React.ReactNode);
   emptyMessage?: React.ReactNode | (() => React.ReactNode);
+  size?: SIZE[keyof SIZE];
 }
 export class TableBuilder<RowT> extends React.Component<
   TableBuilderProps<RowT>


### PR DESCRIPTION
#### Description

Adds a missing TypeScript type definition for the `size` property of `TableBuilderProps`. The Flow type definition for `TableBuilderProps` already includes `size`, so this PR simply ensures the TypeScript definition matches.

#### Scope

Patch: Bug Fix
