### PR TITLE
fix(types): update type aliases, mark optional props for checkbox

### DIFF
--- a/src/checkbox/types.ts
+++ b/src/checkbox/types.ts
@@ -66,7 +66,7 @@ export type CheckboxProps = {
   /** Renders checkbox in errored state. */
   error?: boolean;
   /** Used to get a ref to the input element. Useful for programmatically focusing the input */
-  inputRef: React.RefObject<HTMLInputElement>;
+  inputRef?: React.RefObject<HTMLInputElement>;
   /** Focus the checkbox on initial render. */
   autoFocus?: boolean;
   /** Passed to the input element type attribute */
@@ -80,23 +80,23 @@ export type CheckboxProps = {
   /** How to position the label relative to the checkbox itself. */
   labelPlacement?: LabelPlacement;
   /** Renders UI as checkmark or toggle switch. */
-  checkmarkType: StyleType;
+  checkmarkType?: StyleType;
   /** Text to display in native OS tooltip on long hover. */
   title?: string | null;
   /** Handler for change events on trigger element. */
   onChange?: (e: ChangeEvent<HTMLInputElement>) => unknown;
   /** Handler for mouseenter events on trigger element. */
-  onMouseEnter: (e: ChangeEvent<HTMLInputElement>) => unknown;
+  onMouseEnter?: (e: ChangeEvent<HTMLInputElement>) => unknown;
   /** Handler for mouseleave events on trigger element. */
-  onMouseLeave: (e: ChangeEvent<HTMLInputElement>) => unknown;
+  onMouseLeave?: (e: ChangeEvent<HTMLInputElement>) => unknown;
   /** Handler for mousedown events on trigger element. */
-  onMouseDown: (e: ChangeEvent<HTMLInputElement>) => unknown;
+  onMouseDown?: (e: ChangeEvent<HTMLInputElement>) => unknown;
   /** Handler for mouseup events on trigger element. */
-  onMouseUp: (e: ChangeEvent<HTMLInputElement>) => unknown;
+  onMouseUp?: (e: ChangeEvent<HTMLInputElement>) => unknown;
   /** handler for focus events on trigger element. */
-  onFocus: (e: ChangeEvent<HTMLInputElement>) => unknown;
+  onFocus?: (e: ChangeEvent<HTMLInputElement>) => unknown;
   /** handler for blur events on trigger element. */
-  onBlur: (e: ChangeEvent<HTMLInputElement>) => unknown;
+  onBlur?: (e: ChangeEvent<HTMLInputElement>) => unknown;
 };
 
 export type CheckboxState = {

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -12,7 +12,8 @@ import createDarkTheme from './dark-theme/create-dark-theme';
 import createLightTheme from './light-theme/create-light-theme';
 import darkThemePrimitives from './dark-theme/primitives';
 import lightThemePrimitives from './light-theme/primitives';
-import type { ColorTokens, Primitives } from './types';
+import type { Primitives } from './types';
+import type { Colors as StyleColors } from '../styles';
 
 export {
   createDarkTheme,
@@ -29,6 +30,6 @@ export {
 
 export * from './types';
 /** @deprecated use ColorTokens instead. To be removed in future versions.*/
-export type Colors = ColorTokens;
+export type Colors = StyleColors;
 /** @deprecated use Primitives instead. To be removed in future versions.*/
 export type ThemePrimitives = Primitives;

--- a/src/tree-view/index.ts
+++ b/src/tree-view/index.ts
@@ -23,7 +23,7 @@ export { default as TreeLabel } from './tree-label';
 export { default as TreeLabelInteractable } from './tree-label-interactable';
 export { toggleIsExpanded };
 /** @deprecated use TreeNodeData instead. To be removed in future versions.*/
-export type TreeNode = TreeNodeData;
+export type TreeNode<T = any> = TreeNodeData<T>;
 /** @deprecated To be removed in future versions.*/
 type TGetId = Parameters<toggleIsExpandedT>[2];
 /** @deprecated To be removed in future versions.*/


### PR DESCRIPTION
#### Description

- update deprecated alias (issues found testing on typescript project migrating to new types)
- mark default properties in `CheckboxProps` (while in most cases it works as expected because of `defaultProps` static field, it does cause issues with some more advanced use-cases like when inferring props in HOC)

#### Scope
<!-- Pick one:
Patch: Bug Fix
Minor: New Feature
Major: Breaking change
-->
