### PR TITLE
fix(TimeZone picker) Proper replace all underscores

### DIFF
--- a/src/timezonepicker/timezone-picker.js
+++ b/src/timezonepicker/timezone-picker.js
@@ -64,7 +64,7 @@ class TimezonePicker extends React.Component<
         const offset = getTimezoneOffset(zoneName, compareDate) / 3_600_000;
 
         const offsetFormatted = `${offset >= 0 ? '+' : '-'}${Math.abs(offset)}`;
-        let label = `(GMT${offsetFormatted}) ${zoneName.replace('_', ' ')}`;
+        let label = `(GMT${offsetFormatted}) ${zoneName.replace(/_/g, ' ')}`;
 
         if (this.props.includeAbbreviations) {
           const abbreviation = format(compareDate, 'zzz', {timeZone: zoneName});


### PR DESCRIPTION
#### Description

Some timezones, such as `(GMT-6) America/North Dakota/New_Salem` have multiple underscores (see attached image). Use a regex to replace all of them so the zone will show as `(GMT-6) America/North Dakota/New Salem`.

As an alternative to `replace` with regex `replaceAll` could be used, but browser support is better with `replace`.

<!-- Describe your changes below in as much detail as possible -->

#### Scope
Patch: Bug Fix

![Image 2022-02-25 at 10 33 26 PM](https://user-images.githubusercontent.com/467330/155827349-76858f6e-3493-401b-ae4c-4b2230b59c6a.jpg)

