### PR TITLE
fix(rating): reset preview on outside blur only

### DIFF
--- a/src/rating/emoticon-rating.js
+++ b/src/rating/emoticon-rating.js
@@ -135,7 +135,10 @@ class EmoticonRating extends React.Component<
       <Root
         data-baseweb="emoticon-rating"
         role="radiogroup"
-        onBlur={() => this.updatePreview(undefined)}
+        onBlur={e => {
+          if (!e.currentTarget.contains(e.relatedTarget))
+            this.updatePreview(undefined);
+        }}
         onMouseLeave={() => this.updatePreview(undefined)}
         {...rootProps}
       >

--- a/src/rating/star-rating.js
+++ b/src/rating/star-rating.js
@@ -133,7 +133,10 @@ class StarRating extends React.Component<StarRatingPropsT, RatingStateT> {
       <Root
         data-baseweb="star-rating"
         role="radiogroup"
-        onBlur={() => this.updatePreview(undefined)}
+        onBlur={e => {
+          if (!e.currentTarget.contains(e.relatedTarget))
+            this.updatePreview(undefined);
+        }}
         onMouseLeave={() => this.updatePreview(undefined)}
         {...rootProps}
       >


### PR DESCRIPTION
Fixes #4613

#### Description

<!-- Describe your changes below in as much detail as possible -->

The preview state was getting reset because `Root` component loses focus when clicking on the `Emoticon`/`Star` and `onBlur` is called thus resetting the preview state. The `onBlur` is still needed so that the preview would get reset in case of keyboard navigation.

A check whether the `relatedTarget` (component gaining focus) is within the `currentTarget` (`Root`) seems to fix this issue.

## Before


https://user-images.githubusercontent.com/17617175/140793605-b046b327-e719-478f-a0ab-d1055eaf9928.mp4

https://user-images.githubusercontent.com/17617175/140793634-6d854507-a5ab-4b26-a283-e0d415cb9319.mp4



## After


https://user-images.githubusercontent.com/17617175/140793649-32010ee1-33fa-419e-abab-1bb9faec9e58.mp4


https://user-images.githubusercontent.com/17617175/140793654-8c8fe19f-b1e2-49cc-9a13-a5ee3ca90e2d.mp4


#### Scope
Patch: Bug Fix


