### PR TITLE
fix(timepicker): Add Handling for cases where minDate & maxDate is before & after the current date value

### DIFF
--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -205,8 +205,9 @@ class TimePicker<T = Date> extends React.Component<
     if (!min) {
       min = midnight;
     }
+    const maxDateforCurrentDay = this.setTime(this.props.value, 24, 0, 0);
     if (!max) {
-      max = this.setTime(this.props.value, 24, 0, 0);
+      max = maxDateforCurrentDay;
     } else {
       // maxTime (if provided) should be inclusive, so add an extra step here
       max = this.props.adapter.setSeconds(
@@ -218,9 +219,15 @@ class TimePicker<T = Date> extends React.Component<
     const minDate = this.props.adapter.toJsDate(min);
     const maxDate = this.props.adapter.toJsDate(max);
     const midnightDate = this.props.adapter.toJsDate(midnight);
+    const start = this.props.adapter.isBefore(minDate, midnightDate)
+      ? 0
+      : (minDate - midnightDate) / 1000;
+    const end = this.props.adapter.isAfter(maxDate, maxDateforCurrentDay)
+      ? (maxDateforCurrentDay - midnightDate) / 1000
+      : (maxDate - midnightDate) / 1000;
     return {
-      start: (minDate - midnightDate) / 1000,
-      end: (maxDate - midnightDate) / 1000,
+      start,
+      end,
     };
   };
 

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -205,9 +205,9 @@ class TimePicker<T = Date> extends React.Component<
     if (!min) {
       min = midnight;
     }
-    const maxDateforCurrentDay = this.setTime(this.props.value, 24, 0, 0);
+    const maxForCurrentDay = this.setTime(this.props.value, 24, 0, 0);
     if (!max) {
-      max = maxDateforCurrentDay;
+      max = maxForCurrentDay;
     } else {
       // maxTime (if provided) should be inclusive, so add an extra step here
       max = this.props.adapter.setSeconds(
@@ -219,11 +219,12 @@ class TimePicker<T = Date> extends React.Component<
     const minDate = this.props.adapter.toJsDate(min);
     const maxDate = this.props.adapter.toJsDate(max);
     const midnightDate = this.props.adapter.toJsDate(midnight);
-    const start = this.props.adapter.isBefore(minDate, midnightDate)
+    const maxDateForCurrentDay = this.props.adapter.toJsDate(maxForCurrentDay);
+    const start = this.props.adapter.isBefore(min, midnight)
       ? 0
       : (minDate - midnightDate) / 1000;
-    const end = this.props.adapter.isAfter(maxDate, maxDateforCurrentDay)
-      ? (maxDateforCurrentDay - midnightDate) / 1000
+    const end = this.props.adapter.isAfter(max, maxForCurrentDay)
+      ? (maxDateForCurrentDay - midnightDate) / 1000
       : (maxDate - midnightDate) / 1000;
     return {
       start,


### PR DESCRIPTION
Fixes - https://codesandbox.io/s/timepicker-date-issue-zs300

#### Description
If we set the `minTime` and `maxTime` in Timepicker with time which is not on the same day as the date set in the value, we get options with time `> 12:00 AM` & with `negative time options` as shown in the code sandbox link.

<!-- Describe your changes below in as much detail as possible -->
Putting a check on the start and end of the options list & limiting if the start goes before the current day of the date & end goes after the current day of the date

#### Scope
Patch: Bug Fix

