### PR TITLE
feat: add type of props passed to FormControl child

### DIFF
--- a/src/form-control/index.d.ts
+++ b/src/form-control/index.d.ts
@@ -32,3 +32,12 @@ export class FormControl extends React.Component<
   FormControlProps,
   FormControlState
 > {}
+
+export interface FormControlChildProps {
+  'aria-describedby': string | null,
+  'aria-errormessage': string | null,
+  key: React.Key,
+  disabled: boolean,
+  error: boolean,
+  positive: boolean
+}


### PR DESCRIPTION
Related to #4818

#### Description

The props passed to child of FormControl seems to have the shape mentioned in https://github.com/uber/baseweb/issues/4818#issuecomment-1093925352

This PR adds the type definition.

#### Scope

Minor: New Feature

