### PR TITLE
feat: use different tag than div to prevent hydration issues

### DIFF
--- a/src/spinner/styled-components.js
+++ b/src/spinner/styled-components.js
@@ -51,7 +51,7 @@ export const StyledActivePath = styled<StylePropsT>('path', props => ({
 
 // TODO(v11): Replace Spinner with SpinnerNext
 export const StyledSpinnerNext = styled<{$size?: SizeT}>(
-  'div',
+  'i',
   ({$theme, $size = SIZE.medium}) => {
     const borderWidth = {
       large: $theme.sizing.scale300,


### PR DESCRIPTION
Spinner is often used as a placeholder while the main content & components are loading. This can be an issue when React does [reconciliation/hydration](https://reactjs.org/docs/reconciliation.html#dom-elements-of-the-same-type) between the code that comes from server (with spinner) and client (loaded content) since we use `div` for our spinner and that's also the most common tag for any other component. React then incorrectly re-uses the same element/styling and starts spinning unrelated components.

Repro: https://codesandbox.io/s/base-web-spinner-ssr-forked-uh33d?file=/src/index.js

I believe this should be primarily fixed on the side of application making sure that SSR code = client code. But we can at least significantly lower the probability of this issue just by using a different / more unique tag like `<i>`. (It's being frequently used by icon libraries, saves some bytes and should not break any current users.)

Fixed repro example using this PR: https://codesandbox.io/s/basic-usage-forked-9whgk?file=/example-v2.js