### PR TITLE
fix(eslint): treat opening/closing tags separately

### DIFF
--- a/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
+++ b/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
@@ -298,6 +298,7 @@ const tests = {
       errors: [
         {messageId: MESSAGES.replace.id},
         {messageId: MESSAGES.replace.id},
+        {messageId: MESSAGES.replace.id},
       ],
       output: `
         import { ParagraphXSmall } from "baseui/typography"
@@ -353,6 +354,7 @@ const tests = {
         }
       `,
       errors: [
+        {messageId: MESSAGES.replace.id},
         {messageId: MESSAGES.replace.id},
         {messageId: MESSAGES.replace.id},
       ],
@@ -487,6 +489,7 @@ const tests = {
       errors: [
         {messageId: MESSAGES.replace.id},
         {messageId: MESSAGES.replace.id},
+        {messageId: MESSAGES.replace.id},
       ],
       output: `
         import { HeadingXXLarge } from "baseui/typography"
@@ -506,6 +509,7 @@ const tests = {
           }
       `,
       errors: [
+        {messageId: MESSAGES.replace.id},
         {messageId: MESSAGES.replace.id},
         {messageId: MESSAGES.replace.id},
       ],
@@ -531,6 +535,8 @@ const tests = {
         {messageId: MESSAGES.replace.id},
         {messageId: MESSAGES.replace.id},
         {messageId: MESSAGES.replace.id},
+        {messageId: MESSAGES.replace.id},
+        {messageId: MESSAGES.replace.id},
       ],
       output: `
         import { HeadingXXLarge as Hello, HeadingXLarge } from "baseui/typography"
@@ -549,6 +555,7 @@ const tests = {
           }
       `,
       errors: [
+        {messageId: MESSAGES.replace.id},
         {messageId: MESSAGES.replace.id},
         {messageId: MESSAGES.replace.id},
       ],
@@ -615,6 +622,27 @@ const Example = () => {
         }
       `,
       errors: [{messageId: MESSAGES.styleOnBlock.id}],
+    },
+    {
+      code: `
+        import { Paragraph3 } from "baseui/typography"
+        export default () => {
+          return <Paragraph3><Paragraph3>Hello</Paragraph3>World</Paragraph3>
+        }
+      `,
+      errors: [
+        {messageId: MESSAGES.replace.id},
+        {messageId: MESSAGES.replace.id},
+        {messageId: MESSAGES.replace.id},
+        {messageId: MESSAGES.replace.id},
+        {messageId: MESSAGES.replace.id},
+      ],
+      output: `
+        import { ParagraphSmall } from "baseui/typography"
+        export default () => {
+          return <ParagraphSmall><ParagraphSmall>Hello</ParagraphSmall>World</ParagraphSmall>
+        }
+      `,
     },
   ],
 };

--- a/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
+++ b/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
@@ -112,6 +112,26 @@ const tests = {
         }
       `,
     },
+    // Should not error on ImportNamespaceSpecifiers
+    {
+      code: `
+        import * as Typography from "baseui/typography";
+        
+        const Example = () => {
+          return <div></div>
+        }
+      `,
+    },
+    // Should not error
+    {
+      code: `
+        import * as Typography from "baseui/typography";
+
+        const Example = () => {
+          const hello = {}.toString();
+          return <div></div>
+        }`,
+    },
   ],
   invalid: [
     // Accordion - renderPanelContent
@@ -566,40 +586,6 @@ const tests = {
           return <div><Hello>Large</Hello><HeadingXXLarge>H2</HeadingXXLarge><HeadingXLarge>HeadingXLarge</HeadingXLarge><Hello>Large</Hello></div>
           }
       `,
-    },
-    // Should not error on ImportNamespaceSpecifiers
-    {
-      code: `
-import * as Typography from "baseui/typography";
-
-const Example = () => {
-  return <div></div>
-}
-      `,
-      errors: [],
-      output: `
-import * as Typography from "baseui/typography";
-
-const Example = () => {
-  return <div></div>
-}
-      `,
-    },
-    // Should not error
-    {
-      code: `import * as Typography from "baseui/typography";
-
-const Example = () => {
-  const hello = {}.toString();
-  return <div></div>
-}`,
-      errors: [],
-      output: `import * as Typography from "baseui/typography";
-
-const Example = () => {
-  const hello = {}.toString();
-  return <div></div>
-}`,
     },
 
     // Block - $style

--- a/packages/eslint-plugin-baseui/src/deprecated-component-api.js
+++ b/packages/eslint-plugin-baseui/src/deprecated-component-api.js
@@ -210,7 +210,10 @@ module.exports = {
         // Check if identifier is a component.
         // Ex: isComponent() with <Boo foo={} /> => true
         function isComponent() {
-          return node.parent.type === 'JSXOpeningElement';
+          return (
+            node.parent.type === 'JSXOpeningElement' ||
+            node.parent.type === 'JSXClosingElement'
+          );
         }
 
         // ================
@@ -465,16 +468,7 @@ module.exports = {
               new: newName,
             },
             fix: function(fixer) {
-              const tags = [fixer.replaceText(node, newName)];
-              if (node.parent.parent.closingElement) {
-                tags.push(
-                  fixer.replaceText(
-                    node.parent.parent.closingElement.name,
-                    newName,
-                  ),
-                );
-              }
-              return tags;
+              return [fixer.replaceText(node, newName)];
             },
           });
         }


### PR DESCRIPTION
Nested tags weren't getting replaced, since the outer tag would manipulate the closing element, the child elements changed in a different fix function would be overridden. This separates the fix/report issue by processing each opening/closing tag separately. 