### PR TITLE
Guide to Styletron/Base Web Setup for Remix.js

### DIFF
--- a/documentation-site/pages/getting-started/setup.mdx
+++ b/documentation-site/pages/getting-started/setup.mdx
@@ -138,6 +138,7 @@ export default function Hello() {
 
 There are detailed guides for Styletron/Base Web setup for the following frameworks:
 
+- [Remix](https://github.com/Diggerati/remix-baseweb)
 - [Fusion.js](https://www.styletron.org/getting-started/#with-fusionjs)
 - [Next.js](https://github.com/tajo/nextjs-baseweb)
 - [Gatsby](https://www.styletron.org/getting-started/#with-gatsby)


### PR DESCRIPTION


## Description
Setup for Base Web for Remix.js React Framework to configure with Styletron.
The setup uses Javascript but it is the same with the Typescript

# Scope

Minor: Enhancement


