### PR TITLE
fix(map-marker): mistake during merging conflicts

### DIFF
--- a/src/map-marker/__tests__/tile-grid.js
+++ b/src/map-marker/__tests__/tile-grid.js
@@ -53,21 +53,14 @@ const TileGrid = ({children, customizerOptions, cols}: TileGridPropsT) => {
               >
                 <LabelSmall color={contentSecondary}>{label}</LabelSmall>
                 <Block
+                  alignItems="center"
+                  justifyContent="center"
+                  flex="1"
                   display="flex"
-                  flexDirection="column"
-                  height="150px"
-                  key={index}
                 >
-                  <Label3 color={contentSecondary}>{label}</Label3>
-                  <Block
-                    alignItems="center"
-                    justifyContent="center"
-                    flex="1"
-                    display="flex"
-                  >
-                    {content}
-                  </Block>
+                  {content}
                 </Block>
+              </Block>
             );
           })}
       </Block>


### PR DESCRIPTION
#### Description
The following piece had to be removed:
```
<Block
                  display="flex"
                  flexDirection="column"
                  height="150px"
                  key={index}
                >
                  <Label3 color={contentSecondary}>{label}</Label3>
```

#### Scope
Patch: Bug Fix
