### PR TITLE
docs(setup): add info about installing npm types

### DIFF
--- a/documentation-site/pages/getting-started/setup.mdx
+++ b/documentation-site/pages/getting-started/setup.mdx
@@ -29,7 +29,11 @@ Base Web ships with both Flow and TypeScript support. Styletron ships only with 
 TypeScript, however, there are external TypeScript declarations:
 
 ```bash
+# using yarn
 yarn add @types/styletron-standard @types/styletron-react @types/styletron-engine-atomic
+
+# using npm
+npm install @types/styletron-standard @types/styletron-react @types/styletron-engine-atomic
 ```
 
 Our React components don't use [PropTypes](https://reactjs.org/docs/typechecking-with-proptypes.html).


### PR DESCRIPTION
#### Description

Explains how to install types with npm, to be consistent with rest of the docs.

#### Scope
Patch: Bug Fix