### PR TITLE
feat(datepicker): add onOpen prop; resolves #4633

### DIFF
--- a/documentation-site/components/yard/config/datepicker.ts
+++ b/documentation-site/components/yard/config/datepicker.ts
@@ -251,6 +251,13 @@ const DatepickerConfig: TConfig = {
       description: `Event handler that is called when the calendar is closed.`,
       hidden: true,
     },
+    onOpen: {
+      value: undefined,
+      type: PropTypes.Function,
+      placeholder: '() => {}',
+      description: `Event handler that is called when the calendar is opened.`,
+      hidden: true,
+    },
     orientation: {
       value: 'ORIENTATION.vertical',
       defaultValue: 'ORIENTATION.vertical',

--- a/src/datepicker/__tests__/datepicker-range-separate-inputs.scenario.js
+++ b/src/datepicker/__tests__/datepicker-range-separate-inputs.scenario.js
@@ -50,7 +50,7 @@ export function Scenario() {
         overrides={{
           Day: {
             // eslint-disable-next-line react/display-name
-            component: (props) => (
+            component: props => (
               <StyledDay data-highlighted={props.$isHighlighted} {...props} />
             ),
           },

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -191,11 +191,14 @@ export default class Datepicker<T = Date> extends React.Component<
   };
 
   open = () => {
-    this.setState({
-      isOpen: true,
-      isPseudoFocused: true,
-      calendarFocused: false,
-    });
+    this.setState(
+      {
+        isOpen: true,
+        isPseudoFocused: true,
+        calendarFocused: false,
+      },
+      this.props.onOpen,
+    );
   };
 
   close = () => {

--- a/src/datepicker/index.d.ts
+++ b/src/datepicker/index.d.ts
@@ -169,6 +169,7 @@ export type DatepickerProps = CalendarProps & {
   mask?: string | null;
   mountNode?: HTMLElement;
   onClose?: () => any;
+  onOpen?: () => any;
   separateRangeInputs?: boolean;
   startDateLabel?: string;
   endDateLabel?: string;

--- a/src/datepicker/types.js
+++ b/src/datepicker/types.js
@@ -222,6 +222,8 @@ export type DatepickerPropsT<T = Date> = CalendarPropsT<T> & {
   mountNode?: HTMLElement,
   /** Called when calendar is closed */
   onClose?: () => mixed,
+  /** Called when calendar is opened */
+  onOpen?: () => mixed,
   mask?: string | null,
   /** Determines if startDate and endDate should be separated into two input fields. Ignored if `range` is not true. */
   separateRangeInputs?: boolean,


### PR DESCRIPTION
Fixes #4633 

#### Description

Added an onOpen (function) prop to the datepicker component. This callback will be called when the datepicker is opened. This is analogous to the existing onClose function already being called when the datepicker is closed.

#### Scope
Minor: New Feature
