### PR TITLE
fix(list-item): modify list-item props type (artwork, endEnhancer)

### DIFF
--- a/src/list/index.d.ts
+++ b/src/list/index.d.ts
@@ -47,11 +47,11 @@ export interface LabelOverrides {
 }
 
 export interface PropsT {
-  artwork?: React.ReactNode;
+  artwork?: (args: { size: number }) => React.ReactNode;
   artworkSize?: ArtworkSizesT | number;
   shape?: ShapeT;
   children: React.ReactNode;
-  endEnhancer?: React.ReactNode;
+  endEnhancer?: () => React.ReactNode;
   overrides?: ListOverrides;
   sublist?: boolean;
 }


### PR DESCRIPTION

#### Description

There was an error when I set the value of `artwork` and `endEnhancer` to the current type React.ReactNode. It was the wrong type. So, I changed the type of `artwork` and `endEnhancer`.

#### Scope

Patch: Bug Fix

