### PR TITLE
fix(timezone-picker): correct offset value to align with prev versions

### DIFF
--- a/src/timezonepicker/__tests__/timezone-picker.test.js
+++ b/src/timezonepicker/__tests__/timezone-picker.test.js
@@ -1,0 +1,65 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+import {render, screen, fireEvent} from '@testing-library/react';
+
+import {TimezonePicker} from '../index.js';
+import {TestBaseProvider} from '../../test/test-utils.js';
+
+const mockedDate = new Date('2021-01-01T00:00:00Z');
+const Example = ({setDate}) => {
+  return <TimezonePicker value={mockedDate} onChange={setDate} />;
+};
+
+const renderComponent = () => {
+  const setDate = jest.fn();
+  render(
+    <TestBaseProvider>
+      <Example setDate={setDate} />
+    </TestBaseProvider>,
+  );
+  return setDate;
+};
+describe('TimezonePicker', () => {
+  it('onChange value is accurate for NZ', async () => {
+    const setDate = renderComponent();
+    fireEvent.click(screen.getByLabelText('Select a timezone.'));
+    fireEvent.click(screen.getByText('(GMT+13) Pacific/Fakaofo'));
+
+    expect(setDate).toBeCalledWith({
+      id: 'Pacific/Fakaofo',
+      label: '(GMT+13) Pacific/Fakaofo',
+      offset: -780,
+    });
+  });
+
+  it('onChange value is accurate for HI', async () => {
+    const setDate = renderComponent();
+    fireEvent.click(screen.getByLabelText('Select a timezone.'));
+    fireEvent.click(screen.getByText('(GMT-10) Pacific/Honolulu'));
+
+    expect(setDate).toBeCalledWith({
+      id: 'Pacific/Honolulu',
+      label: '(GMT-10) Pacific/Honolulu',
+      offset: 600,
+    });
+  });
+
+  it('onChange value is accurate for UTC', async () => {
+    const setDate = renderComponent();
+    fireEvent.click(screen.getByLabelText('Select a timezone.'));
+    fireEvent.click(screen.getByText('(GMT+0) Europe/London'));
+
+    expect(setDate).toBeCalledWith({
+      id: 'Europe/London',
+      label: '(GMT+0) Europe/London',
+      offset: 0,
+    });
+  });
+});

--- a/src/timezonepicker/__tests__/timezone-picker.test.js
+++ b/src/timezonepicker/__tests__/timezone-picker.test.js
@@ -12,7 +12,7 @@ import {render, screen, fireEvent} from '@testing-library/react';
 import {TimezonePicker} from '../index.js';
 import {TestBaseProvider} from '../../test/test-utils.js';
 
-const mockedDate = new Date('2021-01-01T00:00:00Z');
+const mockedDate = '2021-01-01T00:00:00Z';
 const Example = ({setDate}) => {
   return <TimezonePicker value={mockedDate} onChange={setDate} />;
 };

--- a/src/timezonepicker/timezone-picker.js
+++ b/src/timezonepicker/timezone-picker.js
@@ -73,10 +73,13 @@ class TimezonePicker extends React.Component<
           }
         }
 
+        const offsetMinutes = offset * 60;
+
         timezones.push({
           id: zoneName,
           label,
-          offset,
+          // offset output is in minutes, difference of UTC and this zone (negative for hours ahead of UTC, positive for hours behind)
+          offset: offsetMinutes === 0 ? 0 : offsetMinutes * -1,
         });
       } catch (error) {
         // Ignores timezones that are not available within a user's browser/operating system

--- a/src/timezonepicker/types.js
+++ b/src/timezonepicker/types.js
@@ -22,6 +22,11 @@ export type TimezonePickerStateT = {
 export type TimezoneT = {
   id: string,
   label: string,
+  /**
+   * The difference, in minutes, between a UTC date, and a date in the indicated time zone.
+   * Positive values indicate hours behind UTC, negative values indicate hours ahead.
+   * This aligns with Date.getTimezoneOffset()
+   */
   offset: number,
 };
 export type TimezonePickerPropsT = {


### PR DESCRIPTION
Fixes the onChange param type to align with previous versions, and Date.getTimezoneOffset(). Adds tests to verify any future changes. 