### PR TITLE
feat: use `ForwardRefRenderFunction`

### DIFF
--- a/documentation-site/examples/menu/virtual-list.tsx
+++ b/documentation-site/examples/menu/virtual-list.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {withStyle} from 'baseui';
 import {StatefulMenu, OptionList, StyledList} from 'baseui/menu';
 import {List, AutoSizer} from 'react-virtualized';
+import {GridCoreProps} from 'react-virtualized/dist/es/Grid';
 
 const ITEMS = Array.from({length: 1500}, (_, index) => ({
   label: `item number: ${index + 1}`,
@@ -9,41 +10,54 @@ const ITEMS = Array.from({length: 1500}, (_, index) => ({
 
 const Container = withStyle(StyledList, {height: '500px'});
 
-const VirtualList = React.forwardRef((props: any, ref) => {
-  const children = React.Children.toArray(props.children);
-  return (
-    <Container {...props} ref={ref}>
-      <AutoSizer>
-        {({width}) => (
-          <List
-            role={props.role}
-            height={500}
-            rowCount={props.children.length}
-            rowHeight={36}
-            rowRenderer={({index, key, style}) => (
-              <OptionList
-                key={key}
-                style={style}
-                {...children[index].props}
-                overrides={{
-                  ListItem: {
-                    style: {
-                      paddingTop: 0,
-                      paddingBottom: 0,
-                      display: 'flex',
-                      alignItems: 'center',
+type Children =
+  | React.ReactElement
+  | Exclude<React.ReactFragment, {}>;
+
+interface VirtualListProps extends GridCoreProps {
+  children: Children;
+}
+
+const VirtualList = React.forwardRef(
+  (props: VirtualListProps, ref) => {
+    const children = React.Children.toArray(
+      props.children,
+    ) as Children[];
+
+    return (
+      <Container {...props} ref={ref}>
+        <AutoSizer>
+          {({width}) => (
+            <List
+              role={props.role}
+              height={500}
+              rowCount={children.length}
+              rowHeight={36}
+              rowRenderer={({index, key, style}) => (
+                <OptionList
+                  key={key}
+                  style={style}
+                  {...children[index].props}
+                  overrides={{
+                    ListItem: {
+                      style: {
+                        paddingTop: 0,
+                        paddingBottom: 0,
+                        display: 'flex',
+                        alignItems: 'center',
+                      },
                     },
-                  },
-                }}
-              />
-            )}
-            width={width}
-          />
-        )}
-      </AutoSizer>
-    </Container>
-  );
-});
+                  }}
+                />
+              )}
+              width={width}
+            />
+          )}
+        </AutoSizer>
+      </Container>
+    );
+  },
+);
 
 export default function Example() {
   return (

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@types/lodash": "^4.14.141",
     "@types/node": "^12.6.8",
     "@types/prettier": "^1.18.0",
-    "@types/react": "^16.8.23",
+    "@types/react": "^17",
     "@types/react-dom": "^16.8.4",
     "@types/react-virtualized": "^9.21.3",
     "@types/react-window": "^1.8.1",
@@ -221,8 +221,8 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
-    "react": ">= 16.8.0 < 19",
-    "react-dom": ">= 16.8.0 < 19",
+    "react": ">= 17 < 19",
+    "react-dom": ">= 17 < 19",
     "styletron-react": ">=5.2.2 < 7"
   },
   "resolutions": {

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -8,7 +8,7 @@ type StyleOverride<T> =
 
 type ComponentOverride<T> =
   | React.ComponentType<T>
-  | React.RefForwardingComponent<T>;
+  | React.ForwardRefRenderFunction<T>;
 
 interface OverrideObject<T> {
   component?: ComponentOverride<T>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4319,13 +4319,27 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.8.23", "@types/react@^16.8.23":
+"@types/react@*", "@types/react@16.8.23":
   version "16.8.23"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.23.tgz#ec6be3ceed6353a20948169b6cb4c97b65b97ad2"
   integrity sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/react@^17":
+  version "17.0.44"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.44.tgz#c3714bd34dd551ab20b8015d9d0dbec812a51ec7"
+  integrity sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -8040,6 +8054,11 @@ csstype@^2.5.7, csstype@^2.6.4:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
   integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
+
+csstype@^3.0.2:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.11.tgz#d66700c5eacfac1940deb4e3ee5642792d85cd33"
+  integrity sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
Fixes #4900

#### Description

`RefForwardingComponent` is deprecated in favor of `ForwardRefRenderFunction`

I'm afraid this will have to wait until we drop v16 since `ForwardRefRenderFunction` is not available there.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2034c45ba9c4ac8524a58e2c8a84eb449d2af339/types/react/index.d.ts#L541-L545
<!-- Describe your changes below in as much detail as possible -->

#### Scope
<!-- Pick one:
Major: Breaking change
-->
