### PR TITLE
fix(eslint): add jsx check if import was renamed

### DIFF
--- a/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
+++ b/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
@@ -442,6 +442,38 @@ const tests = {
         }));
       `,
     },
+    // H1, renamed with a different component using same name
+    {
+      code: `
+        import { H1 as StyledH1 } from "baseui/typography"
+        import ReactMarkdown from 'react-markdown';
+        import { getOverrides } from 'baseui/helpers/overrides';
+
+        const MarkdownRender = ({ overrides = {}, text }: Props) => {
+           const [H1, h1Props] = getOverrides(overrides.H1, StyledH1);
+        
+          return <ReactMarkdown
+            components={{
+              h1: ({ node, ...rest }) => <H1 {...h1Props} {...rest} />
+            }}/>;
+          }
+      `,
+      errors: [{messageId: MESSAGES.replace.id}],
+      output: `
+        import { HeadingXXLarge as StyledH1 } from "baseui/typography"
+        import ReactMarkdown from 'react-markdown';
+        import { getOverrides } from 'baseui/helpers/overrides';
+
+        const MarkdownRender = ({ overrides = {}, text }: Props) => {
+           const [H1, h1Props] = getOverrides(overrides.H1, StyledH1);
+        
+          return <ReactMarkdown
+            components={{
+              h1: ({ node, ...rest }) => <H1 {...h1Props} {...rest} />
+            }}/>;
+          }
+      `,
+    },
 
     // Block - $style
     {

--- a/packages/eslint-plugin-baseui/src/deprecated-component-api.js
+++ b/packages/eslint-plugin-baseui/src/deprecated-component-api.js
@@ -386,6 +386,7 @@ module.exports = {
         deprecatedTypographyComponents.forEach(deprecatedApi => {
           if (
             importState[deprecatedApi.oldName] &&
+            importState[deprecatedApi.oldName] === deprecatedApi.oldName &&
             isComponent(deprecatedApi.oldName)
           ) {
             context.report({


### PR DESCRIPTION
Fix instance where import was renamed and an old typography component name was used within the component (H1 as StyledH1 and later H1 is a valid local variable that should not be renamed). See test for minimally reproduced test case