### PR TITLE
chore(v11): remove isError from radio/radiogroup

### DIFF
--- a/src/radio/index.d.ts
+++ b/src/radio/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import {StyletronComponent} from 'styletron-react';
-import {Override} from '../overrides';
+import { StyletronComponent } from 'styletron-react';
+import { Override } from '../overrides';
 
 export interface STATE_TYPE {
   change: 'CHANGE';
@@ -15,7 +15,7 @@ export type StateReducer = (
   stateType: string,
   nextState: State,
   currentState: State,
-  event: React.SyntheticEvent<HTMLInputElement>,
+  event: React.SyntheticEvent<HTMLInputElement>
 ) => State;
 
 export interface State {
@@ -31,10 +31,7 @@ export interface StatefulContainerProps {
   autoFocus?: boolean;
 }
 
-export class StatefulContainer extends React.Component<
-  StatefulContainerProps,
-  State
-> {
+export class StatefulContainer extends React.Component<StatefulContainerProps, State> {
   onChange(e: React.ChangeEventHandler<HTMLInputElement>): void;
   stateReducer(type: string, e: React.SyntheticEvent<HTMLInputElement>): void;
 }
@@ -61,7 +58,6 @@ export interface RadioGroupProps {
   value?: string;
   disabled?: boolean;
   required?: boolean;
-  isError?: boolean;
   error?: boolean;
   autoFocus?: boolean;
   align?: 'horizontal' | 'vertical';
@@ -97,7 +93,6 @@ export interface RadioProps {
   description?: string;
   disabled?: boolean;
   inputRef?: React.Ref<HTMLInputElement>;
-  isError?: boolean;
   error?: boolean;
   isFocused?: boolean;
   isFocusVisible?: boolean;

--- a/src/radio/radio.js
+++ b/src/radio/radio.js
@@ -39,7 +39,6 @@ class Radio extends React.Component<RadioPropsT, RadioStateT> {
     autoFocus: false,
     inputRef: React.createRef<HTMLInputElement>(),
     align: 'vertical',
-    isError: false,
     error: false,
     onChange: () => {},
     onMouseEnter: () => {},
@@ -58,11 +57,6 @@ class Radio extends React.Component<RadioPropsT, RadioStateT> {
   componentDidMount() {
     if (this.props.autoFocus && this.props.inputRef?.current) {
       this.props.inputRef.current.focus();
-    }
-    if (__DEV__ && this.props.isError) {
-      console.warn(
-        'baseui:Radio Property "isError" will be removed in the next major version. Use "error" property instead.'
-      );
     }
   }
 
@@ -107,7 +101,6 @@ class Radio extends React.Component<RadioPropsT, RadioStateT> {
       $disabled: this.props.disabled,
       $hasDescription: !!this.props.description,
       $isActive: this.state.isActive,
-      $isError: this.props.isError,
       $error: this.props.error,
       $isFocused: this.props.isFocused,
       $isFocusVisible: this.props.isFocused && this.props.isFocusVisible,
@@ -145,7 +138,7 @@ class Radio extends React.Component<RadioPropsT, RadioStateT> {
             <RadioMarkInner {...sharedProps} {...radioMarkInnerProps} />
           </RadioMarkOuter>
           <Input
-            aria-invalid={this.props.error || this.props.isError || null}
+            aria-invalid={this.props.error || null}
             checked={this.props.checked}
             disabled={this.props.disabled}
             name={this.props.name}

--- a/src/radio/radiogroup.js
+++ b/src/radio/radiogroup.js
@@ -21,7 +21,6 @@ class StatelessRadioGroup extends React.Component<PropsT, StatelessStateT> {
     autoFocus: false,
     labelPlacement: 'right',
     align: 'vertical',
-    isError: false,
     error: false,
     required: false,
     onChange: () => {},
@@ -33,14 +32,6 @@ class StatelessRadioGroup extends React.Component<PropsT, StatelessStateT> {
   };
 
   state = { isFocusVisible: false, focusedRadioIndex: -1 };
-
-  componentDidMount() {
-    if (__DEV__ && this.props.isError) {
-      console.warn(
-        'baseui:Radio Property "isError" will be removed in the next major version. Use "error" property instead.'
-      );
-    }
-  }
 
   handleFocus = (event: SyntheticInputEvent<HTMLInputElement>, index: number) => {
     if (isFocusVisible(event)) {
@@ -71,13 +62,12 @@ class StatelessRadioGroup extends React.Component<PropsT, StatelessStateT> {
         role="radiogroup"
         aria-describedby={this.props['aria-describedby']}
         aria-errormessage={this.props['aria-errormessage']}
-        aria-invalid={this.props.error || this.props.isError || null}
+        aria-invalid={this.props.error || null}
         aria-label={this.props['aria-label']}
         aria-labelledby={this.props['aria-labelledby']}
         $align={this.props.align}
         $disabled={this.props.disabled}
-        $isError={this.props.error || this.props.isError}
-        $error={this.props.error || this.props.isError}
+        $error={this.props.error}
         $required={this.props.required}
         {...radioGroupRootProps}
       >
@@ -91,7 +81,6 @@ class StatelessRadioGroup extends React.Component<PropsT, StatelessStateT> {
             autoFocus: this.props.autoFocus,
             checked,
             disabled: this.props.disabled || child.props.disabled,
-            isError: this.props.isError,
             error: this.props.error,
             isFocused: this.state.focusedRadioIndex === index,
             isFocusVisible: this.state.isFocusVisible,

--- a/src/radio/styled-components.js
+++ b/src/radio/styled-components.js
@@ -26,15 +26,14 @@ function getOuterColor(props) {
     $checked,
     $isFocusVisible,
     $error,
-    $isError,
   } = props;
   if ($disabled) return colors.tickFillDisabled;
   if (!$checked) {
     if ($isFocusVisible) return colors.borderSelected;
-    if ($error || $isError) return colors.tickBorderError;
+    if ($error) return colors.tickBorderError;
     return colors.tickBorder;
   } else {
-    if ($error || $isError) {
+    if ($error) {
       switch (getState(props)) {
         case DEFAULT:
           return colors.tickFillErrorSelected;
@@ -66,7 +65,7 @@ function getInnerColor(props) {
   }
 
   if (!props.$checked) {
-    if (props.$error || props.$isError) {
+    if (props.$error) {
       switch (getState(props)) {
         case DEFAULT:
           return colors.tickFillError;

--- a/src/radio/types.js
+++ b/src/radio/types.js
@@ -31,7 +31,6 @@ export type RadioGroupOverridesT = {
 export type DefaultPropsT = {
   value: string,
   disabled: boolean,
-  isError: boolean,
   error: boolean,
   autoFocus: boolean,
   labelPlacement: LabelPlacementT,
@@ -65,8 +64,6 @@ export type PropsT = {
   required?: boolean,
   /** Sets radio group into error state. */
   error?: boolean,
-  /** You should use the error prop instead. */
-  isError?: boolean,
   /** Set to be focused (active) on selected\checked radio. */
   autoFocus?: boolean,
   /** How to position radio buttons in the group. */
@@ -112,8 +109,6 @@ export type RadioPropsT = {
   inputRef?: ReactRefT<HTMLInputElement>,
   /** Renders checkbox in errored state. */
   error?: boolean,
-  /** You should use the error prop instead. */
-  isError?: boolean,
   /** Is radio focused / active? */
   isFocused?: boolean,
   /** Is parent RadioGroup focused by keyboard? */
@@ -201,7 +196,6 @@ export type StylePropsT = {
   $disabled: boolean,
   $hasDescription: boolean,
   $isActive: boolean,
-  $isError: boolean,
   $error: boolean,
   $isFocused: boolean,
   $isFocusVisible: boolean,


### PR DESCRIPTION
#### Description

Removes `isError` from `Radio` and `RadioGroup` components. Lint plugin changes here https://github.com/uber/baseweb/pull/4882

#### Scope
Major: Breaking change
