### PR TITLE
feat(select): add setDropdownOpen to Select API

### DIFF
--- a/src/select/__tests__/select-methods.scenario.js
+++ b/src/select/__tests__/select-methods.scenario.js
@@ -1,0 +1,51 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+
+import {StatefulSelect} from '../index.js';
+import {Button} from '../../button/index.js';
+
+export default function Scenario() {
+  const methods = React.useRef();
+
+  return (
+    <div style={{width: '360px'}}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          marginBottom: '20px',
+        }}
+      >
+        <Button
+          onClick={() => {
+            methods.current && methods.current.setDropdownOpen(true);
+          }}
+        >
+          Open Dropdown
+        </Button>
+        <Button
+          onClick={() => {
+            methods.current && methods.current.setDropdownOpen(false);
+          }}
+        >
+          Close Dropdown
+        </Button>
+      </div>
+      <StatefulSelect
+        methods={methods}
+        options={[
+          {id: 'a', label: 'hey!'},
+          {id: 'b', label: 'are you listening?'},
+          {id: 'c', label: 'look at me!'},
+        ]}
+      />
+    </div>
+  );
+}

--- a/src/select/__tests__/select.stories.js
+++ b/src/select/__tests__/select.stories.js
@@ -29,6 +29,7 @@ import SelectSizes from './select-sizes.scenario.js';
 import SelectStates from './select-states.scenario.js';
 import SelectUnmountBlur from './select-unmount-blur.scenario.js';
 import SelectDefault from './select.scenario.js';
+import SelectMethods from './select-methods.scenario.js';
 
 export const AsyncOptions = () => <SelectAsyncOptions />;
 export const BackspaceBehavior = () => <SelectBackspaceBehavior />;
@@ -52,3 +53,4 @@ export const Sizes = () => <SelectSizes />;
 export const States = () => <SelectStates />;
 export const UnmountBlur = () => <SelectUnmountBlur />;
 export const Select = () => <SelectDefault />;
+export const Methods = () => <SelectMethods />;

--- a/src/select/select-component.js
+++ b/src/select/select-component.js
@@ -124,6 +124,13 @@ class Select extends React.Component<PropsT, SelectStateT> {
       this.focus();
     }
     this.isMounted = true;
+
+    if (this.props.methods) {
+      // $FlowFixMe "Cannot assign ... to `this.props.setDropdownOpen.current` because property `current` is missing in  undefined"
+      this.props.methods.current = {
+        setDropdownOpen: this.handleDropdownOpen.bind(this),
+      };
+    }
   }
 
   componentDidUpdate(prevProps: PropsT, prevState: SelectStateT) {
@@ -155,6 +162,12 @@ class Select extends React.Component<PropsT, SelectStateT> {
   focus() {
     if (!this.input) return;
     this.input.focus();
+  }
+
+  handleDropdownOpen(nextOpenState: boolean) {
+    this.setState({
+      isOpen: nextOpenState,
+    });
   }
 
   // Handle touch outside on mobile to dismiss menu, ensures that the

--- a/src/select/types.js
+++ b/src/select/types.js
@@ -134,6 +134,8 @@ export type PropsT = {
   maxDropdownHeight: string,
   /** Defines if multiple options can be selected. */
   multi: boolean,
+  /** Handle for accessing internal methods. */
+  methods?: React.ElementRef<*>,
   /** Message to be displayed if no options is found for a search query. */
   noResultsMsg?: React.Node,
   onBlur: (e: Event) => mixed,


### PR DESCRIPTION
#### Description
Allow the user to imperatively open and close the `Select` dropdown.
This is achieved with a new `methods` prop that acts as a handle to expose internal component methods to the user. (For now we are just exposing `setDropdownOpen`.)

#### Scope
Minor: New Feature
