### PR TITLE
Map marker label enhancer no color props

### DIFF
--- a/documentation-site/components/yard/config/fixed-marker.ts
+++ b/documentation-site/components/yard/config/fixed-marker.ts
@@ -101,18 +101,6 @@ export const fixedMarkerProps = {
       },
     },
   },
-  badgeEnhancerColor: {
-    value: undefined,
-    placeholder: '#fff',
-    type: PropTypes.String,
-    description: 'Color to render for badge.',
-  },
-  badgeEnhancerBackground: {
-    value: undefined,
-    placeholder: '#276EF1',
-    type: PropTypes.String,
-    description: 'Background color to render for badge.',
-  },
   badgeEnhancerContent: {
     value: '({size}) => <Check size={size}/>',
     placeholder: '({size}) => <Check size={size}/>',
@@ -141,18 +129,6 @@ export const fixedMarkerProps = {
         named: ['LABEL_ENHANCER_POSITIONS'],
       },
     },
-  },
-  labelEnhancerColor: {
-    value: undefined,
-    placeholder: '#000',
-    type: PropTypes.String,
-    description: 'Color for the label enhancer.',
-  },
-  labelEnhancerStrokeColor: {
-    value: undefined,
-    placeholder: '#fff',
-    type: PropTypes.String,
-    description: 'Stroke color for the label enhancer.',
   },
 };
 

--- a/documentation-site/examples/fixed-marker/badge-enhancer-text.js
+++ b/documentation-site/examples/fixed-marker/badge-enhancer-text.js
@@ -10,7 +10,13 @@ export default function Example() {
         startEnhancer={({size}) => <Show size={size} />}
         badgeEnhancerSize={BADGE_ENHANCER_SIZES.mediumText}
         badgeEnhancerContent={({size}) => 'New'}
-        badgeEnhancerBackground="green"
+        overrides={{
+          BadgeEnhancer: {
+            style: {
+              backgroundColor: 'green',
+            },
+          },
+        }}
       />
     </div>
   );

--- a/documentation-site/examples/fixed-marker/badge-enhancer-text.tsx
+++ b/documentation-site/examples/fixed-marker/badge-enhancer-text.tsx
@@ -9,7 +9,13 @@ export default function Example() {
         startEnhancer={({size}) => <Show size={size} />}
         badgeEnhancerSize={BADGE_ENHANCER_SIZES.mediumText}
         badgeEnhancerContent={({size}) => 'New'}
-        badgeEnhancerBackground="green"
+        overrides={{
+          BadgeEnhancer: {
+            style: {
+              backgroundColor: 'green',
+            },
+          },
+        }}
       />
     </div>
   );

--- a/src/map-marker/__tests__/eats-pickup-marker.scenario.js
+++ b/src/map-marker/__tests__/eats-pickup-marker.scenario.js
@@ -96,6 +96,14 @@ export function Scenario() {
                 BadgeEnhancer: {
                   style: () => ({
                     boxShadow: theme.lighting.shadow600,
+                    color:
+                      hoveredLocationIndex === 0 || selectedLocationIndex === 0
+                        ? theme.colors.contentInversePrimary
+                        : theme.colors.contentPositive,
+                    backgroundColor:
+                      hoveredLocationIndex === 0 || selectedLocationIndex === 0
+                        ? theme.colors.backgroundPositive
+                        : theme.colors.backgroundPrimary,
                   }),
                 },
               }}
@@ -106,16 +114,6 @@ export function Scenario() {
                   : LABEL_ENHANCER_POSITIONS.none
               }
               badgeEnhancerSize={BADGE_ENHANCER_SIZES.mediumIcon}
-              badgeEnhancerBackground={
-                hoveredLocationIndex === 0 || selectedLocationIndex === 0
-                  ? theme.colors.backgroundPositive
-                  : theme.colors.backgroundPrimary
-              }
-              badgeEnhancerColor={
-                hoveredLocationIndex === 0 || selectedLocationIndex === 0
-                  ? theme.colors.contentInversePrimary
-                  : theme.colors.contentPositive
-              }
               badgeEnhancerContent={({size}) => <Search size={size} />}
               background={
                 hoveredLocationIndex === 0 || selectedLocationIndex === 0
@@ -181,6 +179,14 @@ export function Scenario() {
                 BadgeEnhancer: {
                   style: () => ({
                     boxShadow: theme.lighting.shadow600,
+                    color:
+                      hoveredLocationIndex === 2 || selectedLocationIndex === 2
+                        ? theme.colors.contentInversePrimary
+                        : theme.colors.contentPositive,
+                    backgroundColor:
+                      hoveredLocationIndex === 2 || selectedLocationIndex === 2
+                        ? theme.colors.backgroundPositive
+                        : theme.colors.backgroundPrimary,
                   }),
                 },
               }}
@@ -191,16 +197,6 @@ export function Scenario() {
                   : LABEL_ENHANCER_POSITIONS.none
               }
               badgeEnhancerSize={BADGE_ENHANCER_SIZES.mediumText}
-              badgeEnhancerBackground={
-                hoveredLocationIndex === 2 || selectedLocationIndex === 2
-                  ? theme.colors.backgroundPositive
-                  : theme.colors.backgroundPrimary
-              }
-              badgeEnhancerColor={
-                hoveredLocationIndex === 2 || selectedLocationIndex === 2
-                  ? theme.colors.contentInversePrimary
-                  : theme.colors.contentPositive
-              }
               badgeEnhancerContent={() => 'New'}
               background={
                 hoveredLocationIndex === 2 || selectedLocationIndex === 2

--- a/src/map-marker/__tests__/fixed-marker-map.scenario.js
+++ b/src/map-marker/__tests__/fixed-marker-map.scenario.js
@@ -227,13 +227,15 @@ export function Scenario() {
                       })`,
                     }),
                   },
+                  BadgeEnhancer: {
+                    style: {
+                      color: 'white',
+                      backgroundColor: 'green',
+                    },
+                  },
                 }}
-                badgeEnhancer={{
-                  size: BADGE_ENHANCER_SIZES.xSmall,
-                  color: 'white',
-                  background: 'green',
-                  content: 'hello',
-                }}
+                badgeEnhancerSize={BADGE_ENHANCER_SIZES.mediumText}
+                badgeEnhancerContent={() => 'hello'}
                 labelEnhancerContent={labelEnhancerText}
                 // $FlowFixMe Mismatch between general type and enum
                 labelEnhancerPosition={labelEnhancerPosition[0].id}

--- a/src/map-marker/__tests__/fixed-marker.scenario.js
+++ b/src/map-marker/__tests__/fixed-marker.scenario.js
@@ -94,8 +94,6 @@ export function Scenario() {
                 labelEnhancerContent={labelEnhancerText}
                 labelEnhancerPosition={labelEnhancerPosition[0].id}
                 badgeEnhancerSize={badgeEnhancerSize[0].id}
-                badgeEnhancerColor={null}
-                badgeEnhancerBackground={null}
                 badgeEnhancerContent={BadgeEnhancerContent}
               />
             ),

--- a/src/map-marker/badge-enhancer.js
+++ b/src/map-marker/badge-enhancer.js
@@ -21,8 +21,6 @@ const BadgeEnhancer = ({
   pinHeadSize,
   markerType,
   badgeEnhancerSize = BADGE_ENHANCER_SIZES.none,
-  badgeEnhancerColor,
-  badgeEnhancerBackground,
   badgeEnhancerContent: BadgeEnhancerContent,
   overrides = {},
 }: BadgeEnhancerComponentT) => {
@@ -69,8 +67,6 @@ const BadgeEnhancer = ({
     <BadgeEnhancerRoot
       $size={badgeEnhancerSize}
       $position={position}
-      $color={badgeEnhancerColor}
-      $background={badgeEnhancerBackground}
       {...badgeEnhancerRootProps}
     >
       {BadgeEnhancerContent &&

--- a/src/map-marker/drag-shadow.js
+++ b/src/map-marker/drag-shadow.js
@@ -1,0 +1,48 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+import * as React from 'react';
+import {getOverrides} from '../helpers/overrides.js';
+import {dragShadowWidth} from './constants.js';
+import {
+  StyledDragShadow,
+  StyledDragShadowContainer,
+} from './styled-components.js';
+import type {DragShadowPropsT} from './types.js';
+
+const DragShadow = ({
+  background,
+  dragging,
+  height,
+  overrides = {},
+}: DragShadowPropsT) => {
+  const [DragShadowContainer, dragShadowContainerProps] = getOverrides(
+    overrides.DragShadowContainer,
+    StyledDragShadowContainer,
+  );
+  const [DragShadow, dragShadowProps] = getOverrides(
+    overrides.DragShadow,
+    StyledDragShadow,
+  );
+
+  return (
+    <DragShadowContainer
+      $width={dragShadowWidth}
+      $height={height}
+      $dragging={dragging}
+      {...dragShadowContainerProps}
+    >
+      <DragShadow
+        $width={dragShadowWidth}
+        $background={background}
+        {...dragShadowProps}
+      />
+    </DragShadowContainer>
+  );
+};
+
+export default DragShadow;

--- a/src/map-marker/fixed-marker.js
+++ b/src/map-marker/fixed-marker.js
@@ -86,11 +86,7 @@ const FixedMarker = ({
   overrides = {},
   labelEnhancerContent = null,
   labelEnhancerPosition = LABEL_ENHANCER_POSITIONS.bottom,
-  labelEnhancerColor,
-  labelEnhancerStrokeColor,
   badgeEnhancerSize = null,
-  badgeEnhancerColor = null,
-  badgeEnhancerBackground = null,
   badgeEnhancerContent = null,
   ...restProps
 }: FixedMarkerPropsT) => {
@@ -151,13 +147,9 @@ const FixedMarker = ({
           type={PINHEAD_TYPES.fixed}
           overrides={overrides}
           badgeEnhancerSize={badgeEnhancerSize}
-          badgeEnhancerColor={badgeEnhancerColor}
-          badgeEnhancerBackground={badgeEnhancerBackground}
           badgeEnhancerContent={badgeEnhancerContent}
           labelEnhancerContent={labelEnhancerContent}
           labelEnhancerPosition={labelEnhancerPosition}
-          labelEnhancerColor={labelEnhancerColor}
-          labelEnhancerStrokeColor={labelEnhancerStrokeColor}
           needle={needle}
         />
         {renderNeedle && (

--- a/src/map-marker/fixed-marker.js
+++ b/src/map-marker/fixed-marker.js
@@ -11,68 +11,19 @@ import {getOverrides} from '../helpers/overrides.js';
 import {
   PINHEAD_TYPES,
   NEEDLE_SIZES,
-  NEEDLE_HEIGHTS,
   PINHEAD_SIZES_SHAPES,
   LABEL_ENHANCER_POSITIONS,
   dragShadowHeight,
   dragShadowMarginTop,
-  dragShadowWidth,
 } from './constants.js';
 import PinHead from './pin-head.js';
+import Needle from './needle.js';
+import DragShadow from './drag-shadow.js';
 import {
   StyledFixedMarkerDragContainer,
   StyledFixedMarkerRoot,
-  StyledNeedle,
-  StyledDragShadow,
-  StyledDragShadowContainer,
 } from './styled-components.js';
-import type {
-  FixedMarkerPropsT,
-  NeedlePropsT,
-  DragShadowPropsT,
-} from './types.js';
-
-const Needle = ({size, background, overrides = {}}: NeedlePropsT) => {
-  const [Needle, needleProps] = getOverrides(overrides.Needle, StyledNeedle);
-  return (
-    <Needle
-      $background={background}
-      $height={NEEDLE_HEIGHTS[size]}
-      {...needleProps}
-    />
-  );
-};
-
-const DragShadow = ({
-  background,
-  dragging,
-  height,
-  overrides = {},
-}: DragShadowPropsT) => {
-  const [DragShadowContainer, dragShadowContainerProps] = getOverrides(
-    overrides.DragShadowContainer,
-    StyledDragShadowContainer,
-  );
-  const [DragShadow, dragShadowProps] = getOverrides(
-    overrides.DragShadow,
-    StyledDragShadow,
-  );
-
-  return (
-    <DragShadowContainer
-      $width={dragShadowWidth}
-      $height={height}
-      $dragging={dragging}
-      {...dragShadowContainerProps}
-    >
-      <DragShadow
-        $width={dragShadowWidth}
-        $background={background}
-        {...dragShadowProps}
-      />
-    </DragShadowContainer>
-  );
-};
+import type {FixedMarkerPropsT} from './types.js';
 
 const FixedMarker = ({
   size = PINHEAD_SIZES_SHAPES.medium,

--- a/src/map-marker/index.d.ts
+++ b/src/map-marker/index.d.ts
@@ -96,8 +96,6 @@ export type ItemPropsT = {
 export type LabelEnhancerT = {
   labelEnhancerContent?: string;
   labelEnhancerPosition?: LabelEnhancerPositionT;
-  labelEnhancerColor?: string;
-  labelEnhancerStrokeColor?: string;
 };
 
 export type LabelEhancerComponentT = LabelEnhancerT & {
@@ -108,8 +106,6 @@ export type LabelEhancerComponentT = LabelEnhancerT & {
 
 export type BadgeEnhancerT = {
   badgeEnhancerSize?: BadgeEnhancerSizeT | null;
-  badgeEnhancerColor?: string | null;
-  badgeEnhancerBackground?: string | null;
   badgeEnhancerContent?: (props: {size: number}) => React.ReactNode;
 };
 

--- a/src/map-marker/label-enhancer.js
+++ b/src/map-marker/label-enhancer.js
@@ -18,8 +18,6 @@ import type {LabelEhancerComponentT} from './types.js';
 const LabelEnhancer = ({
   labelEnhancerContent,
   labelEnhancerPosition,
-  labelEnhancerColor,
-  labelEnhancerStrokeColor,
   needleHeight,
   size,
   overrides = {},
@@ -50,12 +48,7 @@ const LabelEnhancer = ({
       {...strokedLabelContainerProps}
     >
       <RelativeContainer>
-        <StrokedLabel
-          $color={labelEnhancerColor}
-          $strokeColor={labelEnhancerStrokeColor}
-          $size={size}
-          {...strokedLabelProps}
-        >
+        <StrokedLabel $size={size} {...strokedLabelProps}>
           {labelEnhancerContent}
         </StrokedLabel>
       </RelativeContainer>

--- a/src/map-marker/needle.js
+++ b/src/map-marker/needle.js
@@ -1,0 +1,25 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+import * as React from 'react';
+import {getOverrides} from '../helpers/overrides.js';
+import {NEEDLE_HEIGHTS} from './constants.js';
+import {StyledNeedle} from './styled-components.js';
+import type {NeedlePropsT} from './types.js';
+
+const Needle = ({size, background, overrides = {}}: NeedlePropsT) => {
+  const [Needle, needleProps] = getOverrides(overrides.Needle, StyledNeedle);
+  return (
+    <Needle
+      $background={background}
+      $height={NEEDLE_HEIGHTS[size]}
+      {...needleProps}
+    />
+  );
+};
+
+export default Needle;

--- a/src/map-marker/pin-head.js
+++ b/src/map-marker/pin-head.js
@@ -39,11 +39,7 @@ const PinHead = ({
   needle = NEEDLE_SIZES.none,
   labelEnhancerContent,
   labelEnhancerPosition,
-  labelEnhancerColor,
-  labelEnhancerStrokeColor,
   badgeEnhancerSize,
-  badgeEnhancerColor,
-  badgeEnhancerBackground,
   badgeEnhancerContent,
 
   overrides = {},
@@ -85,8 +81,6 @@ const PinHead = ({
       markerType={type}
       pinHeadSize={size}
       badgeEnhancerSize={badgeEnhancerSize}
-      badgeEnhancerColor={badgeEnhancerColor}
-      badgeEnhancerBackground={badgeEnhancerBackground}
       badgeEnhancerContent={badgeEnhancerContent}
       overrides={overrides}
     />
@@ -145,8 +139,6 @@ const PinHead = ({
       <LabelEnhancer
         labelEnhancerContent={labelEnhancerContent}
         labelEnhancerPosition={labelEnhancerPosition}
-        labelEnhancerColor={labelEnhancerColor}
-        labelEnhancerStrokeColor={labelEnhancerStrokeColor}
         needleHeight={NEEDLE_HEIGHTS[needle]}
         size={size}
         overrides={overrides}

--- a/src/map-marker/styled-components.js
+++ b/src/map-marker/styled-components.js
@@ -253,15 +253,12 @@ export const StyledStrokedLabelContainer = styled<{
 });
 
 export const StyledStrokedLabel = styled<{
-  $color: string,
-  $strokeColor: string,
   $stroked: boolean,
   $position: LabelEnhancerPositionT,
   $size: PinHeadSizeT,
-}>('div', ({$theme, $color, $strokeColor, $size}) => {
+}>('div', ({$theme, $size}) => {
   const strokeWidth = 1.5;
-  const strokeColor = $strokeColor || $theme.colors.backgroundPrimary;
-  const color = $color || $theme.colors.primaryA;
+  const strokeColor = $theme.colors.backgroundPrimary;
 
   const textShadow = `-${strokeWidth}px -${strokeWidth}px 0 ${strokeColor},
     0 -${strokeWidth}px 0 ${strokeColor},
@@ -275,7 +272,7 @@ export const StyledStrokedLabel = styled<{
   return {
     display: 'flex',
     ...$theme.typography[LABEL_SIZES[$size]],
-    color,
+    color: $theme.colors.primaryA,
     transition: `${$theme.animation.timing300} ${$theme.animation.easeOutCurve} all`,
     textShadow,
     pointerEvents: 'auto',
@@ -287,15 +284,13 @@ export const StyledStrokedLabel = styled<{
 export const StyledBadgeEnhancerRoot = styled<{
   $size: BadgeEnhancerSizeT,
   $position: BadgePositionT,
-  $background: string,
-  $color: string,
-}>('div', ({$theme, $size, $position, $background, $color}) => {
+}>('div', ({$theme, $size, $position}) => {
   const {x, y} = $position;
   return {
     position: 'absolute',
     ...$theme.typography.LabelSmall,
-    backgroundColor: $background || $theme.colors.backgroundAccent,
-    color: $color || $theme.colors.primaryB,
+    backgroundColor: $theme.colors.backgroundAccent,
+    color: $theme.colors.primaryB,
     boxSizing: 'border-box',
     right: 0,
     transform: `translate(calc(100% + ${x}px), ${y}px)`,

--- a/src/map-marker/types.js
+++ b/src/map-marker/types.js
@@ -68,8 +68,6 @@ export type ItemPropsT = {
 export type LabelEnhancerT = {|
   labelEnhancerContent?: string,
   labelEnhancerPosition?: LabelEnhancerPositionT,
-  labelEnhancerColor?: string,
-  labelEnhancerStrokeColor?: string,
 |};
 
 export type LabelEhancerComponentT = {
@@ -81,8 +79,6 @@ export type LabelEhancerComponentT = {
 
 export type BadgeEnhancerT = {|
   badgeEnhancerSize?: BadgeEnhancerSizeT | null,
-  badgeEnhancerColor?: string | null,
-  badgeEnhancerBackground?: string | null,
   badgeEnhancerContent?: React.AbstractComponent<{|size: number|}>,
 |};
 
@@ -97,7 +93,7 @@ export type BadgePositionT = {
   y: number,
 };
 
-export type FixedMarkerPropsT = {
+export type FixedMarkerPropsT = {|
   size?: PinHeadSizeT,
   needle?: NeedleSizeT,
   label?: string,
@@ -109,7 +105,7 @@ export type FixedMarkerPropsT = {
   overrides?: FixedMarkerOverridesT,
   ...BadgeEnhancerT,
   ...LabelEnhancerT,
-};
+|};
 
 export type FloatingMarkerOverridesT = {
   Root?: OverrideT,


### PR DESCRIPTION
#### Description

Remove `badgeEnhancerColor`, `badgeEnhancerBackground` and `labelEnhancerColor`, `labelEnhancerStrokeColor` properties, but still allow to configure them via overrides

#### Scope
Patch: Bug Fix
