### PR TITLE
docs(cheat-sheet): fix scroll to element

### DIFF
--- a/documentation-site/components/cheat-sheet.js
+++ b/documentation-site/components/cheat-sheet.js
@@ -36,7 +36,7 @@ function CheatSheet() {
     if (query.component) {
       const element = document.getElementById(query.component);
       if (element) {
-        element.scrollIntoView();
+        setTimeout(el => el.scrollIntoView(), 0, element);
       }
     }
   }, [query]);
@@ -86,9 +86,9 @@ function CheatSheet() {
                       {t.name}
                     </StyledLink>
                   </li>
-                  {t.children.map(c => (
+                  {t.children.map((c, idx) => (
                     <li
-                      key={c.name}
+                      key={idx}
                       className={css({
                         ...theme.typography.font300,
                         paddingLeft: '12px',


### PR DESCRIPTION
#### Description
There is a bug on the cheat-sheet page: after scrolling to the element, the page returns to the top again. Happens so fast so looks like the scroll to elements don't actually work.
I've experimenting with `history.scrollRestoration = 'manual';` and next/router [events](https://nextjs.org/docs/api-reference/next/router#routerevents). 
The only solution found so far - do scroll after skipping an event loop cycle. 

Another minor update - use key indexes for child elements, since their names aren't unique.

#### Scope
Patch: Bug Fix
