### PR TITLE
chore(docs): remove ie support from docs site - improve build time

### DIFF
--- a/documentation-site/next.config.js
+++ b/documentation-site/next.config.js
@@ -14,91 +14,48 @@ const withMDX = require('@zeit/next-mdx')({
   extension: /\.mdx?$/,
 });
 
-// The following modules need to be transpiled for IE11.
-// If IE11 breaks again in the future, enable production source maps to find
-// which module is causing the issue.
-const withTM = require('next-transpile-modules')([
-  '@octokit/rest',
-  '@octokit/endpoint',
-  '@octokit/request',
-  '@octokit/request-error',
-  '@babel/core',
-  '@babel/code-frame',
-  '@babel/parser',
-  '@babel/generator',
-  '@babel/traverse',
-  '@babel/types',
-  '@babel/template',
-  '@babel/highlight',
-  '@babel/helpers',
-  '@babel/helper-plugin-utils',
-  '@babel/helper-builder-react-jsx',
-  '@babel/helper-function-name',
-  '@babel/helper-split-export-declaration',
-  '@babel/plugin-transform-react-jsx',
-  '@babel/plugin-transform-react-jsx-source',
-  '@babel/plugin-transform-react-jsx-self',
-  '@babel/plugin-transform-react-display-name',
-  '@babel/plugin-syntax-jsx',
-  '@babel/preset-react',
-  'octokit-pagination-methods',
-  'deprecation',
-  'vnopts',
-  'react-view',
-  'ansi-styles',
-  'debug',
-  'chalk',
-  'is-fullwidth-code-point',
-  'jest-docblock',
-  'gensync',
-  'string-width',
-  'jsesc',
-]);
+module.exports = withMDX(
+  withImages({
+    images: {
+      loader: 'imgix',
+    },
+    typescript: {
+      ignoreBuildErrors: true,
+    },
+    publicRuntimeConfig: {
+      loadYard: process.env.LOAD_YARD,
+    },
+    trailingSlash: true,
+    webpack: (config, { buildId, dev, isServer, defaultLoaders }) => {
+      // fix to correctly resolve mjs file exports
+      // probably can be removed with next.js update
+      config.module.rules.push({
+        test: /\.mjs$/,
+        include: /node_modules/,
+        type: 'javascript/auto',
+      });
 
-module.exports = withTM(
-  withMDX(
-    withImages({
-      images: {
-        loader: 'imgix',
-      },
-      typescript: {
-        ignoreBuildErrors: true,
-      },
-      publicRuntimeConfig: {
-        loadYard: process.env.LOAD_YARD,
-      },
-      trailingSlash: true,
-      webpack: (config, { buildId, dev, isServer, defaultLoaders }) => {
-        // fix to correctly resolve mjs file exports
-        // probably can be removed with next.js update
-        config.module.rules.push({
-          test: /\.mjs$/,
-          include: /node_modules/,
-          type: 'javascript/auto',
-        });
+      config.resolve.alias.baseui = resolve(__dirname, '../dist');
+      config.resolve.alias.examples = resolve(__dirname, 'examples');
+      // references next polyfills example: https://github.com/zeit/next.js/tree/canary/examples/with-polyfills
+      const originalEntry = config.entry;
+      config.node = { fs: 'empty' };
+      config.entry = async () => {
+        const entries = await originalEntry();
 
-        config.resolve.alias.baseui = resolve(__dirname, '../dist');
-        config.resolve.alias.examples = resolve(__dirname, 'examples');
-        // references next polyfills example: https://github.com/zeit/next.js/tree/canary/examples/with-polyfills
-        const originalEntry = config.entry;
-        config.node = { fs: 'empty' };
-        config.entry = async () => {
-          const entries = await originalEntry();
-
-          if (entries['main.js'] && !entries['main.js'].includes('./helpers/polyfills.js')) {
-            entries['main.js'].unshift('./helpers/polyfills.js');
-          }
-
-          return entries;
-        };
-
-        if (dev) {
-          config.devtool = 'inline-source-map';
+        if (entries['main.js'] && !entries['main.js'].includes('./helpers/polyfills.js')) {
+          entries['main.js'].unshift('./helpers/polyfills.js');
         }
 
-        return config;
-      },
-      pageExtensions: ['js', 'jsx', 'mdx'],
-    })
-  )
+        return entries;
+      };
+
+      if (dev) {
+        config.devtool = 'inline-source-map';
+      }
+
+      return config;
+    },
+    pageExtensions: ['js', 'jsx', 'mdx'],
+  })
 );

--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
     "moment": "^2.24.0",
     "next": "^10.0.0",
     "next-images": "^1.6.2",
-    "next-transpile-modules": "^6.0.0",
     "node-fetch": "^2.6.1",
     "now": "16.5.2",
     "npm-run-all": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7697,14 +7697,6 @@ enhanced-resolve@^4.3.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.3.2:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.4.0.tgz#a8bcf23b00affac9455cf71efd80844f4054f4dc"
-  integrity sha512-ZmqfWURB2lConOBM1JdCVfPyMRv5RdKWktLXO6123p97ovVm2CLBgw9t5MBj3jJWA6eHyOeIws9iJQoGFR4euQ==
-  dependencies:
-    graceful-fs "^4.2.4"
-    tapable "^2.0.0"
-
 enquirer@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -8973,14 +8965,6 @@ find-up@^4.0.0, find-up@^4.1.0:
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   dependencies:
     locate-path "^5.0.0"
-    path-exists "^4.0.0"
-
-find-up@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
     path-exists "^4.0.0"
 
 flat-cache@^3.0.4:
@@ -12193,13 +12177,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-locate-path@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
-  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
-  dependencies:
-    p-locate "^5.0.0"
-
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -13117,14 +13094,6 @@ next-tick@~1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-next-transpile-modules@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-6.0.0.tgz#ba2d9c944de34a6e04c8834b6a06dbc4b28e4611"
-  integrity sha512-+Xdn4Upb8FeOXorzqVFyqww3kR9ML6S7y6Q3gFnoLdsqC5Jim3fwGNGTHENLOwedoKxcM6bCyRBuMYzyxru/wA==
-  dependencies:
-    enhanced-resolve "^5.3.2"
-    pkg-dir "^5.0.0"
-
 next@^10.0.0:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/next/-/next-10.0.3.tgz#2bf9a1625dcd0afc8c31be19fc5516af68d99e80"
@@ -13714,13 +13683,6 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
-  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
-  dependencies:
-    yocto-queue "^0.1.0"
-
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -13741,13 +13703,6 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
-
-p-locate@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
-  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
-  dependencies:
-    p-limit "^3.0.2"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -14090,13 +14045,6 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
-
-pkg-dir@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
-  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
-  dependencies:
-    find-up "^5.0.0"
 
 platform@1.3.3:
   version "1.3.3"
@@ -17141,11 +17089,6 @@ tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tapable@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.1.1.tgz#b01cc1902d42a7bb30514e320ce21c456f72fd3f"
-  integrity sha512-Wib1S8m2wdpLbmQz0RBEVosIyvb/ykfKXf3ZIDqvWoMg/zTNm6G/tDSuUM61J1kNCDXWJrLHGSFeMhAG+gAGpQ==
-
 tar-fs@^2.0.0, tar-fs@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
@@ -18633,8 +18576,3 @@ yargs@^15.3.1, yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
-
-yocto-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
-  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
#### Description

Microsoft ended support for IE [last month](https://docs.microsoft.com/en-us/lifecycle/faq/internet-explorer-microsoft-edge#what-is-the-lifecycle-policy-for-internet-explorer-). Our docs site build spends about ~40% of time transpiling for IE so removing should help speed things up
