### PR TITLE
chore(map-marker): add kind property to fixed marker

### DIFF
--- a/documentation-site/components/yard/config/fixed-marker.ts
+++ b/documentation-site/components/yard/config/fixed-marker.ts
@@ -2,6 +2,7 @@ import {
   FixedMarker,
   PINHEAD_SIZES_SHAPES,
   NEEDLE_SIZES,
+  KIND,
   BADGE_ENHANCER_SIZES,
   LABEL_ENHANCER_POSITIONS,
 } from 'baseui/map-marker';
@@ -76,17 +77,18 @@ export const fixedMarkerProps = {
       },
     },
   },
-  background: {
-    value: undefined,
-    placeholder: '#000',
-    type: PropTypes.String,
-    description: 'Color to render for background.',
-  },
-  color: {
-    value: undefined,
-    placeholder: '#fff',
-    type: PropTypes.String,
-    description: 'Color to render for content.',
+  kind: {
+    value: 'KIND.default',
+    enumName: 'KIND',
+    defaultValue: 'KIND.default',
+    options: KIND,
+    type: PropTypes.Enum,
+    description: 'Kind changes colors of the PinHead, Needle and DragShadow.',
+    imports: {
+      'baseui/map-marker': {
+        named: ['KIND'],
+      },
+    },
   },
   badgeEnhancerSize: {
     value: 'BADGE_ENHANCER_SIZES.none',
@@ -145,6 +147,7 @@ const FixedMarkerConfig: TConfig = {
   scope: {
     FixedMarker,
     NEEDLE_SIZES,
+    KIND,
     PINHEAD_SIZES_SHAPES,
     BADGE_ENHANCER_SIZES,
     Check,

--- a/documentation-site/components/yard/config/floating-marker.ts
+++ b/documentation-site/components/yard/config/floating-marker.ts
@@ -70,18 +70,6 @@ export const floatingMarkerProps = {
     description:
       'Icon or element to render in the trailing slot (after the label).',
   },
-  background: {
-    value: undefined,
-    placeholder: '#000',
-    type: PropTypes.String,
-    description: 'Color to render for background.',
-  },
-  color: {
-    value: undefined,
-    placeholder: '#fff',
-    type: PropTypes.String,
-    description: 'Color to render for content.',
-  },
 };
 
 const FloatingMarkerConfig: TConfig = {

--- a/documentation-site/examples/fixed-marker/end-enhancer-color.js
+++ b/documentation-site/examples/fixed-marker/end-enhancer-color.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import {FixedMarker} from 'baseui/map-marker';
+import {FixedMarker, KIND} from 'baseui/map-marker';
 import DeleteAlt from 'baseui/icon/delete-alt';
 
 export default function Example() {
@@ -8,8 +8,7 @@ export default function Example() {
     <FixedMarker
       label="Illegal Dropoff"
       endEnhancer={({size}) => <DeleteAlt size={size} />}
-      color="white"
-      background="#E11900"
+      kind={KIND.negative}
     />
   );
 }

--- a/documentation-site/examples/fixed-marker/end-enhancer-color.tsx
+++ b/documentation-site/examples/fixed-marker/end-enhancer-color.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {FixedMarker} from 'baseui/map-marker';
+import {FixedMarker, KIND} from 'baseui/map-marker';
 import {DeleteAlt} from 'baseui/icon';
 
 export default function Example() {
@@ -9,8 +9,7 @@ export default function Example() {
       endEnhancer={({size}: {size: number}) => (
         <DeleteAlt size={size} />
       )}
-      color="white"
-      background="#E11900"
+      kind={KIND.negative}
     />
   );
 }

--- a/documentation-site/pages/blog/introducing-base-map-markers/index.mdx
+++ b/documentation-site/pages/blog/introducing-base-map-markers/index.mdx
@@ -87,4 +87,4 @@ Interested in learning more about the Base map marker? Check out these resources
 - [How I programmatically built 256 new design system components in Figma](https://medium.com/uber-design/how-i-programmatically-built-256-new-design-system-components-in-figma-84ee26d119c1)
 - [Usage rules for Base map markers at Uber](https://base.uber.com/map-usage-markers)
 
-Thanks to Kelly Hudiono for the help developing this component.
+Thanks to Kelly Hudiono and Filip Spiridonov for the help developing this component.

--- a/documentation-site/pages/components/fixed-marker.mdx
+++ b/documentation-site/pages/components/fixed-marker.mdx
@@ -51,6 +51,7 @@ For more information on the design principles behind the Base map markers, pleas
   - The `xxSmall` or `xSmall` pinhead sizes cannot contain any content.
 - A fixed marker may have either no needle or a choice of 3 different sizes: `short`, `medium`, or `tall`.
 - A fixed marker without a label can only have one icon. As such, do not use both a `startEnhancer` and an `endEnhancer` if there is no label.
+- A fixed marker can have a kind property that changes the colors of PinHead, PinHeadContent, Needle and DragShadow.
 - A fixed marker can have a badge enhancer of the following sizes: `xSmall`, `small`, `mediumText`, `mediumIcon`.
   - The `xSmall` cannot have any content.
   - The `small` can only have an icon as a content.
@@ -88,7 +89,7 @@ A fixed map marker with a start enhancer icon and a label. Icons can be passed t
   <EndEnhancerColor />
 </Example>
 
-A fixed map marker with an end enhancer icon, a label, and custom styling. Background and color properties can be modified.
+A fixed map marker with an end enhancer icon, a label, and custom styling.
 
 <Example
   title="Large size with only an icon"

--- a/documentation-site/pages/components/floating-marker.mdx
+++ b/documentation-site/pages/components/floating-marker.mdx
@@ -53,7 +53,6 @@ For more information on the design principles behind the Base map markers, pleas
 
 ### General
 
-- A floating marker's background or color should not be customized beyond the default light and dark theme.
 - A floating marker may either have no anchor, a square anchor, a circular anchor, or an xx small circular anchor.
 - The anchor of a floating marker can be attached to any of the four corners of the marker.
 - A floating marker without a label can only have one icon. Do not use both a `startEnhancer` and an `endEnhancer` if there is no label.

--- a/src/map-marker/__tests__/eats-pickup-marker.scenario.js
+++ b/src/map-marker/__tests__/eats-pickup-marker.scenario.js
@@ -93,6 +93,22 @@ export function Scenario() {
                       ),
                   },
                 },
+                PinHead: {
+                  style: {
+                    backgroundColor:
+                      hoveredLocationIndex === 0 || selectedLocationIndex === 0
+                        ? theme.colors.backgroundInverseSecondary
+                        : theme.colors.backgroundPrimary,
+                  },
+                },
+                PinHeadContent: {
+                  style: {
+                    color:
+                      hoveredLocationIndex === 0 || selectedLocationIndex === 0
+                        ? theme.colors.primaryB
+                        : theme.colors.primaryA,
+                  },
+                },
                 BadgeEnhancer: {
                   style: () => ({
                     boxShadow: theme.lighting.shadow600,
@@ -115,16 +131,6 @@ export function Scenario() {
               }
               badgeEnhancerSize={BADGE_ENHANCER_SIZES.mediumIcon}
               badgeEnhancerContent={({size}) => <Search size={size} />}
-              background={
-                hoveredLocationIndex === 0 || selectedLocationIndex === 0
-                  ? theme.colors.backgroundInverseSecondary
-                  : theme.colors.backgroundPrimary
-              }
-              color={
-                hoveredLocationIndex === 0 || selectedLocationIndex === 0
-                  ? theme.colors.primaryB
-                  : theme.colors.primaryA
-              }
             />
           </Marker>
 
@@ -176,6 +182,22 @@ export function Scenario() {
                       ),
                   },
                 },
+                PinHead: {
+                  style: {
+                    backgroundColor:
+                      hoveredLocationIndex === 2 || selectedLocationIndex === 2
+                        ? theme.colors.backgroundInverseSecondary
+                        : theme.colors.backgroundPrimary,
+                  },
+                },
+                PinHeadContent: {
+                  style: {
+                    color:
+                      hoveredLocationIndex === 2 || selectedLocationIndex === 2
+                        ? theme.colors.primaryB
+                        : theme.colors.primaryA,
+                  },
+                },
                 BadgeEnhancer: {
                   style: () => ({
                     boxShadow: theme.lighting.shadow600,
@@ -198,16 +220,6 @@ export function Scenario() {
               }
               badgeEnhancerSize={BADGE_ENHANCER_SIZES.mediumText}
               badgeEnhancerContent={() => 'New'}
-              background={
-                hoveredLocationIndex === 2 || selectedLocationIndex === 2
-                  ? theme.colors.backgroundInverseSecondary
-                  : theme.colors.backgroundPrimary
-              }
-              color={
-                hoveredLocationIndex === 2 || selectedLocationIndex === 2
-                  ? theme.colors.primaryB
-                  : theme.colors.primaryA
-              }
             />
           </Marker>
         </ReactMapGL>

--- a/src/map-marker/constants.js
+++ b/src/map-marker/constants.js
@@ -214,3 +214,9 @@ export const BADGE_ENHANCER_CONTENT_SIZE = {
   [BADGE_ENHANCER_SIZES.mediumText]: 12,
   [BADGE_ENHANCER_SIZES.mediumIcon]: 12,
 };
+
+export const KIND = Object.freeze({
+  default: 'default',
+  accent: 'accent',
+  negative: 'negative',
+});

--- a/src/map-marker/fixed-marker.js
+++ b/src/map-marker/fixed-marker.js
@@ -6,13 +6,14 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 import * as React from 'react';
-import {useStyletron} from '../styles/index.js';
+import {useStyletron, type ThemeT} from '../styles/index.js';
 import {getOverrides} from '../helpers/overrides.js';
 import {
   PINHEAD_TYPES,
   NEEDLE_SIZES,
   PINHEAD_SIZES_SHAPES,
   LABEL_ENHANCER_POSITIONS,
+  KIND,
   dragShadowHeight,
   dragShadowMarginTop,
 } from './constants.js';
@@ -23,7 +24,31 @@ import {
   StyledFixedMarkerDragContainer,
   StyledFixedMarkerRoot,
 } from './styled-components.js';
-import type {FixedMarkerPropsT} from './types.js';
+import type {FixedMarkerPropsT, KindT} from './types.js';
+
+type Colors = {
+  color: string,
+  backgroundColor: string,
+};
+
+function getColors(kind: KindT, theme: ThemeT): Colors {
+  if (kind === KIND.accent) {
+    return {
+      color: theme.colors.contentInversePrimary,
+      backgroundColor: theme.colors.backgroundAccent,
+    };
+  }
+  if (kind === KIND.negative) {
+    return {
+      color: theme.colors.contentInversePrimary,
+      backgroundColor: theme.colors.backgroundNegative,
+    };
+  }
+  return {
+    color: theme.colors.contentInversePrimary,
+    backgroundColor: theme.colors.backgroundInversePrimary,
+  };
+}
 
 const FixedMarker = ({
   size = PINHEAD_SIZES_SHAPES.medium,
@@ -31,8 +56,7 @@ const FixedMarker = ({
   label,
   startEnhancer,
   endEnhancer,
-  color,
-  background,
+  kind = KIND.default,
   dragging = false,
   overrides = {},
   labelEnhancerContent = null,
@@ -42,12 +66,7 @@ const FixedMarker = ({
   ...restProps
 }: FixedMarkerPropsT) => {
   const [, theme] = useStyletron();
-  const {
-    colors: {backgroundInversePrimary, primaryB},
-  } = theme;
-
-  color = color || primaryB;
-  background = background || backgroundInversePrimary;
+  const {color, backgroundColor} = getColors(kind, theme);
 
   const doesPinHeadTransformOnDrag =
     needle !== NEEDLE_SIZES.none &&
@@ -94,7 +113,7 @@ const FixedMarker = ({
           {...(startEnhancer ? {startEnhancer} : {})}
           {...(endEnhancer ? {endEnhancer} : {})}
           color={color}
-          background={background}
+          background={backgroundColor}
           type={PINHEAD_TYPES.fixed}
           overrides={overrides}
           badgeEnhancerSize={badgeEnhancerSize}
@@ -104,12 +123,16 @@ const FixedMarker = ({
           needle={needle}
         />
         {renderNeedle && (
-          <Needle size={needle} background={background} overrides={overrides} />
+          <Needle
+            size={needle}
+            background={backgroundColor}
+            overrides={overrides}
+          />
         )}
       </FixedMarkerDragContainer>
       {doesPinHeadTransformOnDrag && (
         <DragShadow
-          background={background}
+          background={backgroundColor}
           dragging={dragging}
           height={dragShadowMarginTop + dragShadowHeight}
           overrides={overrides}

--- a/src/map-marker/floating-marker.js
+++ b/src/map-marker/floating-marker.js
@@ -36,8 +36,6 @@ function getAnchorPinHeadSize(anchorType) {
 }
 
 const FloatingMarker = ({
-  color,
-  background,
   label,
   size = PINHEAD_SIZES_SHAPES.medium,
   anchor = FLOATING_MARKER_ANCHOR_POSITIONS.bottomLeft,
@@ -50,8 +48,6 @@ const FloatingMarker = ({
   const {
     colors: {backgroundPrimary, backgroundInversePrimary, primaryA, primaryB},
   } = theme;
-  color = color || primaryA;
-  background = background || backgroundPrimary;
 
   const anchorPinHeadSize = getAnchorPinHeadSize(anchorType);
 
@@ -88,8 +84,8 @@ const FloatingMarker = ({
       >
         <PinHead
           size={size}
-          color={color}
-          background={background}
+          color={primaryA}
+          background={backgroundPrimary}
           type={PINHEAD_TYPES.floating}
           label={label}
           startEnhancer={startEnhancer}

--- a/src/map-marker/index.d.ts
+++ b/src/map-marker/index.d.ts
@@ -54,6 +54,12 @@ export interface LABEL_ENHANCER_POSITIONS {
   bottom: 'bottom';
 }
 
+export interface KIND {
+  default: 'default';
+  accent: 'accent';
+  negative: 'negative';
+}
+
 interface PINHEAD_TYPES {
   floating: 'floating';
   fixed: 'fixed';
@@ -67,6 +73,7 @@ export type FloatingMarkerSizeT = FLOATING_MARKER_SIZES[keyof FLOATING_MARKER_SI
 export type FloatingMarkerAnchorTypeT = FLOATING_MARKER_ANCHOR_TYPES[keyof FLOATING_MARKER_ANCHOR_TYPES];
 export type BadgeEnhancerSizeT = BADGE_ENHANCER_SIZES[keyof BADGE_ENHANCER_SIZES];
 export type LabelEnhancerPositionT = LABEL_ENHANCER_POSITIONS[keyof LABEL_ENHANCER_POSITIONS];
+export type KindT = KIND[keyof KIND];
 
 export type FixedMarkerOverridesT = {
   Root?: Override<any>;
@@ -127,6 +134,7 @@ export type FixedMarkerPropsT = BadgeEnhancerT &
     label?: string;
     startEnhancer?: (props: {size: number}) => React.ReactNode;
     endEnhancer?: (props: {size: number}) => React.ReactNode;
+    kind?: KindT;
     color?: string;
     background?: string;
     dragging?: boolean;
@@ -151,8 +159,6 @@ export type FloatingMarkerOverridesT = {
 };
 
 export type FloatingMarkerPropsT = {
-  color?: string;
-  background?: string;
   label?: string;
   anchor?: AnchorPositionsT;
   endEnhancer?: (props: {size: number}) => React.ReactNode;
@@ -190,6 +196,7 @@ export const NEEDLE_SIZES: NEEDLE_SIZES;
 export const PINHEAD_SIZES_SHAPES: PINHEAD_SIZES_SHAPES;
 export const BADGE_ENHANCER_SIZES: BADGE_ENHANCER_SIZES;
 export const LABEL_ENHANCER_POSITIONS: LABEL_ENHANCER_POSITIONS;
+export const KIND: KIND;
 
 export const FixedMarker: React.FC<FixedMarkerPropsT>;
 export const FloatingMarker: React.FC<FloatingMarkerPropsT>;

--- a/src/map-marker/index.js
+++ b/src/map-marker/index.js
@@ -16,6 +16,7 @@ export {
   PINHEAD_SIZES_SHAPES,
   BADGE_ENHANCER_SIZES,
   LABEL_ENHANCER_POSITIONS,
+  KIND,
 } from './constants.js';
 
 export type * from './types.js';

--- a/src/map-marker/types.js
+++ b/src/map-marker/types.js
@@ -15,6 +15,7 @@ import {
   FLOATING_MARKER_ANCHOR_TYPES,
   BADGE_ENHANCER_SIZES,
   LABEL_ENHANCER_POSITIONS,
+  KIND,
 } from './constants.js';
 import type {OverrideT} from '../helpers/overrides.js';
 
@@ -36,6 +37,8 @@ export type FloatingMarkerAnchorTypeT = $Values<
 export type BadgeEnhancerSizeT = $Values<typeof BADGE_ENHANCER_SIZES>;
 
 export type LabelEnhancerPositionT = $Values<typeof LABEL_ENHANCER_POSITIONS>;
+
+export type KindT = $Values<typeof KIND>;
 
 export type FixedMarkerOverridesT = {
   Root?: OverrideT,
@@ -99,8 +102,7 @@ export type FixedMarkerPropsT = {|
   label?: string,
   startEnhancer?: React.AbstractComponent<{|size: number|}>,
   endEnhancer?: React.AbstractComponent<{|size: number|}>,
-  color?: string,
-  background?: string,
+  kind?: KindT,
   dragging?: boolean,
   overrides?: FixedMarkerOverridesT,
   ...BadgeEnhancerT,
@@ -125,8 +127,6 @@ export type FloatingMarkerOverridesT = {
 };
 
 export type FloatingMarkerPropsT = {
-  color?: string,
-  background?: string,
   label?: string,
   anchor?: AnchorPositionsT,
   endEnhancer?: React.AbstractComponent<{|size: number|}>,


### PR DESCRIPTION
#### Description

Add `kind`: (`default`, `accent`, `negative`) property to the fixed marker. The colors can still be changed using overrides.

#### Scope
Patch: Bug Fix
