### PR TITLE
Remove radio group overrides pass through

### DIFF
--- a/documentation-site/components/yard/config/radio.ts
+++ b/documentation-site/components/yard/config/radio.ts
@@ -149,15 +149,7 @@ const RadioGroupConfig: TConfig = {
       type: PropTypes.Custom,
       description: 'Lets you customize all aspects of the component.',
       custom: {
-        names: [
-          'Root',
-          'Input',
-          'Label',
-          'Description',
-          'RadioGroupRoot',
-          'RadioMarkInner',
-          'RadioMarkOuter',
-        ],
+        names: ['Root'],
         sharedProps: {
           $isFocused: {
             type: PropTypes.Boolean,

--- a/documentation-site/examples/radio/overrides.js
+++ b/documentation-site/examples/radio/overrides.js
@@ -1,11 +1,15 @@
 // @flow
 import * as React from 'react';
 import {ParagraphSmall} from 'baseui/typography';
-import {Radio, RadioGroup, type OverridesT} from 'baseui/radio';
+import {
+  Radio,
+  RadioGroup,
+  type RadioOverridesT,
+} from 'baseui/radio';
 
 export default function Example() {
   const [value, setValue] = React.useState('1');
-  const radioOverrides: OverridesT = {
+  const radioOverrides: RadioOverridesT = {
     Label: ({$value}) => (
       <ParagraphSmall>
         Custom label for value: {$value}

--- a/packages/baseweb-vscode-extension/yarn.lock
+++ b/packages/baseweb-vscode-extension/yarn.lock
@@ -10523,9 +10523,9 @@ url-loader@1.1.2:
     schema-utils "^1.0.0"
 
 url-parse@^1.4.3:
-  version "1.5.7"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.7.tgz#00780f60dbdae90181f51ed85fb24109422c932a"
-  integrity sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"

--- a/src/radio/radiogroup.js
+++ b/src/radio/radiogroup.js
@@ -71,17 +71,6 @@ class StatelessRadioGroup extends React.Component<PropsT, StatelessStateT> {
       StyledRadioGroupRoot,
     );
 
-    if (__DEV__) {
-      const overrideKeys = Object.keys(overrides);
-      // TODO(v11)
-      if (overrideKeys.length && !overrideKeys.includes('RadioGroupRoot')) {
-        // eslint-disable-next-line no-console
-        console.warn(`All overrides beside 'RadioGroupRoot' will be deprecated in the next major version update.
-          Pass other overrides to the 'Radio' children instead.
-        `);
-      }
-    }
-
     return (
       <RadioGroupRoot
         id={this.props.id}
@@ -123,8 +112,6 @@ class StatelessRadioGroup extends React.Component<PropsT, StatelessStateT> {
             onChange: this.props.onChange,
             onMouseEnter: this.props.onMouseEnter,
             onMouseLeave: this.props.onMouseLeave,
-            // will need to remove overrides pass-through on next major version
-            overrides: {...this.props.overrides, ...child.props.overrides},
           });
         })}
       </RadioGroupRoot>

--- a/src/radio/types.js
+++ b/src/radio/types.js
@@ -27,11 +27,6 @@ export type RadioGroupOverridesT = {
   RadioGroupRoot?: OverrideT,
 };
 
-export type OverridesT = {
-  ...$Exact<RadioOverridesT>,
-  ...$Exact<RadioGroupOverridesT>,
-};
-
 export type DefaultPropsT = {
   value: string,
   disabled: boolean,
@@ -58,7 +53,7 @@ export type PropsT = {
    */
   'aria-labelledby'?: string,
   // This prop will be deprecated in the next major update. Pass overrides to the 'Radio' component instead.
-  overrides?: OverridesT,
+  overrides?: RadioGroupOverridesT,
   /** As `children` in React native approach represents radio buttons inside of Radio Group. Can use `Radio` from this package. */
   children?: Array<React.Node>,
   /** The value of radio button, which is preselected. */
@@ -140,7 +135,7 @@ export type RadioPropsT = {
   onMouseDown?: (e: SyntheticInputEvent<HTMLInputElement>) => mixed,
   /** Handler for mouseup events on trigger element. */
   onMouseUp?: (e: SyntheticInputEvent<HTMLInputElement>) => mixed,
-  overrides?: OverridesT,
+  overrides?: RadioOverridesT,
   /** Marks the checkbox as required. */
   required?: boolean,
   /** Passed to the input element value attribute */
@@ -174,7 +169,7 @@ export type DefaultStatefulPropsT = {
 };
 
 export type StatefulContainerPropsT = {
-  overrides?: OverridesT,
+  overrides?: RadioGroupOverridesT,
   /** Should return `RadioGroup` instance with standard or customized inner elements. */
   children?: (props: PropsT) => React.Node,
   /** Initial state populated into the component */
@@ -188,7 +183,7 @@ export type StatefulContainerPropsT = {
 };
 
 export type StatefulRadioGroupPropsT = {
-  overrides?: OverridesT,
+  overrides?: RadioGroupOverridesT,
   /** A list of `Radio` components. */
   children?: Array<React.Node>,
   /** Initial state populated into the component */

--- a/src/timezonepicker/timezone-picker.js
+++ b/src/timezonepicker/timezone-picker.js
@@ -64,7 +64,7 @@ class TimezonePicker extends React.Component<
         const offset = getTimezoneOffset(zoneName, compareDate) / 3_600_000;
 
         const offsetFormatted = `${offset >= 0 ? '+' : '-'}${Math.abs(offset)}`;
-        let label = `(GMT${offsetFormatted}) ${zoneName.replace('_', ' ')}`;
+        let label = `(GMT${offsetFormatted}) ${zoneName.replace(/_/g, ' ')}`;
 
         if (this.props.includeAbbreviations) {
           const abbreviation = format(compareDate, 'zzz', {timeZone: zoneName});


### PR DESCRIPTION
#### Description
Previously, `RadioGroup` accepted overrides for `Radio` which it passed through to `Radio`. This change deprecates that behavior. Users should instead apply `Radio` overrides directly to instances of the `Radio` component itself.

#### Scope
Major: Breaking change
