### PR TITLE
fix(types): fix typescript definition errors

### DIFF
--- a/documentation-site/examples/snackbar/placement.tsx
+++ b/documentation-site/examples/snackbar/placement.tsx
@@ -9,11 +9,14 @@ import {
   SnackbarProvider,
   useSnackbar,
   PLACEMENT,
+  PlacementT,
 } from 'baseui/snackbar';
 
-const options = Object.keys(PLACEMENT).map(key => {
-  return {label: PLACEMENT[key], id: PLACEMENT[key]};
-});
+const options = (Object.keys(PLACEMENT) as Array<PlacementT>).map(
+  key => {
+    return {label: PLACEMENT[key], id: PLACEMENT[key]};
+  },
+);
 
 function Child({placement}: {placement: string}) {
   const {enqueue} = useSnackbar();
@@ -28,7 +31,9 @@ function Child({placement}: {placement: string}) {
 
 export default function Parent() {
   const [css] = useStyletron();
-  const [placement, setPlacement] = React.useState(PLACEMENT.top);
+  const [placement, setPlacement] = React.useState<PlacementT>(
+    PLACEMENT.top,
+  );
 
   return (
     <div className={css({width: '320px'})}>
@@ -37,7 +42,7 @@ export default function Parent() {
           <Select
             options={options}
             onChange={({value}) =>
-              setPlacement(String(value[0].id))
+              setPlacement(value[0].id as PlacementT)
             }
             value={[{id: placement}]}
             clearable={false}

--- a/src/combobox/index.d.ts
+++ b/src/combobox/index.d.ts
@@ -17,11 +17,14 @@ export interface ComboboxOverrides {
   ListItem?: Override<any>;
 }
 
-export type PropsT<OptionT = unknown> = {
+export type PropsT<OptionT = any> = {
   autocomplete?: boolean;
   disabled?: boolean;
-  mapOptionToNode?: ({isSelected: boolean, option: OptionT}) => React.ReactNode;
-  mapOptionToString: (OptionT) => string;
+  mapOptionToNode?: (option: {
+    isSelected: boolean;
+    option: OptionT;
+  }) => React.ReactNode;
+  mapOptionToString: (option: OptionT) => string;
   id?: string;
   name?: string;
   inputRef?: React.Ref<HTMLInputElement>;

--- a/src/map-marker/index.d.ts
+++ b/src/map-marker/index.d.ts
@@ -40,11 +40,12 @@ export interface FLOATING_MARKER_ANCHOR_TYPES {
   square: 'square';
 }
 
-export type NeedleSizeT = ValueOf<NEEDLE_SIZES>;
-export type PinHeadT = ValueOf<PINHEAD_TYPES>;
-export type PinHeadSizeT = ValueOf<PINHEAD_SIZES_SHAPES>;
-export type AnchorPositionsT = ValueOf<FLOATING_MARKER_ANCHOR_POSITIONS>;
-export type FloatingMarkerSizeT = ValueOf<FLOATING_MARKER_SIZES>;
+export type NeedleSizeT = NEEDLE_SIZES[keyof NEEDLE_SIZES];
+export type PinHeadT = PINHEAD_TYPES[keyof PINHEAD_TYPES];
+export type PinHeadSizeT = PINHEAD_SIZES_SHAPES[keyof PINHEAD_SIZES_SHAPES];
+export type AnchorPositionsT = FLOATING_MARKER_ANCHOR_POSITIONS[keyof FLOATING_MARKER_ANCHOR_POSITIONS];
+export type FloatingMarkerSizeT = FLOATING_MARKER_SIZES[keyof FLOATING_MARKER_SIZES];
+export type FloatingMarkerAnchorTypeT = FLOATING_MARKER_ANCHOR_TYPES[keyof FLOATING_MARKER_ANCHOR_TYPES];
 
 export type FixedMarkerOverridesT = {
   Root?: Override<any>;

--- a/src/snackbar/index.d.ts
+++ b/src/snackbar/index.d.ts
@@ -1,22 +1,27 @@
 import * as React from 'react';
 
 import {Override} from '../overrides';
-import {DURATION, PLACEMENT} from './constants.js';
-export {DURATION, PLACEMENT} from './constants.js';
 
-export type DurationT =
-  | typeof DURATION.infinite
-  | typeof DURATION.short
-  | typeof DURATION.medium
-  | typeof DURATION.long;
+declare const DURATION: {
+  infinite: number;
+  short: number;
+  medium: number;
+  long: number;
+};
 
-export type PlacementT =
-  | typeof PLACEMENT.topLeft
-  | typeof PLACEMENT.top
-  | typeof PLACEMENT.topRight
-  | typeof PLACEMENT.bottomLeft
-  | typeof PLACEMENT.bottom
-  | typeof PLACEMENT.bottomRight;
+declare const PLACEMENT: {
+  topLeft: 'topLeft';
+  top: 'top';
+  topRight: 'topRight';
+  bottomRight: 'bottomRight';
+  bottom: 'bottom';
+  bottomLeft: 'bottomLeft';
+};
+export {DURATION, PLACEMENT};
+
+export type DurationT = (typeof DURATION)[keyof typeof DURATION];
+
+export type PlacementT = (typeof PLACEMENT)[keyof typeof PLACEMENT];
 
 export type SnackbarElementOverridesT = {
   Root?: Override<any>;


### PR DESCRIPTION
Fix type definitions for snackbar, combobox and map marker

#### Description

- combobox - fixed syntax errors for function arguments(had flow syntax)
- map-marker - replaced `ValueOf` with working construction
- snackbar - replaced not working imports from js file, updated documentation example

#### Scope
Patch: Bug Fix

