### PR TITLE
feat(progress-bar): add minValue and maxValue

### DIFF
--- a/documentation-site/components/yard/config/progress-bar.ts
+++ b/documentation-site/components/yard/config/progress-bar.ts
@@ -65,11 +65,17 @@ const ProgressBarConfig: TConfig = {
       description:
         'Defines how many steps the progress bar has. Defaults to 1.',
     },
-    successValue: {
-      value: 100,
+    minValue: {
+      value: '0',
+      defaultValue: '0',
       type: PropTypes.Number,
-      description: 'A custom completion value. Will be removed in v11.',
-      hidden: true,
+      description: 'The smallest value allowed.',
+    },
+    maxValue: {
+      value: '100',
+      defaultValue: '100',
+      type: PropTypes.Number,
+      description: 'The biggest value allowed.',
     },
     errorMessage: {
       value: undefined,

--- a/documentation-site/pages/components/progress-bar.mdx
+++ b/documentation-site/pages/components/progress-bar.mdx
@@ -38,8 +38,6 @@ Indicates a wait time for actions - either within an experience flow or loading 
   - `aria-valuenow={value}`
   - `aria-valuemin={0}`
   - `aria-valuemax={100}`
-- It's important to normalize the value in the range 0 - 100 to properly support screen-reader users. You can apply this formula:
-  - `(value - MIN) * 100 / (MAX - MIN)`
 
 ## Examples
 

--- a/src/progress-bar/__tests__/progressbar.scenario.js
+++ b/src/progress-bar/__tests__/progressbar.scenario.js
@@ -15,11 +15,22 @@ export function Scenario() {
     <>
       <ProgressBar value={20} showLabel size={SIZE.small} />
       <br />
+      <ProgressBar value={120} minValue={100} maxValue={200} showLabel />
+      <br />
       <ProgressBar value={20} showLabel />
       <br />
       <ProgressBar value={20} showLabel size={SIZE.large} />
       <br />
       <ProgressBar value={20} showLabel size={SIZE.large} steps={5} />
+      <br />
+      <ProgressBar
+        value={120}
+        minValue={100}
+        maxValue={200}
+        showLabel
+        size={SIZE.large}
+        steps={10}
+      />
       <br />
       <ProgressBar infinite />
     </>

--- a/src/progress-bar/index.d.ts
+++ b/src/progress-bar/index.d.ts
@@ -25,6 +25,8 @@ export interface ProgressBarProps {
   showLabel?: boolean;
   steps?: number;
   successValue?: number;
+  minValue?: number;
+  mxaValue?: number;
   value?: number;
 }
 export class ProgressBar extends React.Component<ProgressBarProps> {}

--- a/src/progress-bar/progressbar.js
+++ b/src/progress-bar/progressbar.js
@@ -24,14 +24,18 @@ class ProgressBar extends React.Component<
   ProgressBarPropsT & {forwardedRef: any},
 > {
   static defaultProps = {
-    getProgressLabel: (value: number, successValue: number) =>
-      `${Math.round((value / successValue) * 100)}% Loaded`,
+    getProgressLabel: (value: number, maxValue: number, minValue: number) =>
+      `${Math.round(
+        ((value - minValue) / (maxValue - minValue)) * 100,
+      )}% Loaded`,
     infinite: false,
     overrides: {},
     showLabel: false,
     size: SIZE.medium,
     steps: 1,
     successValue: 100,
+    minValue: 0,
+    maxValue: 100,
     value: 0,
   };
 
@@ -55,12 +59,16 @@ class ProgressBar extends React.Component<
       size,
       steps,
       successValue,
+      minValue,
+      maxValue,
       showLabel,
       infinite,
       errorMessage,
       forwardedRef,
       ...restProps
     } = this.props;
+    // fallback on successValue (and it's default) if maxValue is not set by user
+    const maximumValue = maxValue !== 100 ? maxValue : successValue;
     const [Root, rootProps] = getOverrides(overrides.Root, StyledRoot);
     const [BarContainer, barContainerProps] = getOverrides(
       overrides.BarContainer,
@@ -80,7 +88,9 @@ class ProgressBar extends React.Component<
       $infinite: infinite,
       $size: size,
       $steps: steps,
-      $successValue: successValue,
+      $successValue: maximumValue,
+      $minValue: minValue,
+      $maxValue: maximumValue,
       $value: value,
     };
     function renderProgressBar() {
@@ -100,10 +110,12 @@ class ProgressBar extends React.Component<
         ref={forwardedRef}
         data-baseweb="progress-bar"
         role="progressbar"
-        aria-label={ariaLabel || getProgressLabel(value, successValue)}
+        aria-label={
+          ariaLabel || getProgressLabel(value, maximumValue, minValue)
+        }
         aria-valuenow={infinite ? null : value}
-        aria-valuemin={infinite ? null : 0}
-        aria-valuemax={infinite ? null : successValue}
+        aria-valuemin={infinite ? null : minValue}
+        aria-valuemax={infinite ? null : maximumValue}
         aria-invalid={errorMessage ? true : null}
         aria-errormessage={errorMessage}
         {...restProps}
@@ -126,7 +138,7 @@ class ProgressBar extends React.Component<
         </BarContainer>
         {showLabel && (
           <Label {...sharedProps} {...labelProps}>
-            {getProgressLabel(value, successValue)}
+            {getProgressLabel(value, maximumValue, minValue)}
           </Label>
         )}
       </Root>

--- a/src/progress-bar/styled-components.js
+++ b/src/progress-bar/styled-components.js
@@ -62,9 +62,20 @@ export const StyledBar = styled<StylePropsT>('div', props => {
 });
 
 export const StyledBarProgress = styled<StylePropsT>('div', props => {
-  const {$theme, $value, $successValue, $steps, $index} = props;
+  const {
+    $theme,
+    $value,
+    $successValue,
+    $steps,
+    $index,
+    $maxValue,
+    $minValue = 0,
+  } = props;
+  // making sure this doesn't break existing use that use StyledBarProgress directly
+  const maxValue = $maxValue ? $maxValue : $successValue;
   const {colors, sizing, borders} = $theme;
-  const width = `${100 - ($value / $successValue) * 100}%`;
+  const width = `${100 -
+    (($value - $minValue) * 100) / (maxValue - $minValue)}%`;
 
   const stepStates = {
     default: 'default',
@@ -74,8 +85,8 @@ export const StyledBarProgress = styled<StylePropsT>('div', props => {
   };
   let stepState = stepStates.default;
   if ($steps > 1) {
-    const stepValue = $successValue / $steps;
-    const currentValue = ($value / $successValue) * 100;
+    const stepValue = (maxValue - $minValue) / $steps;
+    const currentValue = (($value - $minValue) / (maxValue - $minValue)) * 100;
     const completedSteps = Math.floor(currentValue / stepValue);
     if ($index < completedSteps) {
       stepState = stepStates.completed;

--- a/src/progress-bar/types.js
+++ b/src/progress-bar/types.js
@@ -27,7 +27,11 @@ export type ProgressBarPropsT = {
   /** Error message for screen-reader users**/
   errorMessage?: string,
   /** The function that returns a progress bar label to display. */
-  getProgressLabel: (value: number, successValue: number) => React.Node,
+  getProgressLabel: (
+    value: number,
+    maxValue: number,
+    minValue: number,
+  ) => React.Node,
   /** If set to true, there’s and infinite loading animation. */
   infinite: boolean,
   overrides?: OverridesT,
@@ -37,8 +41,12 @@ export type ProgressBarPropsT = {
   size: SizeT,
   /** Renders a sectional progress bar. Value should be set to a positive number larger than one. */
   steps: number,
-  /** A custom completion value. Should be deleted in v11. */
+  /** A custom completion value. Should be replaced by maxValue prop. */
   successValue: number,
+  /** Maximum possible value. */
+  maxValue: number,
+  /** Minimum possible value. */
+  minValue: number,
   /** The value between `0` and `100 | successValue` of the progress indicator. */
   value: number,
 };
@@ -49,6 +57,8 @@ export type StylePropsT = {
   $size: SizeT,
   $steps: number,
   $successValue: number,
+  $minValue: number,
+  $maxValue: number,
   $value: number,
 };
 


### PR DESCRIPTION
Adds `minValue` and `maxValue` while `successValue` still works as a fallback to `maxValue`. I think it makes sense to preserve the range functionality since the [progress element](https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element) has `max` attribute and having `min` is nice to have so the user doesn't have to normalize values manually.

Some other component libraries like [react-spectrum](https://react-spectrum.adobe.com/react-spectrum/ProgressBar.html) also gives user `minValue` and `maxValue`.
