### PR TITLE
fix(datepicker): remove date callback param covariance

### DIFF
--- a/src/datepicker/types.js
+++ b/src/datepicker/types.js
@@ -241,7 +241,7 @@ export type DatepickerPropsT<T = Date> = {
   /** Where to mount the popover */
   mountNode?: HTMLElement,
   /** When single picker, fn is always called. When range picker, fn is called when start and end date are selected. */
-  onChange?: ({ +date: ?T | Array<T> }) => mixed,
+  onChange?: ({ date: ?T | Array<T> }) => mixed,
   /** Called when calendar is closed */
   onClose?: () => mixed,
   /** Called when calendar is opened */
@@ -320,7 +320,7 @@ export type StatefulContainerPropsT<PropsT, T = Date> = {
   /** A state change handler. */
   stateReducer: StateReducerT<T>,
   /** When single picker, fn is called when date/time is selected. When range picker, fn is called when both start and end are selected. */
-  onChange?: ({ +date: ?T | Array<T> }) => mixed,
+  onChange?: ({ date: ?T | Array<T> }) => mixed,
   /** When single picker, fn is called when date/time is selected. When range picker, fn is called when either start or end date changes. */
   onRangeChange?: ({ +date: ?T | Array<?T> }) => mixed,
   adapter?: DateIOAdapter<T>,


### PR DESCRIPTION
#### Description

Resolves a small issue I introduced in https://github.com/uber/baseweb/pull/4932 where I made the date param covariant in onChange `onChange: ({ +date: ?T | Array<T> }) => mixed` but this causes problems for existing applications that have explicitly typed their callback fn. This was a test I had made that I neglected to revert before making the previous pr.

```jsx
function MyComponent() {
  // state management...

  // flow incompatible-variance error below
  function handleChange({ date: ?Date | Array<Date> }) {}

  return <Datepicker onChange={handleChange} />
}
```

#### Scope
Patch: Bug Fix
