### PR TITLE
feat(eslint): separate block rule from deprecated component api

### DIFF
--- a/packages/eslint-plugin-baseui/README.md
+++ b/packages/eslint-plugin-baseui/README.md
@@ -5,6 +5,7 @@ This ESLint plugin is for developers using the Base Web component library. Mainl
 - Identify usage of deprecated APIs
 - Identify usage of unsupported exports
 - Identify improper usage of components
+- Identify improper styling on Block elements
 
 ## Installation
 
@@ -31,6 +32,7 @@ Then add it to your ESLint configuration:
     'baseui/deprecated-theme-api': "warn",
     'baseui/deprecated-component-api': "warn",
     'baseui/no-deep-imports': "warn",
+    'baseui/no-block-style': "warn",
   }
 }
 ```
@@ -64,11 +66,12 @@ We sync the versions for each package, so you shouldn't have to worry about it.
 
 ## Rules
 
-| Rule | Responsibility |
-| --- | --- |
-| `deprecated-theme-api` | Identify theme properties that are deprecated. |
-| `deprecated-component-api` | Identify components and props that are deprecated. |
-| `no-deep-imports` | Identify importing unsupported modules from `baseui` source code. |
+| Rule                       | Responsibility                                                                                 |
+|----------------------------|------------------------------------------------------------------------------------------------|
+| `deprecated-theme-api`     | Identify theme properties that are deprecated.                                                 |
+| `deprecated-component-api` | Identify components and props that are deprecated.                                             |
+| `no-deep-imports`          | Identify importing unsupported modules from `baseui` source code.                              |
+| `no-block-style`           | Identify instances of Block being used with style/$style instead of overrides. (not supported) |
 
 ## Contributing
 

--- a/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
+++ b/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
@@ -588,27 +588,6 @@ const tests = {
       `,
     },
 
-    // Block - $style
-    {
-      code: `
-        import {Block} from "baseui/block"
-        export default () => {
-          return <Block $style={{ color: "red" }} />
-        }
-      `,
-      errors: [{messageId: MESSAGES.styleOnBlock.id}],
-    },
-
-    // Block - style
-    {
-      code: `
-        import {Block} from "baseui/block"
-        export default () => {
-          return <Block style={{ color: "red" }} />
-        }
-      `,
-      errors: [{messageId: MESSAGES.styleOnBlock.id}],
-    },
     {
       code: `
         import { Paragraph3 } from "baseui/typography"

--- a/packages/eslint-plugin-baseui/__tests__/no-block-style.js
+++ b/packages/eslint-plugin-baseui/__tests__/no-block-style.js
@@ -1,0 +1,76 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+'use strict';
+
+const {RuleTester} = require('eslint');
+const rule = require('../src/no-block-style.js');
+const MESSAGES = require('../src/messages.js');
+
+RuleTester.setDefaultConfig({
+  parser: require.resolve('babel-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+const tests = {
+  valid: [
+    // Block - $style
+    {
+      code: `
+        import {Block} from "baseui/block"
+        export default () => {
+          return <Block $style={{ color: "red" }} />
+        }
+      `,
+      errors: [{messageId: MESSAGES.styleOnBlock.id}],
+    },
+
+    // Block - style
+    {
+      code: `
+        import {Block} from "baseui/block"
+        export default () => {
+          return <Block style={{ color: "red" }} />
+        }
+      `,
+      errors: [{messageId: MESSAGES.styleOnBlock.id}],
+    },
+  ],
+};
+
+// For easier local testing
+if (!process.env.CI) {
+  let only = [];
+  let skipped = [];
+  [...tests.valid, ...tests.invalid].forEach(t => {
+    if (t.skip) {
+      delete t.skip;
+      skipped.push(t);
+    }
+    if (t.only) {
+      delete t.only;
+      only.push(t);
+    }
+  });
+  const predicate = t => {
+    if (only.length > 0) {
+      return only.indexOf(t) !== -1;
+    }
+    if (skipped.length > 0) {
+      return skipped.indexOf(t) === -1;
+    }
+    return true;
+  };
+  tests.valid = tests.valid.filter(predicate);
+  tests.invalid = tests.invalid.filter(predicate);
+}
+
+const ruleTester = new RuleTester();
+ruleTester.run('no-block-style', rule, tests);

--- a/packages/eslint-plugin-baseui/src/deprecated-component-api.js
+++ b/packages/eslint-plugin-baseui/src/deprecated-component-api.js
@@ -4,6 +4,7 @@ Copyright (c) Uber Technologies, Inc.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
+/* eslint-env node */
 
 'use strict';
 
@@ -34,7 +35,7 @@ const mapDeprecatedTypographyComponents = {
 };
 
 const getOverrideIfExists = (name, node) => {
-  // Verify that an object is passed to overrides.
+  // Verify that an object is passed into overrides.
   if (node.parent.value.expression.type === 'ObjectExpression') {
     // Find property name
     return node.parent.value.expression.properties.find(
@@ -51,7 +52,6 @@ module.exports = {
     messages: {
       [MESSAGES.replace.id]: MESSAGES.replace.message,
       [MESSAGES.deprecateSpinner.id]: MESSAGES.deprecateSpinner.message,
-      [MESSAGES.styleOnBlock.id]: MESSAGES.styleOnBlock.message,
       [MESSAGES.buttonKindMinimal.id]: MESSAGES.buttonKindMinimal.message,
       [MESSAGES.modalBackdrop.id]: MESSAGES.modalBackdrop.message,
     },
@@ -131,7 +131,6 @@ module.exports = {
             // These can be referenced later on by instances of components.
             if (isImporting(specifier, 'Accordion', 'baseui/accordion')) return;
             if (isImporting(specifier, 'Modal', 'baseui/modal')) return;
-            if (isImporting(specifier, 'Block', 'baseui/block')) return;
             if (isImporting(specifier, 'Checkbox', 'baseui/checkbox')) return;
             if (isImporting(specifier, 'Button', 'baseui/button')) return;
           }
@@ -263,25 +262,6 @@ module.exports = {
             fix: function(fixer) {
               return fixer.replaceText(node, 'autoFocus');
             },
-          });
-          return;
-        }
-
-        // style and $style
-        // Ex: <Block style={{ ... }} />
-        // Ex: <Block $style={{ ... }} />
-        // The "$style" and "style" props are not supported.
-        // It works because Block spreads props down to the base
-        // styled component, but styles are not guaranteed to be applied
-        // as expected.
-        if (
-          importState.Block &&
-          (isProp('$style', importState.Block) ||
-            isProp('style', importState.Block))
-        ) {
-          context.report({
-            node,
-            messageId: MESSAGES.styleOnBlock.id,
           });
           return;
         }

--- a/packages/eslint-plugin-baseui/src/index.js
+++ b/packages/eslint-plugin-baseui/src/index.js
@@ -10,12 +10,14 @@ LICENSE file in the root directory of this source tree.
 const DeprecatedThemeAPI = require('./deprecated-theme-api.js');
 const DeprecatedComponentAPI = require('./deprecated-component-api.js');
 const NoDeepImports = require('./no-deep-imports.js');
+const NoBlockStyle = require('./no-block-style.js');
 
 module.exports = {
   rules: {
     'deprecated-theme-api': DeprecatedThemeAPI,
     'deprecated-component-api': DeprecatedComponentAPI,
     'no-deep-imports': NoDeepImports,
+    'no-block-style': NoBlockStyle,
   },
   configs: {
     recommended: {
@@ -24,6 +26,7 @@ module.exports = {
         'baseui/deprecated-theme-api': ['warn'],
         'baseui/deprecated-component-api': ['warn'],
         'baseui/no-deep-imports': ['warn'],
+        'baseui/no-block-style': ['warn'],
       },
     },
   },

--- a/packages/eslint-plugin-baseui/src/no-block-style.js
+++ b/packages/eslint-plugin-baseui/src/no-block-style.js
@@ -1,0 +1,93 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+'use strict';
+
+const MESSAGES = require('./messages.js');
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    messages: {
+      [MESSAGES.styleOnBlock.id]: MESSAGES.styleOnBlock.message,
+    },
+  },
+  create(context) {
+    let importState = {};
+
+    return {
+      ImportDeclaration(node) {
+        if (!node.source.value.startsWith('baseui/')) {
+          return;
+        }
+
+        function isImporting(node, importName, importPath) {
+          if (
+            node.imported.name === importName &&
+            node.parent.source.value === importPath
+          ) {
+            importState[importName] = node.local.name;
+            return true;
+          } else {
+            return false;
+          }
+        }
+
+        for (let x = 0; x < node.specifiers.length; x++) {
+          const specifier = node.specifiers[x];
+          if (
+            specifier.type !== 'ImportNamespaceSpecifier' &&
+            specifier.type !== 'ImportDefaultSpecifier'
+          ) {
+            if (isImporting(specifier, 'Block', 'baseui/block')) return;
+          }
+        }
+      },
+      JSXIdentifier(node) {
+        // =======
+        // Helpers
+        // =======
+
+        // isProp
+        // Check if identifier is a prop with matching "name" and is used with
+        // "component".
+        // Ex: isProp("foo", "Boo") with <Boo foo={} /> => true
+        function isProp(name, component) {
+          return (
+            node.name === name &&
+            context
+              .getAncestors()
+              .some(
+                ancestor =>
+                  ancestor.type === 'JSXOpeningElement' &&
+                  ancestor.name.name === component,
+              )
+          );
+        }
+
+        // style and $style
+        // Ex: <Block style={{ ... }} />
+        // Ex: <Block $style={{ ... }} />
+        // The "$style" and "style" props are not supported.
+        // It works because Block spreads props down to the base
+        // styled component, but styles are not guaranteed to be applied
+        // as expected.
+        if (
+          importState.Block &&
+          (isProp('$style', importState.Block) ||
+            isProp('style', importState.Block))
+        ) {
+          context.report({
+            node,
+            messageId: MESSAGES.styleOnBlock.id,
+          });
+          return;
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
Separates the Block style/$style rule into it's own rule, as it's not a deprecated component or api. Will give us more granular ability to enable errors on deprecated components being introduced, without having to refactor Block usage. 