### PR TITLE
fix(badge): avoid warning for inline badges

### DIFF
--- a/src/badge/utils.js
+++ b/src/badge/utils.js
@@ -9,7 +9,7 @@ import * as React from 'react';
 
 export const getAnchorFromChildren = (children: ?React.Node) => {
   const childArray = React.Children.toArray(children);
-  if (childArray.length !== 1) {
+  if (childArray.length > 1) {
     // eslint-disable-next-line no-console
     console.error(
       `[baseui] No more than 1 child may be passed to Badge, found ${childArray.length} children`


### PR DESCRIPTION
#### Description

Badges may have 0 or 1 children. This prevents the erroneous error when calling `Badge` with 0 children (inline badge).

#### Scope

Patch: Bug Fix
