### PR TITLE
fix(types): add missing `animateUnderline` prop

### DIFF
--- a/src/link/index.d.ts
+++ b/src/link/index.d.ts
@@ -6,6 +6,7 @@ export interface LinkProps
     React.AnchorHTMLAttributes<HTMLAnchorElement>,
     HTMLAnchorElement
   > {
+  animateUnderline?: boolean;
   target?: '_self' | '_blank' | '_parent' | '_top';
 }
 


### PR DESCRIPTION
Fixes #4603 <!-- remove the (`) quotes to link the issues -->

#### Description

<!-- Describe your changes below in as much detail as possible -->
Add missing `animateUnderline` prop of StyledLink

#### Scope

Patch: Bug Fix

<!-- Pick one:
Patch: Bug Fix
Minor: New Feature
Major: Breaking change
-->
