### PR TITLE
fix(docs): fix toast docs

### DIFF
--- a/documentation-site/components/yard/config/toast.ts
+++ b/documentation-site/components/yard/config/toast.ts
@@ -15,7 +15,7 @@ const buttonProps = require('!!extract-react-types-loader!../../../../src/button
 const blockProps = require('!!extract-react-types-loader!../../../../src/block/block.js');
 
 const toastConfig: TConfig = {
-  componentName: 'React.Fragment',
+  componentName: 'ToasterContainer',
   imports: {
     'baseui/toast': {
       named: ['toaster', 'ToasterContainer'],
@@ -56,8 +56,7 @@ const toastConfig: TConfig = {
       },
     },
     children: {
-      value: `<ToasterContainer />
-        <Button onClick={()=>{
+      value: `<Button onClick={()=>{
           let toastKey;
           const msg = 'Use toaster.info(), toaster.positive(), toaster.warning(), or toaster.negative()';
           const ok = (

--- a/documentation-site/pages/components/toast.mdx
+++ b/documentation-site/pages/components/toast.mdx
@@ -30,6 +30,10 @@ top/left, bottom/right, bottom/center, bottom/left. Toasts are intended to provi
 and self-dismiss after a short time with an option to self-dismiss. Each toast can be colored to fit
 it’s status type of neutral, positive, warning and alert.
 
+The above example, where the ToasterContainer wraps the child elements, is not SSR safe. The code
+examples below, which show the ToasterContainer as a self closing tag alongside other elements, is SSR
+safe.
+
 **Using the `toaster` utility:**
 
 Toasts can be created easily with some of the helper functions on `toaster`, as seen in the code sample above. If a key isn't provided, it will auto-generate a unique key for you which will be returned in the instantiation functions (`info, positive, warning, negative`).


### PR DESCRIPTION
Fixes yard config, as all props were being added to the top level element. Adds a blurb about not nesting children inside for SSR. 