### PR TITLE
feat(modal): removes no-capitalization autofocus prop

### DIFF
--- a/documentation-site/pages/components/modal.mdx
+++ b/documentation-site/pages/components/modal.mdx
@@ -45,7 +45,7 @@ of bounds dismissal. The primary action is always a system red with a grey cance
 
 We have built in functionality based on the recommendations for dialogs and modals in [WAI-ARIA Authoring Practices 1.1](https://www.w3.org/TR/wai-aria-practices/#dialog_modal).
 
-- Upon opening, focus will be transferred to the first interactive element (unless `autofocus` is set to false)
+- Upon opening, focus will be transferred to the first interactive element (unless `autoFocus` is set to false)
 - Dialog element has `aria-modal="true"`
 - Explicitly exposes a `role` prop to control whether `dialog` or `alertdialog` is used.
 - `Tab` key moves between focusable items (form inputs, footer buttons, etc). User should not be able to tab to items outside of modal.
@@ -88,7 +88,7 @@ Ideally, we want to avoid an abrupt shift in context both visually and for scree
 
 You can achieve this with the `FocusOnce` utility component included in `baseui/modal`.
 To use it, wrap a non interactive element at the top of the modal in `FocusOnce`.
-This will allow the element to be targeted by `autofocus`.
+This will allow the element to be targeted by `autoFocus`.
 Once the user tabs away, the element will be removed from the tab ordering.
 
 <Example title="Adding nested modals" path="modal/nested.js">

--- a/src/modal/index.d.ts
+++ b/src/modal/index.d.ts
@@ -44,10 +44,12 @@ export interface ModalOverrides {
 }
 export interface ModalProps {
   animate?: boolean;
-  autofocus?: boolean;
   autoFocus?: boolean;
   focusLock?: boolean;
-  returnFocus?: boolean | FocusOptions | ((returnTo: Element) => boolean | FocusOptions);
+  returnFocus?:
+    | boolean
+    | FocusOptions
+    | ((returnTo: Element) => boolean | FocusOptions);
   children?: React.ReactNode;
   closeable?: boolean;
   isOpen?: boolean;

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -35,8 +35,6 @@ import {isFocusVisible, forkFocus, forkBlur} from '../utils/focusVisible.js';
 class Modal extends React.Component<ModalPropsT, ModalStateT> {
   static defaultProps: $Shape<ModalPropsT> = {
     animate: true,
-    // TODO(v11): remove
-    autofocus: null,
     autoFocus: true,
     focusLock: true,
     returnFocus: true,
@@ -268,7 +266,6 @@ class Modal extends React.Component<ModalPropsT, ModalStateT> {
       closeable,
       role,
       unstable_ModalBackdropScroll,
-      autofocus,
       autoFocus,
       focusLock,
       returnFocus,
@@ -297,13 +294,6 @@ class Modal extends React.Component<ModalPropsT, ModalStateT> {
     const sharedProps = this.getSharedProps();
     const children = this.getChildren();
 
-    if (autofocus === false && __DEV__) {
-      console.warn(
-        `The prop "autofocus" is deprecated in favor of "autoFocus" to be consistent across the project.
-        The property "autofocus" will be removed in a future major version.`,
-      );
-    }
-
     // Handles backdrop click when `unstable_ModalBackdropScroll` is set to true
     // $FlowFixMe
     if (dialogContainerProps.ref) {
@@ -324,7 +314,7 @@ class Modal extends React.Component<ModalPropsT, ModalStateT> {
             // Allow focus to escape when UI is within an iframe
             crossFrame={false}
             returnFocus={returnFocus}
-            autoFocus={autofocus !== null ? autofocus : autoFocus}
+            autoFocus={autoFocus}
           >
             <Root
               data-baseweb="modal"

--- a/src/modal/types.js
+++ b/src/modal/types.js
@@ -37,7 +37,6 @@ export type ModalPropsT = {
    * If false, the modal container itself will receive focus.
    * Moving focus into a newly opened modal is important for accessibility purposes, so please be careful!
    */
-  autofocus: boolean | null,
   autoFocus: boolean,
   /** If true, focus will be locked to elements within the modal.
    */


### PR DESCRIPTION
Removes `autofocus` prop, use the `autoFocus` prop instead.

#### Scope
Major: Breaking change
