### PR TITLE
fix(eslint): add test and early return for ImportNamespaceSpecifiers

### DIFF
--- a/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
+++ b/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
@@ -560,6 +560,24 @@ const tests = {
           }
       `,
     },
+    // Should not error on ImportNamespaceSpecifiers
+    {
+      code: `
+import * as Typography from "baseui/typography";
+
+const Example = () => {
+  return <div></div>
+}
+      `,
+      errors: [],
+      output: `
+import * as Typography from "baseui/typography";
+
+const Example = () => {
+  return <div></div>
+}
+      `,
+    },
 
     // Block - $style
     {

--- a/packages/eslint-plugin-baseui/src/deprecated-component-api.js
+++ b/packages/eslint-plugin-baseui/src/deprecated-component-api.js
@@ -102,6 +102,9 @@ module.exports = {
 
         // Map existing imports (newName: localName), preference given to first renamed import.
         node.specifiers.forEach(specifier => {
+          if (specifier.type === 'ImportNamespaceSpecifier') {
+            return;
+          }
           const currentImportedName = specifier.imported.name;
           if (existingImports[currentImportedName]) {
             if (
@@ -117,6 +120,9 @@ module.exports = {
 
         const specifiers = node.specifiers || [];
         specifiers.forEach((specifier, specifierIndex) => {
+          if (specifier.type === 'ImportNamespaceSpecifier') {
+            return;
+          }
           const deprecatedComponent = specifier.imported.name;
           const newComponent =
             mapDeprecatedTypographyComponents[deprecatedComponent];


### PR DESCRIPTION
Adds early return on `import * as Typography from...` declarations, since we're now processing the entire ImportDeclaration. 