### PR TITLE
docs: link working nextjs baseweb project in setup

### DIFF
--- a/documentation-site/pages/getting-started/setup.mdx
+++ b/documentation-site/pages/getting-started/setup.mdx
@@ -136,10 +136,10 @@ export default function Hello() {
   this component adds an <b>additional div</b> that could impact your layout.
 </Notification>
 
-There are detailed guides for Styletron setup for the following frameworks:
+There are detailed guides for Styletron/Base Web setup for the following frameworks:
 
 - [Fusion.js](https://www.styletron.org/getting-started/#with-fusionjs)
-- [Next.js](https://www.styletron.org/getting-started/#with-nextjs)
+- [Next.js](https://github.com/tajo/nextjs-baseweb)
 - [Gatsby](https://www.styletron.org/getting-started/#with-gatsby)
 - [Other React applications](https://www.styletron.org/getting-started/#with-react)
 


### PR DESCRIPTION
Fixes #4131

#### Description

Nextjs Styletron template is nice but it doesn't give you working Base Web setup and there are some pitfalls along the way. Let's link the full working example project I am maintaining.