### PR TITLE
fix(form-control.label): label component in form-control overrides theme font-weight

### DIFF
--- a/src/form-control/styled-components.js
+++ b/src/form-control/styled-components.js
@@ -16,7 +16,6 @@ export const Label = styled<StylePropsT>('label', (props) => {
   } = props;
   return {
     ...typography.font250,
-    fontWeight: 500,
     width: '100%',
     color: $disabled ? colors.contentSecondary : colors.contentPrimary,
     display: 'block',


### PR DESCRIPTION
#### Description

The Label component found in the FormControl component uses font250 which has a default font-weight of 500. 
When creating a theme with an overrides object it is possible to change the font weight of font250. 
This will affect, for example: Button with SIZE.compact, SortableLabel in Table component, etc.
This should also affect the aforementioned Label, but it doesn't because the fontWeight is always set to 500 (which is already the default because of using font250).

#### Scope
Patch: Bug Fix
