### PR TITLE
fix(ts): use React.Ref type instead of React.ObjectRef

### DIFF
--- a/src/checkbox/__tests__/checkbox-react-hook-form.scenario.tsx
+++ b/src/checkbox/__tests__/checkbox-react-hook-form.scenario.tsx
@@ -28,7 +28,6 @@ const StatefulCheckboxExample = () => {
       <form onSubmit={form.handleSubmit(handleSubmit)}>
         <StatefulCheckbox
           {...checkboxA}
-          // @ts-expect-error todo(flow->ts) type mismatch
           inputRef={refA}
           labelPlacement={LABEL_PLACEMENT.right}
           initialState={{ checked: true, isIndeterminate: false }}
@@ -69,7 +68,6 @@ const CheckboxWithControllerExample = () => {
             <Checkbox
               {...rest}
               checked={value}
-              // @ts-expect-error todo(flow->ts) type mismatch
               inputRef={ref}
               labelPlacement={LABEL_PLACEMENT.right}
             >

--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -52,7 +52,7 @@ class StatelessCheckbox extends React.Component<CheckboxProps, CheckboxState> {
 
   componentDidMount() {
     const { autoFocus, inputRef } = this.props;
-    if (autoFocus && inputRef.current) {
+    if (autoFocus && typeof inputRef === 'object' && inputRef.current) {
       inputRef.current.focus();
     }
   }

--- a/src/checkbox/types.ts
+++ b/src/checkbox/types.ts
@@ -32,7 +32,7 @@ export type DefaultProps = {
   type: string;
   autoFocus: boolean;
   isIndeterminate: boolean;
-  inputRef: React.RefObject<HTMLInputElement>;
+  inputRef: React.Ref<HTMLInputElement>;
   checkmarkType: StyleType;
   onChange: (e: ChangeEvent<HTMLInputElement>) => unknown;
   onMouseEnter: (e: ChangeEvent<HTMLInputElement>) => unknown;
@@ -66,7 +66,7 @@ export type CheckboxProps = {
   /** Renders checkbox in errored state. */
   error?: boolean;
   /** Used to get a ref to the input element. Useful for programmatically focusing the input */
-  inputRef?: React.RefObject<HTMLInputElement>;
+  inputRef?: React.Ref<HTMLInputElement>;
   /** Focus the checkbox on initial render. */
   autoFocus?: boolean;
   /** Passed to the input element type attribute */

--- a/src/input/base-input.tsx
+++ b/src/input/base-input.tsx
@@ -80,7 +80,7 @@ class BaseInput<T extends HTMLInputElement | HTMLTextAreaElement> extends React.
 
   componentDidMount() {
     const { autoFocus, clearable } = this.props;
-    if (this.inputRef.current) {
+    if (typeof this.inputRef === 'object' && this.inputRef.current) {
       if (autoFocus) {
         this.inputRef.current.focus();
       }
@@ -92,28 +92,30 @@ class BaseInput<T extends HTMLInputElement | HTMLTextAreaElement> extends React.
 
   componentWillUnmount() {
     const { clearable } = this.props;
-    if (clearable && this.inputRef.current) {
+    if (clearable && typeof this.inputRef === 'object' && this.inputRef.current) {
       this.inputRef.current.removeEventListener('keydown', this.onInputKeyDown);
     }
   }
 
   clearValue() {
-    // trigger a fake input change event (as if all text was deleted)
-    const input = this.inputRef.current;
-    if (input) {
-      const nativeInputValue = Object.getOwnPropertyDescriptor(
-        this.props.type === CUSTOM_INPUT_TYPE.textarea
-          ? // todo(flow->ts): globals, not props of window object
-            HTMLTextAreaElement.prototype
-          : HTMLInputElement.prototype,
-        'value'
-      );
-      if (nativeInputValue) {
-        const nativeInputValueSetter = nativeInputValue.set;
-        if (nativeInputValueSetter) {
-          nativeInputValueSetter.call(input, '');
-          const event = createEvent('input');
-          input.dispatchEvent(event);
+    if (typeof this.inputRef === 'object' && this.inputRef.current) {
+      // trigger a fake input change event (as if all text was deleted)
+      const input = this.inputRef.current;
+      if (input) {
+        const nativeInputValue = Object.getOwnPropertyDescriptor(
+          this.props.type === CUSTOM_INPUT_TYPE.textarea
+            ? // todo(flow->ts): globals, not props of window object
+              HTMLTextAreaElement.prototype
+            : HTMLInputElement.prototype,
+          'value'
+        );
+        if (nativeInputValue) {
+          const nativeInputValueSetter = nativeInputValue.set;
+          if (nativeInputValueSetter) {
+            nativeInputValueSetter.call(input, '');
+            const event = createEvent('input');
+            input.dispatchEvent(event);
+          }
         }
       }
     }
@@ -123,6 +125,7 @@ class BaseInput<T extends HTMLInputElement | HTMLTextAreaElement> extends React.
     if (
       this.props.clearOnEscape &&
       e.key === 'Escape' &&
+      typeof this.inputRef === 'object' &&
       this.inputRef.current &&
       !this.props.readOnly
     ) {
@@ -133,9 +136,11 @@ class BaseInput<T extends HTMLInputElement | HTMLTextAreaElement> extends React.
   };
 
   onClearIconClick = () => {
-    if (this.inputRef.current) this.clearValue();
-    // return focus to the input after click
-    if (this.inputRef.current) this.inputRef.current.focus();
+    if (typeof this.inputRef === 'object' && this.inputRef.current) {
+      this.clearValue();
+      // return focus to the input after click
+      this.inputRef.current.focus();
+    }
   };
 
   onFocus = (e: FocusEvent<T>) => {

--- a/src/input/types.ts
+++ b/src/input/types.ts
@@ -105,7 +105,7 @@ export type BaseInputProps<T> = {
   /** A  hint as to the type of data that might be entered by the user while editing the element or its contents. */
   inputMode?: string;
   /** A ref to access an input element. */
-  inputRef?: React.RefObject<T>;
+  inputRef?: React.Ref<T>;
   name?: string;
   onBlur?: (e: FocusEvent<T>) => void;
   onChange?: (e: ChangeEvent<T>) => void;

--- a/src/menu/types.ts
+++ b/src/menu/types.ts
@@ -30,7 +30,7 @@ export type GetProfileItemImgFn = (item: Item) => string | React.ComponentType<a
 
 export type GetProfileItemImgTextFn = (item: Item) => string;
 
-export type SetRootRefFn = (ref: React.RefObject<typeof HTMLElement>) => void;
+export type SetRootRefFn = (ref: React.Ref<typeof HTMLElement>) => void;
 
 export type RootRef = {
   current: null | HTMLElement;

--- a/src/phone-input/base-country-picker.tsx
+++ b/src/phone-input/base-country-picker.tsx
@@ -216,7 +216,7 @@ export default function CountryPicker(props: CountrySelectProps) {
           );
         }
         // After choosing a country, shift focus to the text input
-        if (inputRef && inputRef.current) {
+        if (typeof inputRef === 'object' && inputRef.current) {
           inputRef.current.focus();
         }
       }}

--- a/src/phone-input/types.ts
+++ b/src/phone-input/types.ts
@@ -63,7 +63,7 @@ export type CountrySelectProps = {
   country: Country;
   disabled: boolean;
   error: boolean;
-  inputRef: React.RefObject<HTMLInputElement>;
+  inputRef: React.Ref<HTMLInputElement>;
   onCountryChange: (event: OnChangeParams) => unknown;
   mapIsoToLabel?: mapIsoToLabel;
   maxDropdownHeight: string;

--- a/src/radio/radio.tsx
+++ b/src/radio/radio.tsx
@@ -55,7 +55,11 @@ class Radio extends React.Component<RadioProps, RadioState> {
   };
 
   componentDidMount() {
-    if (this.props.autoFocus && this.props.inputRef?.current) {
+    if (
+      this.props.autoFocus &&
+      typeof this.props.inputRef === 'object' &&
+      this.props.inputRef.current
+    ) {
       this.props.inputRef.current.focus();
     }
   }

--- a/src/radio/types.ts
+++ b/src/radio/types.ts
@@ -98,7 +98,7 @@ export type RadioProps = {
   /** Disable the checkbox from being changed. */
   disabled?: boolean;
   /** Used to get a ref to the input element. Useful for programmatically focusing the input */
-  inputRef?: React.RefObject<HTMLInputElement>;
+  inputRef?: React.Ref<HTMLInputElement>;
   /** Renders checkbox in errored state. */
   error?: boolean;
   /** Is radio focused / active? */


### PR DESCRIPTION
Seeing issues like below where `Input` component is wrapped in react-hook-form https://github.com/react-hook-form/react-hook-form/blob/master/src/types/form.ts#L154

#### Description

```
  | 2022-07-15 16:56:21 PDT | address-subform.tsx:34:15 - error TS2769: No overload matches this call.
  | 2022-07-15 16:56:38 PDT | Overload 1 of 2, '(props: InputProps \| Readonly<InputProps>): Input', gave the following error.
  | 2022-07-15 16:56:38 PDT | Type 'RefCallBack' is not assignable to type 'RefObject<HTMLInputElement \| HTMLTextAreaElement>'.
  | 2022-07-15 16:56:38 PDT | Overload 2 of 2, '(props: InputProps, context: any): Input', gave the following error.
  | 2022-07-15 16:56:38 PDT | Type 'RefCallBack' is not assignable to type 'RefObject<HTMLInputElement \| HTMLTextAreaElement>'.
  | 2022-07-15 16:56:38 PDT |  
  | 2022-07-15 16:56:38 PDT | 34               inputRef={ref}
  | 2022-07-15 16:56:38 PDT | ~~~~~~~~
  | 2022-07-15 16:56:38 PDT |  
  | 2022-07-15 16:56:38 PDT | ../../../../../.yarn/unplugged/baseui-virtual-6b92cc0fcd/node_modules/baseui/input/types.d.ts:93:5
  | 2022-07-15 16:56:38 PDT | 93     inputRef?: React.RefObject<T>;
  | 2022-07-15 16:56:38 PDT | ~~~~~~~~
  | 2022-07-15 16:56:38 PDT | The expected type comes from property 'inputRef' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<Input> & Pick<Readonly<InputProps> & Readonly<{ children?: ReactNode; }>, "value" \| ... 29 more ... \| "step"> & Partial<...> & Partial<...>'
```

#### Scope
Patch: Bug Fix
