### PR TITLE
fix(types): accordion, relax children type

### DIFF
--- a/src/accordion/stateless-accordion.tsx
+++ b/src/accordion/stateless-accordion.tsx
@@ -23,9 +23,18 @@ function StatelessAccordion({
   return (
     <Root data-baseweb="accordion" {...rootProps}>
       {React.Children.map(children, (child, index) => {
-        const key = child.key || String(index);
-        return React.cloneElement(child, {
-          disabled: child.props.disabled || disabled,
+        let normalizedChild =
+          typeof child === 'object' ? (
+            (child as  // skip {} from type definition
+              | React.ReactElement<any, string | React.JSXElementConstructor<any>>
+              | React.ReactPortal)
+          ) : (
+            // if primitive value - wrap it in a fragment
+            <>{child}</>
+          );
+        const key = normalizedChild.key || String(index);
+        return React.cloneElement(normalizedChild, {
+          disabled: normalizedChild.props.disabled || disabled,
           expanded: expanded.includes(key),
           key,
           onChange:
@@ -49,7 +58,7 @@ function StatelessAccordion({
                   onChange({ key, expanded: next });
                 }
               : onChange,
-          overrides: child.props.overrides || PanelOverrides,
+          overrides: normalizedChild.props.overrides || PanelOverrides,
           renderAll,
         });
       })}

--- a/src/accordion/stateless-accordion.tsx
+++ b/src/accordion/stateless-accordion.tsx
@@ -5,6 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 import * as React from 'react';
+import { isElement, isPortal } from 'react-is';
 import { getOverrides } from '../helpers/overrides';
 import { Root as StyledRoot } from './styled-components';
 import type { StatelessAccordionProps } from './types';
@@ -24,10 +25,8 @@ function StatelessAccordion({
     <Root data-baseweb="accordion" {...rootProps}>
       {React.Children.map(children, (child, index) => {
         let normalizedChild =
-          typeof child === 'object' ? (
-            (child as  // skip {} from type definition
-              | React.ReactElement<any, string | React.JSXElementConstructor<any>>
-              | React.ReactPortal)
+          isElement(child) || isPortal(child) ? (
+            child
           ) : (
             // if primitive value - wrap it in a fragment
             <>{child}</>

--- a/src/accordion/types.ts
+++ b/src/accordion/types.ts
@@ -54,15 +54,13 @@ export type OnChangeHandler = (a: { expanded: boolean }) => unknown;
 
 export type AccordionOnChangeHandler = (a: { expanded: Array<React.Key> }) => unknown;
 
-type Children = Array<React.ReactElement<any>> | React.ReactElement<any>;
-
 export type AccordionProps = {
   /** Determines how many panels may be expanded at a time. If set to
    * true it will collapse a current panel when a new panel is expanded.
    * If set to false more than one panel may be expanded at a time. */
   accordion?: boolean;
   /** Accordion expandable items. See Panel API below for reference. */
-  children: Children;
+  children: React.ReactNode;
   /** If set to true all its children panels will be disabled from toggling. */
   disabled?: boolean;
   initialState?: AccordionState;
@@ -91,7 +89,7 @@ export type StatelessAccordionProps = {
    * If set to false more than one panel may be expanded at a time. */
   accordion?: boolean;
   /** Accordion expandable items. See Panel API below for reference. */
-  children: Children;
+  children: React.ReactNode;
   /** If set to true all its children panels will be disabled from toggling. */
   disabled?: boolean;
   /** List of Panel keys which are expanded. */


### PR DESCRIPTION
#### Description

Current type does not allow to pass children like this:

```jsx
    <Accordion>
      {[
          <Panel key="1">1</Panel>,
          <Panel key="2">2</Panel>
      ]}
      <Panel key="3">3</Panel>
    </Accordion>
```

Making the type less strict (ReactNode instead of only ReactElement), also adding support for primitive values

#### Scope
<!-- Pick one:
Patch: Bug Fix
Minor: New Feature
Major: Breaking change
-->
