### PR TITLE
docs(guides/tables):Fixed the spelling of utilizes

### DIFF
--- a/documentation-site/pages/guides/tables.mdx
+++ b/documentation-site/pages/guides/tables.mdx
@@ -43,7 +43,7 @@ Think of this as something closer to Excel rather than a standard table.
 Base Web publishes two additional tables that are not quite as useful as the above, but may be appropriate
 in niche situtaions.
 
-First is the [`table-grid`](/components/table-grid). This table ustilizes `css-grid`
+First is the [`table-grid`](/components/table-grid). This table utilizes `css-grid`
 for layout which some developers prefer over the semantic table element. It will require a custom
 accessibility solution, but supports some alternative row/column spans.
 


### PR DESCRIPTION
#### Description

I looked in the documentation and found the word `ustilizes`. I think this is a typo and meant to be `utilizes` instead of `ustilizes`.

<!-- Describe your changes below in as much detail as possible -->

#### Scope
<!-- Pick one:
Patch: Bug Fix
Minor: New Feature
Major: Breaking change
-->
