### PR TITLE
docs(accordion): fix stateless accordion example

### DIFF
--- a/documentation-site/examples/accordion/stateless.tsx
+++ b/documentation-site/examples/accordion/stateless.tsx
@@ -3,8 +3,8 @@ import {StatelessAccordion, Panel} from 'baseui/accordion';
 
 export default function Example() {
   const [expanded, setExpanded] = React.useState<React.Key[]>([
-    'L1',
-    'L2',
+    'P1',
+    'P2',
   ]);
   return (
     <StatelessAccordion


### PR DESCRIPTION
#### Description

Use correct `key`s in `useState` to showcase initial state 

#### Scope

`patch`