### PR TITLE
Remove unnecessary `// @flow` from TS implementation

### DIFF
--- a/documentation-site/examples/select/overridden.tsx
+++ b/documentation-site/examples/select/overridden.tsx
@@ -1,4 +1,3 @@
-// @flow
 import * as React from 'react';
 import {Select, Value} from 'baseui/select';
 


### PR DESCRIPTION
#### Description

Fixes a typo in docs. TS implementation doesn't need the `// @flow` comment.

#### Scope
<!-- Pick one:
Patch: Bug Fix
Minor: New Feature
Major: Breaking change
-->
Documentation