### PR TITLE
Remove select searchicon override

### DIFF
--- a/packages/eslint-plugin-baseui/src/deprecated-component-api.js
+++ b/packages/eslint-plugin-baseui/src/deprecated-component-api.js
@@ -391,20 +391,6 @@ module.exports = {
           }
         }
 
-        // Select
-        // Ex: <Select overrides={{ SearchIcon: {}}} />
-        // Replacement: SearchIconContainer
-        if (importState.Select && isProp('overrides', importState.Select)) {
-          const property = getOverrideIfExists('SearchIcon', node);
-          if (property) {
-            context.report({
-              node: property,
-              messageId: MESSAGES.selectSearchIcon.id,
-            });
-            return;
-          }
-        }
-
         // RadioGroup - All overrides are deprecated except for RadioGroupRoot
         // Ex: <RadioGroup overrides={{ RadioMarkInner: {}}} />
         // Ex: <RadioGroup overrides={{ Description: {}}} />

--- a/packages/eslint-plugin-baseui/src/messages.js
+++ b/packages/eslint-plugin-baseui/src/messages.js
@@ -41,11 +41,6 @@ module.exports = {
     message:
       'The "successValue" prop has been deprecated. The "value" prop should be normalized as though "successValue" was always set to 100.',
   },
-  selectSearchIcon: {
-    id: 'selectSearchIcon',
-    message:
-      'The "SearchIcon" override will be removed in favor of "StyledSearchIconContainer".',
-  },
   radioGroupOverrides: {
     id: 'radioGroupOverrides',
     message:

--- a/src/select/index.d.ts
+++ b/src/select/index.d.ts
@@ -326,8 +326,6 @@ export const StyledIconsContainer: StyletronComponent<any>;
 export const StyledSelectArrow: StyletronComponent<any>;
 export const StyledClearIcon: StyletronComponent<any>;
 export const StyledSearchIconContainer: StyletronComponent<any>;
-// TODO(v11): remove StyledSearchIcon
-export const StyledSearchIcon: StyletronComponent<any>;
 export const StyledDropdownContainer: StyletronComponent<any>;
 export const StyledDropdown: StyletronComponent<any>;
 export const StyledDropdownListItem: StyletronComponent<any>;

--- a/src/select/index.js
+++ b/src/select/index.js
@@ -29,8 +29,6 @@ export {
   StyledIconsContainer,
   StyledSelectArrow,
   StyledClearIcon,
-  // TODO(v11): remove StyledSearchIconContainer as StyledSearchIcon
-  StyledSearchIconContainer as StyledSearchIcon,
   StyledSearchIconContainer,
   StyledDropdownContainer,
   StyledDropdown,

--- a/src/select/select-component.js
+++ b/src/select/select-component.js
@@ -866,13 +866,13 @@ class Select extends React.Component<PropsT, SelectStateT> {
     const sharedProps = this.getSharedProps();
 
     return (
-      // TODO(v11): remove searchIconProps from SearchIconContainer
-      <SearchIconContainer
-        {...sharedProps}
-        {...searchIconProps}
-        {...searchIconContainerProps}
-      >
-        <SearchIcon size={16} title={'search'} {...searchIconProps} />
+      <SearchIconContainer {...sharedProps} {...searchIconContainerProps}>
+        <SearchIcon
+          size={16}
+          title={'search'}
+          {...sharedProps}
+          {...searchIconProps}
+        />
       </SearchIconContainer>
     );
   }


### PR DESCRIPTION
#### Description
The `SearchIcon` override for `Select` is deprecated in favor of `SearchIconContainer`.
