### PR TITLE
fix(styletron): correct StyletronComponent signature

### DIFF
--- a/src/accordion/index.d.ts
+++ b/src/accordion/index.d.ts
@@ -123,10 +123,10 @@ export class StatefulPanelContainer extends React.Component<
   ): void;
 }
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledPanelContainer: StyletronComponent<any, any>;
-export declare const StyledHeader: StyletronComponent<any, any>;
-export declare const StyledContent: StyletronComponent<any, any>;
-export declare const StyledContentAnimationContainer: StyletronComponent<any, any>;
-export declare const StyledToggleIcon: StyletronComponent<any, any>;
-export declare const StyledToggleIconGroup: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledPanelContainer: StyletronComponent<any>;
+export declare const StyledHeader: StyletronComponent<any>;
+export declare const StyledContent: StyletronComponent<any>;
+export declare const StyledContentAnimationContainer: StyletronComponent<any>;
+export declare const StyledToggleIcon: StyletronComponent<any>;
+export declare const StyledToggleIconGroup: StyletronComponent<any>;

--- a/src/avatar/index.d.ts
+++ b/src/avatar/index.d.ts
@@ -22,6 +22,6 @@ export interface AvatarProps {
 
 export declare const Avatar: React.FC<AvatarProps>;
 
-export declare const StyledAvatar: StyletronComponent<any, any>;
-export declare const StyledInitials: StyletronComponent<any, any>;
-export declare const StyledRoot: StyletronComponent<any, any>;
+export declare const StyledAvatar: StyletronComponent<any>;
+export declare const StyledInitials: StyletronComponent<any>;
+export declare const StyledRoot: StyletronComponent<any>;

--- a/src/badge/index.d.ts
+++ b/src/badge/index.d.ts
@@ -81,11 +81,11 @@ export type HintDotPropsT = {
   children?: React.ReactNode;
 };
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledPositioner: StyletronComponent<any, any>;
-export declare const StyledBadge: StyletronComponent<any, any>;
-export declare const StyledNotificationCircle: StyletronComponent<any, any>;
-export declare const StyledHintDot: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledPositioner: StyletronComponent<any>;
+export declare const StyledBadge: StyletronComponent<any>;
+export declare const StyledNotificationCircle: StyletronComponent<any>;
+export declare const StyledHintDot: StyletronComponent<any>;
 
 export declare const Badge: React.FC<BadgePropsT>;
 export declare const NotificationCircle: React.FC<NotificationCirclePropsT>;

--- a/src/banner/index.d.ts
+++ b/src/banner/index.d.ts
@@ -57,14 +57,14 @@ export interface PropsT {
   title?: React.ReactNode;
 }
 
-export declare const StyledBelowContent: StyletronComponent<any, any>;
-export declare const StyledLeadingContent: StyletronComponent<any, any>;
-export declare const StyledMessage: StyletronComponent<any, any>;
-export declare const StyledMessageContent: StyletronComponent<any, any>;
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledTitle: StyletronComponent<any, any>;
-export declare const StyledTrailingContent: StyletronComponent<any, any>;
-export declare const StyledTrailingButtonContainer: StyletronComponent<any, any>;
-export declare const StyledTrailingIconButton: StyletronComponent<any, any>;
+export declare const StyledBelowContent: StyletronComponent<any>;
+export declare const StyledLeadingContent: StyletronComponent<any>;
+export declare const StyledMessage: StyletronComponent<any>;
+export declare const StyledMessageContent: StyletronComponent<any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledTitle: StyletronComponent<any>;
+export declare const StyledTrailingContent: StyletronComponent<any>;
+export declare const StyledTrailingButtonContainer: StyletronComponent<any>;
+export declare const StyledTrailingIconButton: StyletronComponent<any>;
 
 export declare const Banner: React.FC<PropsT>;

--- a/src/breadcrumbs/index.d.ts
+++ b/src/breadcrumbs/index.d.ts
@@ -20,5 +20,5 @@ export interface BreadcrumbsProps {
 
 export declare const Breadcrumbs: React.FC<BreadcrumbsProps>;
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledSeparator: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledSeparator: StyletronComponent<any>;

--- a/src/button-group/index.d.ts
+++ b/src/button-group/index.d.ts
@@ -14,7 +14,7 @@ export declare const STATE_CHANGE_TYPE: {
   change: 'change';
 };
 
-export declare const StyledRoot: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
 
 export interface ButtonGroupOverrides {
   Root?: Override<any>;

--- a/src/button/index.d.ts
+++ b/src/button/index.d.ts
@@ -56,10 +56,10 @@ export interface ButtonProps {
   type?: 'submit' | 'reset' | 'button';
 }
 
-export declare const StyledBaseButton: StyletronComponent<any, any>;
-export declare const StyledStartEnhancer: StyletronComponent<any, any>;
-export declare const StyledEndEnhancer: StyletronComponent<any, any>;
-export declare const StyledLoadingSpinner: StyletronComponent<any, any>;
-export declare const StyledLoadingSpinnerContainer: StyletronComponent<any, any>;
+export declare const StyledBaseButton: StyletronComponent<any>;
+export declare const StyledStartEnhancer: StyletronComponent<any>;
+export declare const StyledEndEnhancer: StyletronComponent<any>;
+export declare const StyledLoadingSpinner: StyletronComponent<any>;
+export declare const StyledLoadingSpinnerContainer: StyletronComponent<any>;
 
-export declare const Button: StyletronComponent<any, ButtonProps>;
+export declare const Button: StyletronComponent<ButtonProps>;

--- a/src/card/index.d.ts
+++ b/src/card/index.d.ts
@@ -25,11 +25,11 @@ export interface CardProps {
 export declare const Card: React.FC<CardProps>;
 export type hasThumbnail = (props: { readonly thumbnail?: string }) => boolean;
 
-export declare const StyledAction: StyletronComponent<any, any>;
-export declare const StyledBody: StyletronComponent<any, any>;
-export declare const StyledContents: StyletronComponent<any, any>;
-export declare const StyledHeaderImage: StyletronComponent<any, any>;
-export declare const StyledThumbnail: StyletronComponent<any, any>;
-export declare const StyledTitle: StyletronComponent<any, any>;
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledWrapper: StyletronComponent<any, any>;
+export declare const StyledAction: StyletronComponent<any>;
+export declare const StyledBody: StyletronComponent<any>;
+export declare const StyledContents: StyletronComponent<any>;
+export declare const StyledHeaderImage: StyletronComponent<any>;
+export declare const StyledThumbnail: StyletronComponent<any>;
+export declare const StyledTitle: StyletronComponent<any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledWrapper: StyletronComponent<any>;

--- a/src/checkbox/index.d.ts
+++ b/src/checkbox/index.d.ts
@@ -23,13 +23,13 @@ type initialState = {
   isIndeterminate?: boolean;
 };
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledCheckmark: StyletronComponent<any, any>;
-export declare const StyledLabel: StyletronComponent<any, any>;
-export declare const StyledInput: StyletronComponent<any, any>;
-export declare const StyledToggle: StyletronComponent<any, any>;
-export declare const StyledToggleInner: StyletronComponent<any, any>;
-export declare const StyledToggleTrack: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledCheckmark: StyletronComponent<any>;
+export declare const StyledLabel: StyletronComponent<any>;
+export declare const StyledInput: StyletronComponent<any>;
+export declare const StyledToggle: StyletronComponent<any>;
+export declare const StyledToggleInner: StyletronComponent<any>;
+export declare const StyledToggleTrack: StyletronComponent<any>;
 
 export type StateReducer = (
   stateType: string,

--- a/src/dnd-list/index.d.ts
+++ b/src/dnd-list/index.d.ts
@@ -69,12 +69,12 @@ export interface ListProps {
 
 export class List extends React.Component<ListProps> {}
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledList: StyletronComponent<any, any>;
-export declare const StyledItem: StyletronComponent<any, any>;
-export declare const StyledDragHandle: StyletronComponent<any, any>;
-export declare const StyledCloseHandle: StyletronComponent<any, any>;
-export declare const StyledLabel: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledList: StyletronComponent<any>;
+export declare const StyledItem: StyletronComponent<any>;
+export declare const StyledDragHandle: StyletronComponent<any>;
+export declare const StyledCloseHandle: StyletronComponent<any>;
+export declare const StyledLabel: StyletronComponent<any>;
 
 export declare const arrayMove: typeof arrayMoveT;
 export declare const arrayRemove: typeof arrayRemoveT;

--- a/src/drawer/index.d.ts
+++ b/src/drawer/index.d.ts
@@ -84,8 +84,8 @@ export class Drawer extends React.Component<DrawerProps, DrawerState> {
   renderDrawer(): React.ReactNode;
 }
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledBackdrop: StyletronComponent<any, any>;
-export declare const StyledDrawerContainer: StyletronComponent<any, any>;
-export declare const StyledDrawerBody: StyletronComponent<any, any>;
-export declare const StyledClose: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledBackdrop: StyletronComponent<any>;
+export declare const StyledDrawerContainer: StyletronComponent<any>;
+export declare const StyledDrawerBody: StyletronComponent<any>;
+export declare const StyledClose: StyletronComponent<any>;

--- a/src/file-uploader/index.d.ts
+++ b/src/file-uploader/index.d.ts
@@ -69,8 +69,8 @@ export interface FileUploaderProps {
 }
 export declare const FileUploader: React.FC<FileUploaderProps>;
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledFileDragAndDrop: StyletronComponent<any, any>;
-export declare const StyledContentMessage: StyletronComponent<any, any>;
-export declare const StyledErrorMessage: StyletronComponent<any, any>;
-export declare const StyledHiddenInput: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledFileDragAndDrop: StyletronComponent<any>;
+export declare const StyledContentMessage: StyletronComponent<any>;
+export declare const StyledErrorMessage: StyletronComponent<any>;
+export declare const StyledHiddenInput: StyletronComponent<any>;

--- a/src/form-control/index.d.ts
+++ b/src/form-control/index.d.ts
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { StyletronComponent } from 'styletron-react';
 import { Override } from '../overrides';
 
-export declare const StyledLabel: StyletronComponent<any, any>;
-export declare const StyledCaption: StyletronComponent<any, any>;
-export declare const StyledControlContainer: StyletronComponent<any, any>;
+export declare const StyledLabel: StyletronComponent<any>;
+export declare const StyledCaption: StyletronComponent<any>;
+export declare const StyledControlContainer: StyletronComponent<any>;
 
 export interface FormControlOverrides {
   Label?: Override<any>;

--- a/src/header-navigation/index.d.ts
+++ b/src/header-navigation/index.d.ts
@@ -19,6 +19,6 @@ export interface HeaderNavigationProps {
 
 export class HeaderNavigation extends React.Component<HeaderNavigationProps> {}
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledNavigationItem: StyletronComponent<any, any>;
-export declare const StyledNavigationList: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledNavigationItem: StyletronComponent<any>;
+export declare const StyledNavigationList: StyletronComponent<any>;

--- a/src/helper/index.d.ts
+++ b/src/helper/index.d.ts
@@ -22,8 +22,8 @@ export type HelperStepsPropsT = {
 
 export { ACCESSIBILITY_TYPE, PLACEMENT, TRIGGER_TYPE };
 
-export declare const StyledArrow: StyletronComponent<any, any>;
-export declare const StyledBody: StyletronComponent<any, any>;
+export declare const StyledArrow: StyletronComponent<any>;
+export declare const StyledBody: StyletronComponent<any>;
 
 export declare const Unstable_Helper: React.FC<PropsT>;
 export declare const Unstable_StatefulHelper: React.FC<StatefulPropsT>;

--- a/src/icon/index.d.ts
+++ b/src/icon/index.d.ts
@@ -21,7 +21,7 @@ export interface IconProps {
 
 export declare const Icon: React.FC<IconProps>;
 
-export declare const StyledSvg: StyletronComponent<any, any>;
+export declare const StyledSvg: StyletronComponent<any>;
 
 export declare const Alert: React.FC<IconProps>;
 export declare const ArrowDown: React.FC<IconProps>;

--- a/src/input/index.d.ts
+++ b/src/input/index.d.ts
@@ -154,9 +154,9 @@ export type StatefulInputProps = InputProps & StatefulContainerProps & { childre
 export declare const StatefulInput: React.FC<StatefulInputProps>;
 export declare const StatefulContainer: React.FC<StatefulContainerProps>;
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledInputEnhancer: StyletronComponent<any, any>;
-export declare const StyledStartEnhancer: StyletronComponent<any, any>;
-export declare const StyledEndEnhancer: StyletronComponent<any, any>;
-export declare const StyledInputContainer: StyletronComponent<any, any>;
-export declare const StyledInput: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledInputEnhancer: StyletronComponent<any>;
+export declare const StyledStartEnhancer: StyletronComponent<any>;
+export declare const StyledEndEnhancer: StyletronComponent<any>;
+export declare const StyledInputContainer: StyletronComponent<any>;
+export declare const StyledInput: StyletronComponent<any>;

--- a/src/layout-grid/index.d.ts
+++ b/src/layout-grid/index.d.ts
@@ -94,5 +94,5 @@ export type StyledCellProps = {
 
 export declare const Grid: React.FunctionComponent<GridProps>;
 export declare const Cell: React.FunctionComponent<CellProps>;
-export declare const StyledGrid: StyletronComponent<any, StyledGridProps>;
-export declare const StyledCell: StyletronComponent<any, StyledCellProps>;
+export declare const StyledGrid: StyletronComponent<StyledGridProps>;
+export declare const StyledCell: StyletronComponent<StyledCellProps>;

--- a/src/link/index.d.ts
+++ b/src/link/index.d.ts
@@ -10,4 +10,4 @@ export interface LinkProps
   target?: '_self' | '_blank' | '_parent' | '_top';
 }
 
-export declare const StyledLink: StyletronComponent<any, LinkProps>;
+export declare const StyledLink: StyletronComponent<LinkProps>;

--- a/src/list/index.d.ts
+++ b/src/list/index.d.ts
@@ -73,10 +73,10 @@ export declare const ListItem: React.ForwardRefExoticComponent<
 export declare const ListItemLabel: React.FC<LabelPropsT>;
 export declare const MenuAdapter: React.FC<MenuAdapterPropsT>;
 
-export declare const StyledRoot: StyletronComponent<any, {}>;
-export declare const StyledContent: StyletronComponent<any, StyledContentPropsT>;
-export declare const StyledEndEnhancerContainer: StyletronComponent<any, {}>;
-export declare const StyledArtworkContainer: StyletronComponent<any, StyledArtworkContainerPropsT>;
+export declare const StyledRoot: StyletronComponent<{}>;
+export declare const StyledContent: StyletronComponent<StyledContentPropsT>;
+export declare const StyledEndEnhancerContainer: StyletronComponent<{}>;
+export declare const StyledArtworkContainer: StyletronComponent<StyledArtworkContainerPropsT>;
 
 export interface HeadingPropsT {
   heading: React.ReactNode;
@@ -99,13 +99,10 @@ export declare const ListHeading: React.ForwardRefExoticComponent<
   HeadingPropsT & React.RefAttributes<HTMLLIElement>
 >;
 
-export declare const StyledHeadingRoot: StyletronComponent<any, {}>;
-export declare const StyledHeadingContent: StyletronComponent<any, {}>;
-export declare const StyledHeadingContentRow: StyletronComponent<any, {}>;
-export declare const StyledHeadingMainHeading: StyletronComponent<any, StyledHeadingHeadingPropsT>;
-export declare const StyledHeadingSubHeading: StyletronComponent<any, StyledHeadingHeadingPropsT>;
-export declare const StyledHeadingEndEnhancerContainer: StyletronComponent<
-  any,
-  StyledHeadingEndEnhancerContainerPropsT
->;
-export declare const StyledHeadingEndEnhancerDescriptionContainer: StyletronComponent<any, {}>;
+export declare const StyledHeadingRoot: StyletronComponent<{}>;
+export declare const StyledHeadingContent: StyletronComponent<{}>;
+export declare const StyledHeadingContentRow: StyletronComponent<{}>;
+export declare const StyledHeadingMainHeading: StyletronComponent<StyledHeadingHeadingPropsT>;
+export declare const StyledHeadingSubHeading: StyletronComponent<StyledHeadingHeadingPropsT>;
+export declare const StyledHeadingEndEnhancerContainer: StyletronComponent<StyledHeadingEndEnhancerContainerPropsT>;
+export declare const StyledHeadingEndEnhancerDescriptionContainer: StyletronComponent<{}>;

--- a/src/menu/index.d.ts
+++ b/src/menu/index.d.ts
@@ -200,13 +200,13 @@ export class NestedMenus extends React.Component<NestedMenuProps, NestedMenuStat
   isNestedMenuVisible(ref: React.Ref<HTMLElement>): boolean;
 }
 
-export declare const StyledEmptyState: StyletronComponent<any, any>;
-export declare const StyledList: StyletronComponent<any, any>;
-export declare const StyledListItem: StyletronComponent<any, any>;
-export declare const StyledListItemProfile: StyletronComponent<any, any>;
-export declare const StyledProfileImgContainer: StyletronComponent<any, any>;
-export declare const StyledProfileImg: StyletronComponent<any, any>;
-export declare const StyledProfileLabelsContainer: StyletronComponent<any, any>;
-export declare const StyledProfileTitle: StyletronComponent<any, any>;
-export declare const StyledProfileSubtitle: StyletronComponent<any, any>;
-export declare const StyledProfileBody: StyletronComponent<any, any>;
+export declare const StyledEmptyState: StyletronComponent<any>;
+export declare const StyledList: StyletronComponent<any>;
+export declare const StyledListItem: StyletronComponent<any>;
+export declare const StyledListItemProfile: StyletronComponent<any>;
+export declare const StyledProfileImgContainer: StyletronComponent<any>;
+export declare const StyledProfileImg: StyletronComponent<any>;
+export declare const StyledProfileLabelsContainer: StyletronComponent<any>;
+export declare const StyledProfileTitle: StyletronComponent<any>;
+export declare const StyledProfileSubtitle: StyletronComponent<any>;
+export declare const StyledProfileBody: StyletronComponent<any>;

--- a/src/modal/index.d.ts
+++ b/src/modal/index.d.ts
@@ -85,10 +85,10 @@ export class ModalButton extends React.Component<ButtonProps & { autoFocus?: boo
 
 export class FocusOnce extends React.Component<{ children: React.ReactNode }> {}
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledDialog: StyletronComponent<any, any>;
-export declare const StyledDialogContainer: StyletronComponent<any, any>;
-export declare const StyledClose: StyletronComponent<any, any>;
-export declare const ModalHeader: StyletronComponent<any, any>;
-export declare const ModalBody: StyletronComponent<any, any>;
-export declare const ModalFooter: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledDialog: StyletronComponent<any>;
+export declare const StyledDialogContainer: StyletronComponent<any>;
+export declare const StyledClose: StyletronComponent<any>;
+export declare const ModalHeader: StyletronComponent<any>;
+export declare const ModalBody: StyletronComponent<any>;
+export declare const ModalFooter: StyletronComponent<any>;

--- a/src/pagination/index.d.ts
+++ b/src/pagination/index.d.ts
@@ -87,6 +87,6 @@ export class StatefulContainer extends React.Component<StatefulContainerProps, S
   onPageChange(args: { nextPage: number }): void;
 }
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledMaxLabel: StyletronComponent<any, any>;
-export declare const StyledDropdownContainer: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledMaxLabel: StyletronComponent<any>;
+export declare const StyledDropdownContainer: StyletronComponent<any>;

--- a/src/payment-card/index.d.ts
+++ b/src/payment-card/index.d.ts
@@ -25,4 +25,4 @@ export type StatefulPaymentCardProps = InputProps &
 export declare const StatefulPaymentCard: React.FC<StatefulPaymentCardProps>;
 export class PaymentCard extends React.Component<PaymentCardProps> {}
 
-export declare const StyledIconWrapper: StyletronComponent<any, any>;
+export declare const StyledIconWrapper: StyletronComponent<any>;

--- a/src/phone-input/index.d.ts
+++ b/src/phone-input/index.d.ts
@@ -426,15 +426,15 @@ export interface FlagProps {
 }
 export declare const Flag: React.FC<FlagProps>;
 
-export declare const StyledFlag: StyletronComponent<any, any>;
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledDialCode: StyletronComponent<any, any>;
-export declare const StyledCountrySelectContainer: StyletronComponent<any, any>;
-export declare const StyledCountrySelectDropdownContainer: StyletronComponent<any, any>;
-export declare const StyledCountrySelectDropdownListItem: StyletronComponent<any, any>;
-export declare const StyledCountrySelectDropdownFlagColumn: StyletronComponent<any, any>;
-export declare const StyledCountrySelectDropdownNameColumn: StyletronComponent<any, any>;
-export declare const StyledCountrySelectDropdownDialcodeColumn: StyletronComponent<any, any>;
+export declare const StyledFlag: StyletronComponent<any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledDialCode: StyletronComponent<any>;
+export declare const StyledCountrySelectContainer: StyletronComponent<any>;
+export declare const StyledCountrySelectDropdownContainer: StyletronComponent<any>;
+export declare const StyledCountrySelectDropdownListItem: StyletronComponent<any>;
+export declare const StyledCountrySelectDropdownFlagColumn: StyletronComponent<any>;
+export declare const StyledCountrySelectDropdownNameColumn: StyletronComponent<any>;
+export declare const StyledCountrySelectDropdownDialcodeColumn: StyletronComponent<any>;
 
 export declare const DEFAULT_MAX_DROPDOWN_WIDTH: '400px';
 export declare const DEFAULT_MAX_DROPDOWN_HEIGHT: '400px';

--- a/src/popover/index.d.ts
+++ b/src/popover/index.d.ts
@@ -177,10 +177,10 @@ export class Popover extends React.Component<PopoverProps, PopoverPrivateState> 
   renderPopover(): React.ReactNode;
 }
 
-export declare const StyledArrow: StyletronComponent<any, any>;
-export declare const StyledBody: StyletronComponent<any, any>;
-export declare const StyledInner: StyletronComponent<any, any>;
-export declare const StyledPadding: StyletronComponent<any, any>;
+export declare const StyledArrow: StyletronComponent<any>;
+export declare const StyledBody: StyletronComponent<any>;
+export declare const StyledInner: StyletronComponent<any>;
+export declare const StyledPadding: StyletronComponent<any>;
 
 export declare const POPOVER_MARGIN: 8;
 export declare const ARROW_SIZE: 6;

--- a/src/progress-bar/index.d.ts
+++ b/src/progress-bar/index.d.ts
@@ -49,9 +49,9 @@ export interface ProgressBarRoundedProps {
 }
 export declare const ProgressBarRounded: React.FC<ProgressBarRoundedProps>;
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledBarContainer: StyletronComponent<any, any>;
-export declare const StyledBar: StyletronComponent<any, any>;
-export declare const StyledBarProgress: StyletronComponent<any, any>;
-export declare const StyledInfiniteBar: StyletronComponent<any, any>;
-export declare const StyledLabel: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledBarContainer: StyletronComponent<any>;
+export declare const StyledBar: StyletronComponent<any>;
+export declare const StyledBarProgress: StyletronComponent<any>;
+export declare const StyledInfiniteBar: StyletronComponent<any>;
+export declare const StyledLabel: StyletronComponent<any>;

--- a/src/progress-steps/index.d.ts
+++ b/src/progress-steps/index.d.ts
@@ -58,14 +58,14 @@ export interface StyleProps {
   $isCompleted?: boolean;
   $disabled?: boolean;
 }
-export declare const StyledProgressSteps: StyletronComponent<any, StyleProps>;
-export declare const StyledStep: StyletronComponent<any, StyleProps>;
-export declare const StyledIcon: StyletronComponent<any, StyleProps>;
-export declare const StyledInnerIcon: StyletronComponent<any, StyleProps>;
-export declare const StyledContent: StyletronComponent<any, StyleProps>;
-export declare const StyledContentTitle: StyletronComponent<any, StyleProps>;
-export declare const StyledContentTail: StyletronComponent<any, StyleProps>;
-export declare const StyledContentDescription: StyletronComponent<any, StyleProps>;
-export declare const StyledNumberStep: StyletronComponent<any, StyleProps>;
-export declare const StyledNumberIcon: StyletronComponent<any, StyleProps>;
-export declare const StyledNumberContentTail: StyletronComponent<any, StyleProps>;
+export declare const StyledProgressSteps: StyletronComponent<StyleProps>;
+export declare const StyledStep: StyletronComponent<StyleProps>;
+export declare const StyledIcon: StyletronComponent<StyleProps>;
+export declare const StyledInnerIcon: StyletronComponent<StyleProps>;
+export declare const StyledContent: StyletronComponent<StyleProps>;
+export declare const StyledContentTitle: StyletronComponent<StyleProps>;
+export declare const StyledContentTail: StyletronComponent<StyleProps>;
+export declare const StyledContentDescription: StyletronComponent<StyleProps>;
+export declare const StyledNumberStep: StyletronComponent<StyleProps>;
+export declare const StyledNumberIcon: StyletronComponent<StyleProps>;
+export declare const StyledNumberContentTail: StyletronComponent<StyleProps>;

--- a/src/radio/index.d.ts
+++ b/src/radio/index.d.ts
@@ -125,10 +125,10 @@ export class Radio extends React.Component<RadioProps, RadioState> {
   onBlur(event: React.FocusEvent<HTMLInputElement>): void;
 }
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledLabel: StyletronComponent<any, any>;
-export declare const StyledInput: StyletronComponent<any, any>;
-export declare const StyledDescription: StyletronComponent<any, any>;
-export declare const StyledRadioMarkInner: StyletronComponent<any, any>;
-export declare const StyledRadioMarkOuter: StyletronComponent<any, any>;
-export declare const StyledRadioGroupRoot: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledLabel: StyletronComponent<any>;
+export declare const StyledInput: StyletronComponent<any>;
+export declare const StyledDescription: StyletronComponent<any>;
+export declare const StyledRadioMarkInner: StyletronComponent<any>;
+export declare const StyledRadioMarkOuter: StyletronComponent<any>;
+export declare const StyledRadioGroupRoot: StyletronComponent<any>;

--- a/src/rating/index.d.ts
+++ b/src/rating/index.d.ts
@@ -48,6 +48,6 @@ export interface StyledRatingItemProps {
   $isSelected: boolean;
   $index: number;
 }
-export declare const StyledRoot: StyletronComponent<any, StyledRootProps>;
-export declare const StyledStar: StyletronComponent<any, StyledRatingItemProps>;
-export declare const StyledEmoticon: StyletronComponent<any, StyledRatingItemProps>;
+export declare const StyledRoot: StyletronComponent<StyledRootProps>;
+export declare const StyledStar: StyletronComponent<StyledRatingItemProps>;
+export declare const StyledEmoticon: StyletronComponent<StyledRatingItemProps>;

--- a/src/select/index.d.ts
+++ b/src/select/index.d.ts
@@ -308,19 +308,19 @@ export class StatefulSelectContainer extends React.Component<StatefulContainerPr
   internalSetState(params: OnChangeParams): void;
 }
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledControlContainer: StyletronComponent<any, any>;
-export declare const StyledValueContainer: StyletronComponent<any, any>;
-export declare const StyledPlaceholder: StyletronComponent<any, any>;
-export declare const StyledSingleValue: StyletronComponent<any, any>;
-export declare const StyledInputContainer: StyletronComponent<any, any>;
-export declare const StyledInput: StyletronComponent<any, any>;
-export declare const StyledInputSizer: StyletronComponent<any, any>;
-export declare const StyledIconsContainer: StyletronComponent<any, any>;
-export declare const StyledSelectArrow: StyletronComponent<any, any>;
-export declare const StyledClearIcon: StyletronComponent<any, any>;
-export declare const StyledSearchIconContainer: StyletronComponent<any, any>;
-export declare const StyledDropdownContainer: StyletronComponent<any, any>;
-export declare const StyledDropdown: StyletronComponent<any, any>;
-export declare const StyledDropdownListItem: StyletronComponent<any, any>;
-export declare const StyledOptionContent: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledControlContainer: StyletronComponent<any>;
+export declare const StyledValueContainer: StyletronComponent<any>;
+export declare const StyledPlaceholder: StyletronComponent<any>;
+export declare const StyledSingleValue: StyletronComponent<any>;
+export declare const StyledInputContainer: StyletronComponent<any>;
+export declare const StyledInput: StyletronComponent<any>;
+export declare const StyledInputSizer: StyletronComponent<any>;
+export declare const StyledIconsContainer: StyletronComponent<any>;
+export declare const StyledSelectArrow: StyletronComponent<any>;
+export declare const StyledClearIcon: StyletronComponent<any>;
+export declare const StyledSearchIconContainer: StyletronComponent<any>;
+export declare const StyledDropdownContainer: StyletronComponent<any>;
+export declare const StyledDropdown: StyletronComponent<any>;
+export declare const StyledDropdownListItem: StyletronComponent<any>;
+export declare const StyledOptionContent: StyletronComponent<any>;

--- a/src/side-navigation/index.d.ts
+++ b/src/side-navigation/index.d.ts
@@ -53,8 +53,8 @@ export class NavItem extends React.Component<NavItemProps> {
   handleKeyDown(event: React.KeyboardEvent): void;
 }
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledNavItemContainer: StyletronComponent<any, any>;
-export declare const StyledNavLink: StyletronComponent<any, any>;
-export declare const StyledNavItem: StyletronComponent<any, any>;
-export declare const StyledSubNavContainer: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledNavItemContainer: StyletronComponent<any>;
+export declare const StyledNavLink: StyletronComponent<any>;
+export declare const StyledNavItem: StyletronComponent<any>;
+export declare const StyledSubNavContainer: StyletronComponent<any>;

--- a/src/slider/index.d.ts
+++ b/src/slider/index.d.ts
@@ -82,11 +82,11 @@ export class StatefulContainer extends React.Component<StatefulContainerProps, S
   internalSetState(type: 'change', { value }: State): void;
 }
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledTrack: StyletronComponent<any, any>;
-export declare const StyledInnerTrack: StyletronComponent<any, any>;
-export declare const StyledThumb: StyletronComponent<any, any>;
-export declare const StyledInnerThumb: StyletronComponent<any, any>;
-export declare const StyledTick: StyletronComponent<any, any>;
-export declare const StyledTickBar: StyletronComponent<any, any>;
-export declare const StyledMark: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledTrack: StyletronComponent<any>;
+export declare const StyledInnerTrack: StyletronComponent<any>;
+export declare const StyledThumb: StyletronComponent<any>;
+export declare const StyledInnerThumb: StyletronComponent<any>;
+export declare const StyledTick: StyletronComponent<any>;
+export declare const StyledTickBar: StyletronComponent<any>;
+export declare const StyledMark: StyletronComponent<any>;

--- a/src/spinner/index.d.ts
+++ b/src/spinner/index.d.ts
@@ -14,4 +14,4 @@ export interface SpinnerProps {
   $size?: number | string | SIZE | Sizing;
 }
 
-export declare const Spinner: StyletronComponent<any, SpinnerProps>;
+export declare const Spinner: StyletronComponent<SpinnerProps>;

--- a/src/styles/index.d.ts
+++ b/src/styles/index.d.ts
@@ -37,10 +37,10 @@ export interface Theme {
 type UseStyletronFn<Theme> = () => [(arg: StyleObject) => string, Theme];
 export function createThemedUseStyletron<Theme>(): UseStyletronFn<Theme>;
 export declare const useStyletron: UseStyletronFn<Theme>;
-export function withWrapper<C extends StyletronComponent<any, any>, P extends object>(
+export function withWrapper<C extends StyletronComponent<any>, P extends object>(
   component: C,
   wrapper: (component: C) => React.ComponentType<P>
-): StyletronComponent<C, P>;
+): StyletronComponent<P>;
 
 export function styled<
   P extends object,
@@ -49,26 +49,26 @@ export function styled<
 >(
   component: C,
   styledFn: StyleObject | ((props: { $theme: T } & P) => StyleObject)
-): StyletronComponent<C, P>;
-export function withStyle<C extends StyletronComponent<any, any>, P extends object, T = Theme>(
+): StyletronComponent<P>;
+export function withStyle<C extends StyletronComponent<any>, P extends object, T = Theme>(
   component: C,
   styledFn: StyleObject | ((props: { $theme: T } & P) => StyleObject)
-): StyletronComponent<C, P>;
+): StyletronComponent<P>;
 
 export interface StyledFn<T> extends StyletronStyledFn {
   <C extends keyof JSX.IntrinsicElements | React.ComponentType<any>, P extends object>(
     component: C,
     style: (props: { $theme: T } & P) => StyleObject
-  ): StyletronComponent<C, P>;
+  ): StyletronComponent<P>;
 }
 
 export function createThemedStyled<Theme>(): StyledFn<Theme>;
 
 export interface WithStyleFn<T = Theme> extends StyletronWithStyleFn {
-  <C extends StyletronComponent<any, any>, P extends object, T1 = T>(
+  <C extends StyletronComponent<any>, P extends object, T1 = T>(
     component: C,
     style: (props: P & { $theme: T1 }) => StyleObject
-  ): StyletronComponent<C, P>;
+  ): StyletronComponent<P>;
 }
 
 export function createThemedWithStyle<Theme>(): WithStyleFn<Theme>;

--- a/src/table-grid/index.d.ts
+++ b/src/table-grid/index.d.ts
@@ -1,7 +1,7 @@
 import { StyletronComponent } from 'styletron-react';
 import { SORT_DIRECTION, SortableHeadCell } from '../table/';
 
-export declare const StyledTable: StyletronComponent<any, any>;
-export declare const StyledHeadCell: StyletronComponent<any, any>;
-export declare const StyledBodyCell: StyletronComponent<any, any>;
+export declare const StyledTable: StyletronComponent<any>;
+export declare const StyledHeadCell: StyletronComponent<any>;
+export declare const StyledBodyCell: StyletronComponent<any>;
 export { SORT_DIRECTION, SortableHeadCell };

--- a/src/table-semantic/index.d.ts
+++ b/src/table-semantic/index.d.ts
@@ -81,17 +81,17 @@ export interface TableBuilderColumnProps<RowT> {
 }
 export class TableBuilderColumn<RowT> extends React.Component<TableBuilderColumnProps<RowT>> {}
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledTable: StyletronComponent<any, any>;
-export declare const StyledTableHead: StyletronComponent<any, any>;
-export declare const StyledTableHeadRow: StyletronComponent<any, any>;
-export declare const StyledTableHeadCell: StyletronComponent<any, any>;
-export declare const StyledTableHeadCellSortable: StyletronComponent<any, any>;
-export declare const StyledTableBody: StyletronComponent<any, any>;
-export declare const StyledTableBodyRow: StyletronComponent<any, any>;
-export declare const StyledTableBodyCell: StyletronComponent<any, any>;
-export declare const StyledTableLoadingMessage: StyletronComponent<any, any>;
-export declare const StyledTableEmptyMessage: StyletronComponent<any, any>;
-export declare const StyledSortAscIcon: StyletronComponent<any, any>;
-export declare const StyledSortDescIcon: StyletronComponent<any, any>;
-export declare const StyledSortNoneIcon: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledTable: StyletronComponent<any>;
+export declare const StyledTableHead: StyletronComponent<any>;
+export declare const StyledTableHeadRow: StyletronComponent<any>;
+export declare const StyledTableHeadCell: StyletronComponent<any>;
+export declare const StyledTableHeadCellSortable: StyletronComponent<any>;
+export declare const StyledTableBody: StyletronComponent<any>;
+export declare const StyledTableBodyRow: StyletronComponent<any>;
+export declare const StyledTableBodyCell: StyletronComponent<any>;
+export declare const StyledTableLoadingMessage: StyletronComponent<any>;
+export declare const StyledTableEmptyMessage: StyletronComponent<any>;
+export declare const StyledSortAscIcon: StyletronComponent<any>;
+export declare const StyledSortDescIcon: StyletronComponent<any>;
+export declare const StyledSortNoneIcon: StyletronComponent<any>;

--- a/src/table/index.d.ts
+++ b/src/table/index.d.ts
@@ -54,15 +54,15 @@ export interface FilterProps {
 }
 export declare const Filter: React.FC<FilterProps>;
 
-export declare const StyledTable: StyletronComponent<any, any>;
-export declare const StyledFilterButton: StyletronComponent<any, any>;
-export declare const StyledFilterContent: StyletronComponent<any, any>;
-export declare const StyledFilterHeading: StyletronComponent<any, any>;
-export declare const StyledFilterFooter: StyletronComponent<any, any>;
-export declare const StyledHead: StyletronComponent<any, any>;
-export declare const StyledHeadCell: StyletronComponent<any, any>;
-export declare const StyledBody: StyletronComponent<any, any>;
-export declare const StyledRow: StyletronComponent<any, any>;
-export declare const StyledCell: StyletronComponent<any, any>;
-export declare const StyledAction: StyletronComponent<any, any>;
-export declare const StyledSortableLabel: StyletronComponent<any, any>;
+export declare const StyledTable: StyletronComponent<any>;
+export declare const StyledFilterButton: StyletronComponent<any>;
+export declare const StyledFilterContent: StyletronComponent<any>;
+export declare const StyledFilterHeading: StyletronComponent<any>;
+export declare const StyledFilterFooter: StyletronComponent<any>;
+export declare const StyledHead: StyletronComponent<any>;
+export declare const StyledHeadCell: StyletronComponent<any>;
+export declare const StyledBody: StyletronComponent<any>;
+export declare const StyledRow: StyletronComponent<any>;
+export declare const StyledCell: StyletronComponent<any>;
+export declare const StyledAction: StyletronComponent<any>;
+export declare const StyledSortableLabel: StyletronComponent<any>;

--- a/src/tabs-motion/index.d.ts
+++ b/src/tabs-motion/index.d.ts
@@ -30,13 +30,13 @@ export declare const isRTL: (direction: string) => boolean;
 
 // styled-components
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledTabList: StyletronComponent<any, any>;
-export declare const StyledTab: StyletronComponent<any, any>;
-export declare const StyledArtworkContainer: StyletronComponent<any, any>;
-export declare const StyledTabBorder: StyletronComponent<any, any>;
-export declare const StyledTabHighlight: StyletronComponent<any, any>;
-export declare const StyledTabPanel: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledTabList: StyletronComponent<any>;
+export declare const StyledTab: StyletronComponent<any>;
+export declare const StyledArtworkContainer: StyletronComponent<any>;
+export declare const StyledTabBorder: StyletronComponent<any>;
+export declare const StyledTabHighlight: StyletronComponent<any>;
+export declare const StyledTabPanel: StyletronComponent<any>;
 
 // tabs
 

--- a/src/tabs/index.d.ts
+++ b/src/tabs/index.d.ts
@@ -85,7 +85,7 @@ export class Tab extends React.Component<TabProps> {
   getSharedProps(): SharedProps;
 }
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledTab: StyletronComponent<any, any>;
-export declare const StyledTabBar: StyletronComponent<any, any>;
-export declare const StyledTabContent: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledTab: StyletronComponent<any>;
+export declare const StyledTabBar: StyletronComponent<any>;
+export declare const StyledTabContent: StyletronComponent<any>;

--- a/src/tag/index.d.ts
+++ b/src/tag/index.d.ts
@@ -65,6 +65,6 @@ export class Tag extends React.Component<TagProps> {
   handleActionKeyDown(event: KeyboardEvent): void;
 }
 
-export declare const StyledRoot: StyletronComponent<any, any>;
-export declare const StyledAction: StyletronComponent<any, any>;
-export declare const StyledText: StyletronComponent<any, any>;
+export declare const StyledRoot: StyletronComponent<any>;
+export declare const StyledAction: StyletronComponent<any>;
+export declare const StyledText: StyletronComponent<any>;

--- a/src/textarea/index.d.ts
+++ b/src/textarea/index.d.ts
@@ -33,7 +33,7 @@ export declare const StatefulTextarea: React.FC<StatefulTextareaProps>;
 
 export { StatefulContainer };
 
-export declare const StyledTextareaContainer: StyletronComponent<any, any>;
-export declare const StyledTextarea: StyletronComponent<any, any>;
+export declare const StyledTextareaContainer: StyletronComponent<any>;
+export declare const StyledTextarea: StyletronComponent<any>;
 
 export { STATE_CHANGE_TYPE };

--- a/src/toast/index.d.ts
+++ b/src/toast/index.d.ts
@@ -118,6 +118,6 @@ export class Toast extends React.Component<ToastProps, ToastPrivateState> {
   getSharedProps(): Readonly<SharedStylePropsArg>;
 }
 
-export declare const Root: StyletronComponent<any, any>;
-export declare const Body: StyletronComponent<any, any>;
-export declare const CloseIconSvg: StyletronComponent<any, any>;
+export declare const Root: StyletronComponent<any>;
+export declare const Body: StyletronComponent<any>;
+export declare const CloseIconSvg: StyletronComponent<any>;

--- a/src/tooltip/index.d.ts
+++ b/src/tooltip/index.d.ts
@@ -21,6 +21,6 @@ export { ACCESSIBILITY_TYPE, PLACEMENT, TRIGGER_TYPE };
 export type TooltipProps = PopoverProps;
 export class Tooltip extends React.Component<TooltipProps> {}
 
-export declare const StyledArrow: StyletronComponent<any, any>;
-export declare const StyledBody: StyletronComponent<any, any>;
-export declare const StyledInner: StyletronComponent<any, any>;
+export declare const StyledArrow: StyletronComponent<any>;
+export declare const StyledBody: StyletronComponent<any>;
+export declare const StyledInner: StyletronComponent<any>;

--- a/src/tree-view/index.d.ts
+++ b/src/tree-view/index.d.ts
@@ -62,10 +62,10 @@ export declare const StatefulTreeView: React.FC<TreeViewProps>;
 
 export declare const TreeLabel: React.FC<TreeLabelProps>;
 
-export declare const StyledTreeItemList: StyletronComponent<any, any>;
-export declare const StyledTreeItem: StyletronComponent<any, any>;
-export declare const StyledItemContent: StyletronComponent<any, any>;
-export declare const StyledIconContainer: StyletronComponent<any, any>;
+export declare const StyledTreeItemList: StyletronComponent<any>;
+export declare const StyledTreeItem: StyletronComponent<any>;
+export declare const StyledItemContent: StyletronComponent<any>;
+export declare const StyledIconContainer: StyletronComponent<any>;
 
 type TGetId = (node: TreeNode) => string | number;
 type toggleIsExpandedT = (data: TreeNode[], toggledNode: TreeNode, getId?: TGetId) => TreeNode[];


### PR DESCRIPTION


#### Description

https://github.com/uber/baseweb/pull/5006 broke TS since type declaration has changed

`TS2314: Generic type 'StyletronComponent' requires 1 type argument(s).`

_I hope [this](https://github.com/uber/baseweb/pull/5009) gets merged so such issues won't happen. Flow was great but it's TS era now (no offense)_

#### Scope
Patch: Bug Fix
