### PR TITLE
chore(map-marker): add round and square options to pinhead, flow issues, fix examples

### DIFF
--- a/documentation-site/components/floating-marker-container.js
+++ b/documentation-site/components/floating-marker-container.js
@@ -5,8 +5,8 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
-const FloatingMarkerContainer = ({children}) => {
+import * as React from 'react';
+const FloatingMarkerContainer = ({children}: {children: React.Node}) => {
   return (
     <div
       style={{

--- a/documentation-site/components/floating-marker-container.js
+++ b/documentation-site/components/floating-marker-container.js
@@ -4,7 +4,8 @@ Copyright (c) Uber Technologies, Inc.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
-
+// @flow
+import React from 'react';
 const FloatingMarkerContainer = ({children}) => {
   return (
     <div

--- a/documentation-site/components/yard/config/floating-marker.ts
+++ b/documentation-site/components/yard/config/floating-marker.ts
@@ -31,9 +31,9 @@ export const fixedMarkerProps = {
     },
   },
   anchorType: {
-    value: 'FLOATING_MARKER_ANCHOR_TYPES.round',
+    value: 'FLOATING_MARKER_ANCHOR_TYPES.circle',
     type: PropTypes.Enum,
-    defaultValue: 'FLOATING_MARKER_ANCHOR_TYPES.round',
+    defaultValue: 'FLOATING_MARKER_ANCHOR_TYPES.circle',
     options: FLOATING_MARKER_ANCHOR_TYPES,
     description: 'Type of anchor to render around the marker.',
     imports: {

--- a/documentation-site/examples/fixed-marker/x-small.js
+++ b/documentation-site/examples/fixed-marker/x-small.js
@@ -9,7 +9,7 @@ import {
 export default function Example() {
   return (
     <FixedMarker
-      size={PINHEAD_SIZES.xSmall}
+      size={PINHEAD_SIZES.xSmallCircle}
       needle={NEEDLE_SIZES.tall}
     />
   );

--- a/documentation-site/examples/fixed-marker/x-small.tsx
+++ b/documentation-site/examples/fixed-marker/x-small.tsx
@@ -9,7 +9,7 @@ import {
 export default function Example() {
   return (
     <FixedMarker
-      size={PINHEAD_SIZES.xSmall}
+      size={PINHEAD_SIZES.xSmallCircle}
       needle={NEEDLE_SIZES.tall}
     />
   );

--- a/src/map-marker/__tests__/floating-marker.scenario.js
+++ b/src/map-marker/__tests__/floating-marker.scenario.js
@@ -46,8 +46,9 @@ export default function Scenario() {
       ),
     }),
   );
-  //$FlowFixMe
+
   const options = Object.values(FLOATING_MARKER_ANCHOR_POSITIONS).map(
+    //$FlowFixMe
     (x: string) => ({
       label: x,
       id: x,
@@ -56,7 +57,6 @@ export default function Scenario() {
 
   return (
     <TileGrid
-      // TODO: pass as children, make a separate component called "customization header"
       customizerOptions={[
         <Select
           options={options}

--- a/src/map-marker/constants.js
+++ b/src/map-marker/constants.js
@@ -27,14 +27,14 @@ export const PIN_SIZES = Object.freeze({
 });
 
 export const PINHEAD_SIZES = Object.freeze({
-  xSmall: 'x-small',
+  xSmallCircle: 'x-small-circle',
+  xSmallSquare: 'x-small-square',
   small: 'small',
   medium: 'medium',
   large: 'large',
 });
 
-export const PINHEAD_SIZE = Object.freeze({
-  [PINHEAD_SIZES.xSmall]: {height: 12, icon: 12},
+export const PINHEAD_DIMENSIONS = Object.freeze({
   [PINHEAD_SIZES.small]: {height: 24, icon: 16},
   [PINHEAD_SIZES.medium]: {height: 36, icon: 16},
   [PINHEAD_SIZES.large]: {height: 48, icon: 24},
@@ -67,3 +67,4 @@ export const FLOATING_MARKER_ANCHOR_TYPES = Object.freeze({
 export const dragShadowHeight = 4;
 export const dragShadowMarginTop = 6;
 export const dragShadowWidth = 6;
+export const anchorSize = 16;

--- a/src/map-marker/constants.js
+++ b/src/map-marker/constants.js
@@ -34,7 +34,13 @@ export const PINHEAD_SIZES = Object.freeze({
   large: 'large',
 });
 
+const xSmallPinheadDimension = {
+  height: 16,
+  icon: 4,
+};
 export const PINHEAD_DIMENSIONS = Object.freeze({
+  [PINHEAD_SIZES.xSmallSquare]: xSmallPinheadDimension,
+  [PINHEAD_SIZES.xSmallCircle]: xSmallPinheadDimension,
   [PINHEAD_SIZES.small]: {height: 24, icon: 16},
   [PINHEAD_SIZES.medium]: {height: 36, icon: 16},
   [PINHEAD_SIZES.large]: {height: 48, icon: 24},
@@ -60,7 +66,7 @@ export const FLOATING_MARKER_ANCHOR_POSITIONS = Object.freeze({
 });
 
 export const FLOATING_MARKER_ANCHOR_TYPES = Object.freeze({
-  round: 'round',
+  circle: 'circle',
   square: 'square',
 });
 

--- a/src/map-marker/floating-marker.js
+++ b/src/map-marker/floating-marker.js
@@ -62,7 +62,6 @@ const FloatingMarker = ({
         <StyledFloatingMarkerAnchorContainer>
           <PinHead
             size={anchorPinHeadSize}
-            // anchorType={anchorType}
             color={primaryB}
             background={backgroundInversePrimary}
             type={PINHEAD_TYPES.fixed}

--- a/src/map-marker/floating-marker.js
+++ b/src/map-marker/floating-marker.js
@@ -29,7 +29,7 @@ const FloatingMarker = ({
   anchor = FLOATING_MARKER_ANCHOR_POSITIONS.bottomLeft,
   endEnhancer,
   startEnhancer,
-  anchorType = FLOATING_MARKER_ANCHOR_TYPES.round,
+  anchorType = FLOATING_MARKER_ANCHOR_TYPES.circle,
 }: FloatingMarkerPropsT) => {
   const [, theme] = useStyletron();
   const {
@@ -39,7 +39,7 @@ const FloatingMarker = ({
   background = background || backgroundPrimary;
 
   const anchorPinHeadSize =
-    anchorType === FLOATING_MARKER_ANCHOR_TYPES.round
+    anchorType === FLOATING_MARKER_ANCHOR_TYPES.circle
       ? PINHEAD_SIZES.xSmallCircle
       : PINHEAD_SIZES.xSmallSquare;
   return (

--- a/src/map-marker/floating-marker.js
+++ b/src/map-marker/floating-marker.js
@@ -19,6 +19,7 @@ import {
   PINHEAD_SIZES,
   PINHEAD_TYPES,
   FLOATING_MARKER_ANCHOR_TYPES,
+  anchorSize,
 } from './constants.js';
 const FloatingMarker = ({
   color,
@@ -37,8 +38,10 @@ const FloatingMarker = ({
   color = color || primaryA;
   background = background || backgroundPrimary;
 
-  const anchorSize = 16;
-
+  const anchorPinHeadSize =
+    anchorType === FLOATING_MARKER_ANCHOR_TYPES.round
+      ? PINHEAD_SIZES.xSmallCircle
+      : PINHEAD_SIZES.xSmallSquare;
   return (
     <StyledFloatingMarkerRoot data-baseweb="map-marker">
       <StyledFloatingMarkerPinHeadContainer
@@ -58,8 +61,8 @@ const FloatingMarker = ({
       {anchor !== FLOATING_MARKER_ANCHOR_POSITIONS.none && (
         <StyledFloatingMarkerAnchorContainer>
           <PinHead
-            size={PINHEAD_SIZES.xSmall}
-            anchorType={anchorType}
+            size={anchorPinHeadSize}
+            // anchorType={anchorType}
             color={primaryB}
             background={backgroundInversePrimary}
             type={PINHEAD_TYPES.fixed}

--- a/src/map-marker/pin-head.js
+++ b/src/map-marker/pin-head.js
@@ -38,44 +38,47 @@ const PinHead = ({
   const activeElements = [label, startEnhancer, endEnhancer].filter(x => x);
   const gridTemplateColumns = activeElements.map(() => 'auto').join(' ');
   const forceCircle = activeElements.length === 1 && !label;
-
+  const {height, icon} = PINHEAD_DIMENSIONS[size];
   if (
     type === PINHEAD_TYPES.fixed &&
     (size === PINHEAD_SIZES.xSmallSquare || size === PINHEAD_SIZES.xSmallCircle)
   ) {
     const round = size === PINHEAD_SIZES.xSmallCircle;
     return (
-      <StyledOuterXSmallAnchor $round={round} $background={background}>
-        <StyledInnerXSmallAnchor $color={color} $round={round} />
+      <StyledOuterXSmallAnchor
+        $round={round}
+        $background={background}
+        $size={height}
+      >
+        <StyledInnerXSmallAnchor $color={color} $round={round} $size={icon} />
       </StyledOuterXSmallAnchor>
     );
+  } else {
+    return (
+      <StyledPinHead
+        $background={background}
+        $height={height}
+        $gridTemplateColumns={gridTemplateColumns}
+        $forceCircle={forceCircle}
+        $type={type}
+      >
+        {startEnhancer && (
+          <Item size={height} color={color}>
+            {React.cloneElement(startEnhancer, {size: `${icon}px`}, null)}
+          </Item>
+        )}
+        {label && (
+          <Item size={height} color={color}>
+            {label}
+          </Item>
+        )}
+        {endEnhancer && (
+          <Item size={height} color={color}>
+            {React.cloneElement(endEnhancer, {size: `${icon}px`}, null)}
+          </Item>
+        )}
+      </StyledPinHead>
+    );
   }
-  const {height, icon} = PINHEAD_DIMENSIONS[size];
-
-  return (
-    <StyledPinHead
-      $background={background}
-      $height={height}
-      $gridTemplateColumns={gridTemplateColumns}
-      $forceCircle={forceCircle}
-      $type={type}
-    >
-      {startEnhancer && (
-        <Item size={height} color={color}>
-          {React.cloneElement(startEnhancer, {size: `${icon}px`}, null)}
-        </Item>
-      )}
-      {label && (
-        <Item size={height} color={color}>
-          {label}
-        </Item>
-      )}
-      {endEnhancer && (
-        <Item size={height} color={color}>
-          {React.cloneElement(endEnhancer, {size: `${icon}px`}, null)}
-        </Item>
-      )}
-    </StyledPinHead>
-  );
 };
 export default PinHead;

--- a/src/map-marker/pin-head.js
+++ b/src/map-marker/pin-head.js
@@ -7,12 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 import * as React from 'react';
 import {useStyletron} from '../styles/index.js';
-import {
-  PINHEAD_SIZES,
-  PINHEAD_TYPES,
-  PINHEAD_SIZE,
-  FLOATING_MARKER_ANCHOR_TYPES,
-} from './constants.js';
+import {PINHEAD_SIZES, PINHEAD_TYPES, PINHEAD_DIMENSIONS} from './constants.js';
 import Item from './pin-head-item.js';
 import {
   StyledInnerXSmallAnchor,
@@ -43,16 +38,19 @@ const PinHead = ({
   const activeElements = [label, startEnhancer, endEnhancer].filter(x => x);
   const gridTemplateColumns = activeElements.map(() => 'auto').join(' ');
   const forceCircle = activeElements.length === 1 && !label;
-  const {height, icon} = PINHEAD_SIZE[size];
 
-  if (type === PINHEAD_TYPES.fixed && size === PINHEAD_SIZES.xSmall) {
-    const round = anchorType === FLOATING_MARKER_ANCHOR_TYPES.round;
+  if (
+    type === PINHEAD_TYPES.fixed &&
+    (size === PINHEAD_SIZES.xSmallSquare || size === PINHEAD_SIZES.xSmallCircle)
+  ) {
+    const round = size === PINHEAD_SIZES.xSmallCircle;
     return (
       <StyledOuterXSmallAnchor $round={round} $background={background}>
         <StyledInnerXSmallAnchor $color={color} $round={round} />
       </StyledOuterXSmallAnchor>
     );
   }
+  const {height, icon} = PINHEAD_DIMENSIONS[size];
 
   return (
     <StyledPinHead

--- a/src/map-marker/styled-components.js
+++ b/src/map-marker/styled-components.js
@@ -99,13 +99,14 @@ export const StyledFixedMarkerDragContainer = styled<{
 export const StyledOuterXSmallAnchor = styled<{
   $round: boolean,
   $background: string,
-}>('div', ({$theme, $round, $background}) => ({
+  $size: number,
+}>('div', ({$theme, $round, $background, $size}) => ({
   background: $background,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  height: '16px',
-  width: '16px',
+  height: `${$size}px`,
+  width: `${$size}px`,
   borderRadius: $round ? '50%' : 0,
   boxShadow: $theme.lighting.shadow600,
 }));
@@ -113,10 +114,11 @@ export const StyledOuterXSmallAnchor = styled<{
 export const StyledInnerXSmallAnchor = styled<{
   $round: boolean,
   $color: string,
-}>('div', ({$round, $color}) => ({
+  $size: number,
+}>('div', ({$round, $color, $size}) => ({
   background: $color,
-  height: '4px',
-  width: '4px',
+  height: `${$size}px`,
+  width: `${$size}px`,
   borderRadius: $round ? '50%' : 0,
 }));
 


### PR DESCRIPTION
Add xSmallSquare and xSmallCircle back to pin head sizes.