### PR TITLE
feat(eslint): add no shorthand properties rule

### DIFF
--- a/packages/eslint-plugin-baseui/README.md
+++ b/packages/eslint-plugin-baseui/README.md
@@ -7,6 +7,7 @@ This ESLint plugin is for developers using the Base Web component library. Mainl
 - Identify improper usage of components
 - Identify improper styling on Block elements
 - Identify improper styling on baseui components
+- Identify shorthand properties in baseui overrides
 
 ## Installation
 
@@ -35,6 +36,7 @@ Then add it to your ESLint configuration:
     'baseui/no-deep-imports': "warn",
     'baseui/no-block-style': "warn",
     'baseui/no-component-classname': "warn",
+    'baseui/no-shorthand-properties': "warn",
   }
 }
 ```
@@ -75,6 +77,7 @@ We sync the versions for each package, so you shouldn't have to worry about it.
 | `no-deep-imports`          | Identify importing unsupported modules from `baseui` source code.                              |
 | `no-block-style`           | Identify instances of Block being used with style/$style instead of overrides. (not supported) |
 | `no-component-classname`   | Identify instances of components being styled using className. (not supported)                 |
+| `no-shorthand-properties`  | Identify instances of component overrides using shorthand css properties.                      |
 
 ## Contributing
 

--- a/packages/eslint-plugin-baseui/__tests__/no-shorthand-properties.test.js
+++ b/packages/eslint-plugin-baseui/__tests__/no-shorthand-properties.test.js
@@ -27,6 +27,11 @@ const tests = {
     },
     {
       code: `
+      import {Menu} from "baseui/menu"
+      return (<Menu overrides={{Option: {props: {overrides: {ListItem: {style: {borderTopColor: 'white'}}}}}}} />);`,
+    },
+    {
+      code: `
       import {Button} from "baseui/button"
       return (<Button overrides={{Root: {style: () => ({borderTopColor: 'white'})}}} />);`,
     },
@@ -50,13 +55,11 @@ const tests = {
     {
       code: `
       import {Button} from "baseui/button"
-      const hello = {Root: {style: function() {return {borderTopColor: 'white'}; }}};
       return (<Button overrides={''} />);`,
     },
     {
       code: `
       import {Button} from "baseui/button"
-      const hello = {Root: {style: function() {return {borderTopColor: 'white'}; }}};
       return (<Button overrides />);`,
     },
     {
@@ -97,6 +100,12 @@ const tests = {
         return {borderColor: hello}; 
       }
       }}} />);`,
+      errors: 1,
+    },
+    {
+      code: `
+      import {Menu} from "baseui/menu"
+      return (<Menu overrides={{Option: {props: {overrides: {ListItem: {style: {borderColor: 'white'}}}}}}} />);`,
       errors: 1,
     },
   ],

--- a/packages/eslint-plugin-baseui/__tests__/no-shorthand-properties.test.js
+++ b/packages/eslint-plugin-baseui/__tests__/no-shorthand-properties.test.js
@@ -1,0 +1,109 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../src/no-shorthand-properties.js');
+
+RuleTester.setDefaultConfig({
+  parser: require.resolve('babel-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+const tests = {
+  valid: [
+    {
+      code: `
+      import {Button} from "baseui/button"
+      return (<Button overrides={{Root: {style: {borderTopColor: 'white'}}}} />);`,
+    },
+    {
+      code: `
+      import {Button} from "baseui/button"
+      return (<Button overrides={{Root: {style: () => ({borderTopColor: 'white'})}}} />);`,
+    },
+    {
+      code: `
+      import {Button} from "baseui/button"
+      return (<Button overrides={{Root: {style: function() {return {borderTopColor: 'white'}; }}}} />);`,
+    },
+    {
+      code: `
+      import {Button} from "baseui/button"
+      return (<Button overrides={{Root: {style: function() {
+        const hello = 'white';
+        return {borderTopColor: hello}; 
+      }
+      }}} />);`,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      import {Button} from "baseui/button"
+      return (<Button overrides={{Root: {style: {borderColor: 'white'}}}} />);`,
+      errors: 1,
+    },
+    {
+      code: `
+      import {Button} from "baseui/button"
+      return (<Button overrides={{Root: {style: () => ({borderColor: 'white'})}}} />);`,
+      errors: 1,
+    },
+    {
+      code: `
+      import {Button} from "baseui/button"
+      return (<Button overrides={{Root: {style: function() {return {borderColor: 'white'}; }}}} />);`,
+      errors: 1,
+    },
+
+    {
+      code: `
+      import {Button} from "baseui/button"
+      return (<Button overrides={{Root: {style: function() {
+        const hello = 'white';
+        return {borderColor: hello}; 
+      }
+      }}} />);`,
+      errors: 1,
+    },
+  ],
+};
+
+// For easier local testing
+if (!process.env.CI) {
+  let only = [];
+  let skipped = [];
+  [...tests.valid, ...tests.invalid].forEach((t) => {
+    if (t.skip) {
+      delete t.skip;
+      skipped.push(t);
+    }
+    if (t.only) {
+      delete t.only;
+      only.push(t);
+    }
+  });
+  const predicate = (t) => {
+    if (only.length > 0) {
+      return only.indexOf(t) !== -1;
+    }
+    if (skipped.length > 0) {
+      return skipped.indexOf(t) === -1;
+    }
+    return true;
+  };
+  tests.valid = tests.valid.filter(predicate);
+  tests.invalid = tests.invalid.filter(predicate);
+}
+
+const ruleTester = new RuleTester();
+ruleTester.run('no-shorthand-properties', rule, tests);

--- a/packages/eslint-plugin-baseui/__tests__/no-shorthand-properties.test.js
+++ b/packages/eslint-plugin-baseui/__tests__/no-shorthand-properties.test.js
@@ -38,6 +38,30 @@ const tests = {
     {
       code: `
       import {Button} from "baseui/button"
+      const hello = {style: function() {return {borderTopColor: 'white'}; }};
+      return (<Button overrides={{Root: hello}} />);`,
+    },
+    {
+      code: `
+      import {Button} from "baseui/button"
+      const hello = {Root: {style: function() {return {borderTopColor: 'white'}; }}};
+      return (<Button overrides={hello} />);`,
+    },
+    {
+      code: `
+      import {Button} from "baseui/button"
+      const hello = {Root: {style: function() {return {borderTopColor: 'white'}; }}};
+      return (<Button overrides={''} />);`,
+    },
+    {
+      code: `
+      import {Button} from "baseui/button"
+      const hello = {Root: {style: function() {return {borderTopColor: 'white'}; }}};
+      return (<Button overrides />);`,
+    },
+    {
+      code: `
+      import {Button} from "baseui/button"
       return (<Button overrides={{Root: {style: function() {
         const hello = 'white';
         return {borderTopColor: hello}; 

--- a/packages/eslint-plugin-baseui/src/index.js
+++ b/packages/eslint-plugin-baseui/src/index.js
@@ -12,6 +12,7 @@ const DeprecatedComponentAPI = require('./deprecated-component-api.js');
 const NoDeepImports = require('./no-deep-imports.js');
 const NoBlockStyle = require('./no-block-style.js');
 const NoComponentClassname = require('./no-component-classname.js');
+const NoShorthandProperties = require('./no-shorthand-properties.js');
 
 module.exports = {
   rules: {
@@ -20,6 +21,7 @@ module.exports = {
     'no-deep-imports': NoDeepImports,
     'no-block-style': NoBlockStyle,
     'no-component-classname': NoComponentClassname,
+    'no-shorthand-properties': NoShorthandProperties,
   },
   configs: {
     recommended: {
@@ -30,6 +32,7 @@ module.exports = {
         'baseui/no-deep-imports': ['warn'],
         'baseui/no-block-style': ['warn'],
         'baseui/no-component-classname': ['warn'],
+        'baseui/no-shorthand-properties': ['warn'],
       },
     },
   },

--- a/packages/eslint-plugin-baseui/src/messages.js
+++ b/packages/eslint-plugin-baseui/src/messages.js
@@ -55,4 +55,9 @@ module.exports = {
     message:
       'Base web components should only be styled using `styled`, `withStyle`, or `overrides`. {{ component }} is using className, which can cause unintended styling issues. See https://baseweb.design/guides/styling/ for recommended styling patterns.',
   },
+  noShorthandProperties: {
+    id: 'noShorthandProperties',
+    message:
+      'Shorthand properties should not be used with baseui component overrides. See https://baseweb.design/guides/styling/ for recommended styling patterns.',
+  },
 };

--- a/packages/eslint-plugin-baseui/src/no-shorthand-properties.js
+++ b/packages/eslint-plugin-baseui/src/no-shorthand-properties.js
@@ -1,0 +1,92 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+/* eslint-env node */
+
+'use strict';
+const { hasProp } = require('jsx-ast-utils');
+const MESSAGES = require('./messages.js');
+const SHORTHAND_PROPERTIES = [
+  'background',
+  'border',
+  'borderBottom',
+  'borderTop',
+  'borderLeft',
+  'borderRight',
+  'borderColor',
+  'borderRadius',
+  'borderStyle',
+  'borderWidth',
+  'flex',
+  'margin',
+  'outline',
+  'padding',
+  'transform',
+  'transition',
+];
+
+module.exports = {
+  meta: {
+    fixable: 'code',
+    messages: {
+      [MESSAGES.noShorthandProperties.id]: MESSAGES.noShorthandProperties.message,
+    },
+  },
+  create(context) {
+    let importState = {};
+
+    return {
+      ImportDeclaration(node) {
+        if (!node.source.value.startsWith('baseui/')) {
+          return;
+        }
+        // Keep track of all things imported. Later in the jsx, we'll determine if it's a component (JSXIdentifiers should only be components).
+        for (let x = 0; x < node.specifiers.length; x++) {
+          const specifier = node.specifiers[x];
+          if (
+            specifier.type !== 'ImportNamespaceSpecifier' &&
+            specifier.type !== 'ImportDefaultSpecifier'
+          ) {
+            importState[specifier.local.name] = true;
+          }
+        }
+      },
+      JSXOpeningElement(node) {
+        if (importState[node.name.name] && hasProp(node.attributes, 'overrides')) {
+          const overrides = node.attributes.filter((attr) => attr.name.name === 'overrides').pop();
+          const expression = overrides.value.expression;
+          const nodesToScan = [...expression.properties];
+          while (nodesToScan.length > 0) {
+            const property = nodesToScan.shift();
+            if (property.value) {
+              if (property.value.type === 'ObjectExpression') {
+                nodesToScan.push(...property.value.properties);
+              } else if (property.value.type === 'ArrowFunctionExpression') {
+                nodesToScan.push(...property.value.body.properties);
+              } else if (property.value.type === 'FunctionExpression') {
+                const returnArg = property.value.body.body[property.value.body.body.length - 1];
+                nodesToScan.push(...returnArg.argument.properties);
+              }
+            }
+            if (
+              property.type === 'Property' &&
+              property.key &&
+              property.value &&
+              property.value.type !== 'ObjectExpression'
+            ) {
+              if (SHORTHAND_PROPERTIES.includes(property.key.name)) {
+                context.report({
+                  node: property,
+                  messageId: MESSAGES.noShorthandProperties.id,
+                });
+              }
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-baseui/src/no-shorthand-properties.js
+++ b/packages/eslint-plugin-baseui/src/no-shorthand-properties.js
@@ -57,6 +57,14 @@ module.exports = {
       JSXOpeningElement(node) {
         if (importState[node.name.name] && hasProp(node.attributes, 'overrides')) {
           const overrides = node.attributes.filter((attr) => attr.name.name === 'overrides').pop();
+          if (
+            !overrides ||
+            !overrides.value ||
+            !overrides.value.expression ||
+            overrides.value.expression.type !== 'ObjectExpression'
+          ) {
+            return;
+          }
           const expression = overrides.value.expression;
           const nodesToScan = [...expression.properties];
           while (nodesToScan.length > 0) {


### PR DESCRIPTION
Related: #3845 

Adds a lint rule to check if override properties are using shorthand CSS, which is discouraged in BaseUI. This doesn't catch instances where a variable is passed into overrides, or any other instance where the properties are not inline. Those should be caught via flow/TS, but I'm not sure if flow allows for a type specific enough to disallow the behavior (any `key: string` except border/padding/etc). 