### PR TITLE
fix(input): allow for 'any' value for input step

### DIFF
--- a/src/input/index.d.ts
+++ b/src/input/index.d.ts
@@ -69,7 +69,7 @@ export interface BaseInputProps<T> {
   rows?: number;
   min?: number;
   max?: number;
-  step?: number;
+  step?: number | 'any';
 }
 
 export interface State {

--- a/src/input/types.js
+++ b/src/input/types.js
@@ -140,7 +140,7 @@ export type BaseInputPropsT<T> = {|
   /** max value when used as input type=number */
   max?: number,
   /** step value when used as input type=number */
-  step?: number,
+  step?: number | 'any',
 |};
 
 export type InputPropsT = {|


### PR DESCRIPTION
Allow for 'any' value for input step. See spec:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-step
