### PR TITLE
fix(modal): modal will not lock focus within an iframe only

### DIFF
--- a/src/drawer/drawer.js
+++ b/src/drawer/drawer.js
@@ -253,7 +253,13 @@ class Drawer extends React.Component<DrawerPropsT, DrawerStateT> {
       <LocaleContext.Consumer>
         {locale => {
           return (
-            <FocusLock returnFocus autoFocus={autoFocus} noFocusGuards={true}>
+            <FocusLock
+              // Allow focus to escape when UI is within an iframe
+              crossFrame={false}
+              returnFocus
+              autoFocus={autoFocus}
+              noFocusGuards={true}
+            >
               <Root
                 data-baseweb="drawer"
                 ref={this.getRef('Root')}

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -321,6 +321,8 @@ class Modal extends React.Component<ModalPropsT, ModalStateT> {
         {locale => (
           <FocusLock
             disabled={!focusLock}
+            // Allow focus to escape when UI is within an iframe
+            crossFrame={false}
             returnFocus={returnFocus}
             autoFocus={autofocus !== null ? autofocus : autoFocus}
           >

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -477,6 +477,8 @@ class PopoverInner extends React.Component<
                   // see popover-focus-loop.scenario.js for why hover cannot return focus
                   returnFocus={!this.isHoverTrigger() && this.props.returnFocus}
                   autoFocus={this.state.autoFocusAfterPositioning}
+                  // Allow focus to escape when UI is within an iframe
+                  crossFrame={false}
                   focusOptions={this.props.focusOptions}
                 >
                   {this.renderPopover(renderedContent)}

--- a/src/table/filter.js
+++ b/src/table/filter.js
@@ -57,7 +57,11 @@ export default function Filter(props: FilterProps) {
         return nextState;
       }}
       content={({close}) => (
-        <FocusLock autoFocus={false}>
+        <FocusLock
+          autoFocus={false}
+          // Allow focus to escape when UI is within an iframe
+          crossFrame={false}
+        >
           <Heading {...headingProps}>Filter Column</Heading>
           <Content {...contentProps}>{props.children}</Content>
           <Footer {...footerProps}>


### PR DESCRIPTION
Fixes #4743

#### Description

This change allows a focus-locked component (modal, drawer, popover, table filter) to lose focus only when the focus exits the frame. This will only occur if the component is within an `iframe`

See prop details here https://github.com/theKashey/react-focus-lock/commit/486a7e08428487286d09ef7bfeaa701e8376318d

#### Scope
Patch: Bug Fix
