### PR TITLE
fix(modal): update returnFocus type to match with returnFocus type of FocusLock

### DIFF
--- a/src/modal/index.d.ts
+++ b/src/modal/index.d.ts
@@ -47,7 +47,7 @@ export interface ModalProps {
   autofocus?: boolean;
   autoFocus?: boolean;
   focusLock?: boolean;
-  returnFocus?: boolean | FocusOptions;
+  returnFocus?: boolean | FocusOptions | ((returnTo: Element) => boolean | FocusOptions);
   children?: React.ReactNode;
   closeable?: boolean;
   isOpen?: boolean;

--- a/src/modal/types.js
+++ b/src/modal/types.js
@@ -48,7 +48,10 @@ export type ModalPropsT = {
    * Optionally, can pass focus options instead of `true` to control the focus
    * more precisely (ie. `{ preventScroll: true }`)
    */
-  returnFocus?: boolean | FocusOptions,
+  returnFocus?:
+    | boolean
+    | FocusOptions
+    | ((returnTo: Element) => boolean | FocusOptions),
   /** Modal content. The children-as-function API may be preferable
    * for performance reasons (wont render until opened) */
   children?: React.Node | (() => React.Node),


### PR DESCRIPTION
#### Description

update returnFocus type to match with returnFocus type of FocusLock.
So that we don't have to do flow-ignore or ts-ignore.

#### Scope
Patch: Bug Fix
