### PR TITLE
chore(spinner): remove styledspinnernext deprecation warning

### DIFF
--- a/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
+++ b/packages/eslint-plugin-baseui/__tests__/deprecated-component-api.test.js
@@ -376,28 +376,6 @@ const tests = {
       errors: [{ messageId: MESSAGES.modalBackdrop.id }],
     },
 
-    // Spinner
-    {
-      code: `
-        import { Spinner } from "baseui/spinner"
-        export default function() {
-          return <Spinner />
-        }
-      `,
-      errors: [{ messageId: MESSAGES.deprecateSpinner.id }],
-    },
-
-    // Spinner renamed
-    {
-      code: `
-        import { Spinner as BaseSpinner } from "baseui/spinner"
-        export default function() {
-          return <BaseSpinner />
-        }
-      `,
-      errors: [{ messageId: MESSAGES.deprecateSpinner.id }],
-    },
-
     // Button - minimal kind
     // Prop as imported constant
     {

--- a/packages/eslint-plugin-baseui/src/deprecated-component-api.js
+++ b/packages/eslint-plugin-baseui/src/deprecated-component-api.js
@@ -50,7 +50,6 @@ module.exports = {
     fixable: 'code',
     messages: {
       [MESSAGES.replace.id]: MESSAGES.replace.message,
-      [MESSAGES.deprecateSpinner.id]: MESSAGES.deprecateSpinner.message,
       [MESSAGES.buttonKindMinimal.id]: MESSAGES.buttonKindMinimal.message,
       [MESSAGES.modalBackdrop.id]: MESSAGES.modalBackdrop.message,
       [MESSAGES.radioGroupOverrides.id]: MESSAGES.radioGroupOverrides.message,
@@ -113,18 +112,6 @@ module.exports = {
             specifier.type !== 'ImportNamespaceSpecifier' &&
             specifier.type !== 'ImportDefaultSpecifier'
           ) {
-            // Spinner
-            // Ex: import {Spinner} from "baseui/spinner";
-            // Note, we are not replacing Spinner because the new API
-            // is not compatible.
-            if (isImporting(specifier, 'Spinner', 'baseui/spinner')) {
-              context.report({
-                node: specifier.imported,
-                messageId: MESSAGES.deprecateSpinner.id,
-              });
-              return;
-            }
-
             // These can be referenced later on by instances of components.
             if (isImporting(specifier, 'Accordion', 'baseui/accordion')) return;
             if (isImporting(specifier, 'Modal', 'baseui/modal')) return;

--- a/packages/eslint-plugin-baseui/src/messages.js
+++ b/packages/eslint-plugin-baseui/src/messages.js
@@ -20,10 +20,6 @@ module.exports = {
     id: 'replaceThemeProperty',
     message: `The theme property, "{{ old }}", is deprecated and can be replaced with "{{ new }}".`,
   },
-  deprecateSpinner: {
-    id: 'deprecateSpinner',
-    message: `The "Spinner" component has been deprecated in favor of "StyledSpinnerNext". In v11 of baseui, "Spinner" will be removed and "StyledSpinnerNext" will be renamed to "Spinner".`,
-  },
   styleOnBlock: {
     id: 'styleOnBlock',
     message: `"$style" and "style" are not supported props for the "Block" component. Please use "overrides.Block" to pass styles down to the root element.`,


### PR DESCRIPTION
Fixes #4908

In v11, `Spinner` was deprecated and `StyledSpinnerNext` was renamed to `Spinner`. Remove the warning as it no longer applies.

#### Scope
Patch: Remove deprecation warning