### PR TITLE
fix(documentation:select) Removes `<ValueT>` from JavaScript example

### DIFF
--- a/documentation-site/examples/select/label.js
+++ b/documentation-site/examples/select/label.js
@@ -27,7 +27,7 @@ const getLabel = ({option}) => {
 };
 
 function CustomLabel() {
-  const [value, setValue] = React.useState<ValueT>([]);
+  const [value, setValue] = React.useState([]);
   return (
     <Select
       options={[


### PR DESCRIPTION
#### Description

Removes errant type `<ValueT>` from the JavaScript "[Select with Custom Labels](https://baseweb.design/components/select/#select-with-custom-labels)" documentation example that was preventing it from working on code sandbox.

#### Scope
Patch: Bug Fix
