### PR TITLE
fix(theme): add color to body

### DIFF
--- a/src/helper/styled-components.js
+++ b/src/helper/styled-components.js
@@ -174,6 +174,7 @@ export const StyledBody = styled<SharedStylePropsArgT>('div', props => {
       props.$placement,
       props.$popoverMargin,
     ),
+    color: props.$theme.colors.contentPrimary,
     backgroundColor: props.$theme.colors.backgroundPrimary,
   };
 });


### PR DESCRIPTION
It stands to reason that if we apply the backgroundColor to the body, we should also be applying the text color as well to ensure accessibility. 