### PR TITLE
fix(datepicker): add calendarDayBackgroundSelected to Colors interface

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -51,6 +51,7 @@ export function styled<
     P
 >;
 
+export {Theme} from 'baseui/theme';
 export const LightTheme: Theme;
 export const LightThemeMove: Theme;
 export const lightThemePrimitives: ThemePrimitives;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -285,6 +285,7 @@ export interface Colors {
   calendarDayForegroundPseudoSelected: string;
   calendarDayBackgroundPseudoSelectedHighlighted: string;
   calendarDayForegroundPseudoSelectedHighlighted: string;
+  calendarDayBackgroundSelected: string;
   calendarDayForegroundSelected: string;
   calendarDayBackgroundSelectedHighlighted: string;
   calendarDayForegroundSelectedHighlighted: string;


### PR DESCRIPTION
Fixes #4511

#### Description

Colors was missing the calendarDayBackgroundSelected property for typescript, causing some ts errors when overriding color values. Add it to match the flow ComponentColorTokensT.

Also exports Theme from src/index.d.ts, after seeing the conversation on https://github.com/uber/baseweb/issues/4511

#### Scope

Patch: Bug Fix
