### PR TITLE
chore(docs): fix Badge shared props

### DIFF
--- a/documentation-site/components/yard/config/badge.ts
+++ b/documentation-site/components/yard/config/badge.ts
@@ -111,11 +111,7 @@ const BadgeConfig: TConfig = {
       description: 'Lets you customize all aspects of the component.',
       custom: {
         names: ['Root', 'Badge', 'Positioner'],
-        sharedProps: {
-          $hierarchy: 'hierarchy',
-          $shape: 'shape',
-          $color: 'color',
-        },
+        sharedProps: [],
       },
     },
   },


### PR DESCRIPTION
#### Description
Badge does not use shared props for its styled components, but the docs
currently imply that it does.



#### Scope
Patch: Bug Fix
