### PR TITLE
feat(button): accept arbitrary color in button component

### DIFF
--- a/src/button/__tests__/button-colors.scenario.js
+++ b/src/button/__tests__/button-colors.scenario.js
@@ -1,0 +1,94 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+import {useStyletron} from '../../styles/index.js';
+import {Button, SHAPE} from '../index.js';
+
+function Container({backgroundColor, children}) {
+  const [css] = useStyletron();
+  return (
+    <div className={css({backgroundColor, padding: '16px'})}>{children}</div>
+  );
+}
+
+export function Scenario() {
+  const [css] = useStyletron();
+
+  return (
+    <div>
+      <Container backgroundColor="#276ef1">
+        <Button
+          shape={SHAPE.pill}
+          color={{background: '#1e54b7', text: 'white'}}
+        >
+          Label
+        </Button>
+      </Container>
+      <Container backgroundColor="#eff3fe">
+        <Button
+          shape={SHAPE.pill}
+          color={{background: '#d4e2fc', text: 'block'}}
+        >
+          Label
+        </Button>
+      </Container>
+
+      <Container backgroundColor="#048848">
+        <Button
+          shape={SHAPE.pill}
+          color={{background: '#03703c', text: 'white'}}
+        >
+          Label
+        </Button>
+      </Container>
+      <Container backgroundColor="#e6f2ed">
+        <Button
+          shape={SHAPE.pill}
+          color={{background: '#addec9', text: 'black'}}
+        >
+          Label
+        </Button>
+      </Container>
+
+      <Container backgroundColor="#ffc043">
+        <Button
+          shape={SHAPE.pill}
+          color={{background: '#ffe3ac', text: 'black'}}
+        >
+          Label
+        </Button>
+      </Container>
+      <Container backgroundColor="#fffaf0">
+        <Button
+          shape={SHAPE.pill}
+          color={{background: '#ffe3ac', text: 'black'}}
+        >
+          Label
+        </Button>
+      </Container>
+
+      <Container backgroundColor="#e11900">
+        <Button
+          shape={SHAPE.pill}
+          color={{background: '#ab1300', text: 'white'}}
+        >
+          Label
+        </Button>
+      </Container>
+      <Container backgroundColor="#ffefed">
+        <Button
+          shape={SHAPE.pill}
+          color={{background: '#fed7d2', text: 'black'}}
+        >
+          Label
+        </Button>
+      </Container>
+    </div>
+  );
+}

--- a/src/button/__tests__/button.stories.js
+++ b/src/button/__tests__/button.stories.js
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 
 import React from 'react';
 import {Scenario as ButtonCircle} from './button-circle.scenario.js';
+import {Scenario as ButtonColors} from './button-colors.scenario.js';
 import {Scenario as ButtonEnhancersCompact} from './button-enhancers-compact.scenario.js';
 import {Scenario as ButtonEnhancers} from './button-enhancers.scenario.js';
 import {Scenario as ButtonShapes} from './button-shapes.scenario.js';
@@ -16,6 +17,7 @@ import {Scenario as ButtonSizes} from './button-sizes.scenario.js';
 import {Scenario as ButtonDefault} from './button.scenario.js';
 
 export const Circle = () => <ButtonCircle />;
+export const Colors = () => <ButtonColors />;
 export const EnhancersCompact = () => <ButtonEnhancersCompact />;
 export const Enhancers = () => <ButtonEnhancers />;
 export const Shapes = () => <ButtonShapes />;

--- a/src/button/styled-components.js
+++ b/src/button/styled-components.js
@@ -14,6 +14,7 @@ export const BaseButton = styled<SharedStylePropsT>(
   ({
     $theme,
     $size,
+    $color,
     $kind,
     $shape,
     $isLoading,
@@ -55,8 +56,14 @@ export const BaseButton = styled<SharedStylePropsT>(
     ...getFontStyles({$theme, $size}),
     ...getBorderRadiiStyles({$theme, $size, $shape}),
     ...getPaddingStyles({$theme, $size, $shape}),
-    // Kind style override
-    ...getKindStyles({$theme, $kind, $isLoading, $isSelected, $disabled}),
+    ...getColorStyles({
+      $theme,
+      $color,
+      $kind,
+      $isLoading,
+      $isSelected,
+      $disabled,
+    }),
     ...getShapeStyles({$theme, $shape, $size}),
   }),
 );
@@ -302,26 +309,43 @@ function getPaddingStyles({$theme, $size, $shape}) {
   }
 }
 
-type KindStylesT = {|
+type ColorStylesT = {|
   color?: string,
   backgroundColor?: string,
   ':hover'?: {
-    backgroundColor: string,
+    boxShadow?: string,
+    backgroundColor?: string,
   },
   ':focus'?: {
-    backgroundColor: string,
+    boxShadow?: string,
+    backgroundColor?: string,
   },
   ':active'?: {
-    backgroundColor: string,
+    boxShadow?: string,
+    backgroundColor?: string,
   },
 |};
-function getKindStyles({
+function getColorStyles({
   $theme,
+  $color,
   $isLoading,
   $isSelected,
   $kind,
   $disabled,
-}): KindStylesT {
+}): ColorStylesT {
+  if ($color) {
+    return {
+      color: $color.text,
+      backgroundColor: $color.background,
+      ':hover': {
+        boxShadow: 'inset 999px 999px 0px rgba(0, 0, 0, 0.04)',
+      },
+      ':active': {
+        boxShadow: 'inset 999px 999px 0px rgba(0, 0, 0, 0.08)',
+      },
+    };
+  }
+
   if ($disabled) {
     return Object.freeze({});
   }

--- a/src/button/types.js
+++ b/src/button/types.js
@@ -19,8 +19,14 @@ export type OverridesT = {
   LoadingSpinner?: OverrideT,
 };
 
+export type CustomColorT = {|
+  background: string,
+  text: string,
+|};
+
 export type ButtonPropsT = {
   children?: React$Node,
+  color?: CustomColorT,
   disabled?: boolean,
   /** A helper rendered at the end of the button. */
   // eslint-disable-next-line flowtype/no-weak-types
@@ -44,6 +50,7 @@ export type ButtonPropsT = {
 };
 
 export type SharedStylePropsT = {
+  $color?: CustomColorT,
   $kind?: $Keys<typeof KIND>,
   $isSelected?: boolean,
   $shape?: $Keys<typeof SHAPE>,

--- a/src/button/utils.js
+++ b/src/button/utils.js
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 import type {ButtonPropsT} from './types.js';
 
 export function getSharedProps({
+  color,
   disabled,
   isLoading,
   isSelected,
@@ -16,6 +17,7 @@ export function getSharedProps({
   size,
 }: ButtonPropsT) {
   return {
+    $color: color,
     $disabled: disabled,
     $isLoading: isLoading,
     $isSelected: isSelected,


### PR DESCRIPTION
#### Description

Button component accepts arbitrary background and text color
<img width="651" alt="Screen Shot 2022-03-04 at 10 32 22 AM" src="https://user-images.githubusercontent.com/5317799/156821565-df52af9d-7fff-4595-af5c-b54b584822a4.png">


#### Scope
Minor: New Feature
