### PR TITLE
docs(select): update example to render correctly

### DIFF
--- a/documentation-site/examples/select/with-many-options.js
+++ b/documentation-site/examples/select/with-many-options.js
@@ -64,7 +64,7 @@ const VirtualDropdown = React.forwardRef((props, ref) => {
   );
 
   return (
-    <StyledList $style={{height: height + 'px'}} ref={ref}>
+    <StyledList ref={ref}>
       <FixedSizeList
         width="100%"
         height={height}


### PR DESCRIPTION
Update example to render correctly, copying the fix from #4461 for #3991 to the JS file.