### PR TITLE
fix(select): handleBlur should check event type before bound check

### DIFF
--- a/src/select/__tests__/select-controlref.test.js
+++ b/src/select/__tests__/select-controlref.test.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, getByTestId } from '@testing-library/react';
 import BaseProvider from '../../helpers/base-provider.js';
 import { LightTheme } from '../../themes/index.js';
 
@@ -150,5 +150,56 @@ describe('setInputValue', function () {
       }
     });
     expect(input?.getAttribute('value')).toBe('item not included');
+  });
+});
+
+describe('setInputFocus', function () {
+  const getBorderColor = (container) => {
+    let controlContainer = getByTestId(container, 'control-container');
+
+    let testStyle = controlContainer.getAttribute('test-style');
+    let style = JSON.parse(testStyle || '');
+
+    return style.borderLeftColor;
+  };
+
+  it('focuses the input', () => {
+    const options = [
+      { id: 'a', label: 'a' },
+      { id: 'b', label: 'b' },
+      { id: 'c', label: 'c' },
+    ];
+    const controlRef = React.createRef();
+
+    const TestCase = () => {
+      const [value, setValue] = React.useState([]);
+
+      return (
+        <BaseProvider theme={LightTheme}>
+          <Select
+            value={value}
+            onChange={(params) => setValue(params.value)}
+            options={options}
+            controlRef={controlRef}
+            overrides={{
+              ControlContainer: {
+                props: { 'data-testid': 'control-container' },
+              },
+            }}
+          />
+        </BaseProvider>
+      );
+    };
+
+    const { container, getByRole } = render(<TestCase />);
+    const input = getByRole('combobox');
+
+    expect(getBorderColor(container)).toEqual('$theme.colors.inputBorder');
+
+    fireEvent.focus(input);
+    expect(getBorderColor(container)).toEqual('$theme.colors.borderSelected');
+
+    fireEvent.blur(input);
+    expect(getBorderColor(container)).toEqual('$theme.colors.inputBorder');
   });
 });

--- a/src/select/select-component.js
+++ b/src/select/select-component.js
@@ -318,8 +318,10 @@ class Select extends React.Component<PropsT, SelectStateT> {
       ) {
         return;
       }
-    } else if (containsNode(this.anchor.current, event.target)) {
-      return;
+    } else if (event.type !== 'blur') {
+      if (containsNode(this.anchor.current, event.target)) {
+        return;
+      }
     }
 
     if (this.props.onBlur) {


### PR DESCRIPTION
Fixes [#4936](https://github.com/uber/baseweb/issues/4936)

#### Description

When we handle a blur event in the select-component, we want to check if
the event is transferring focus to an element which is a child of the
select component before we un-focus.

Because handle blur takes FocusEvents or MouseEvents, there is a hole in
the logic, where a FocusEvent which does not have a relatedTarget (which
is what happens if you imperatively blur with element.blur() or via the
controlRef.setInputBlur() ) will pass to the second conditional check in
handleBlur, which should only be applied to mouse events (i.e. If you
click on a new element, we check if that new element (event.target) is
inside our anchor).

In the case of a FocusEvent, event.target is the element being blurred
(the input) so it will always be inside our anchor.

#### Scope
Patch: Bug Fix

