### PR TITLE
feat(locale): add locale inheritence to provider

### DIFF
--- a/src/locale/__tests__/unit.test.tsx
+++ b/src/locale/__tests__/unit.test.tsx
@@ -1,0 +1,47 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+import React from 'react';
+import { render, getByTestId } from '@testing-library/react';
+import LocaleProvider, { LocaleContext } from '../index';
+import en_US from '../en_US';
+import tr_TR from '../tr_TR';
+
+describe('LocaleProvider', () => {
+  const ExpectLocaleComponent = ({ expectedValue }) => {
+    const locale = React.useContext(LocaleContext);
+    expect(locale).toEqual(expectedValue);
+    return null;
+  };
+
+  it('default returns en_US', () => {
+    expect.assertions(1);
+    render(
+      <LocaleProvider locale={{}}>
+        <ExpectLocaleComponent expectedValue={en_US} />
+      </LocaleProvider>
+    );
+  });
+
+  it('locale provider inherits from parent', () => {
+    expect.assertions(2);
+    const override = { breadcrumbs: { ariaLabel: 'TEST' }, newProperty: { nestedProperty: 'a ' } };
+    const expectedValue = {
+      ...tr_TR,
+      ...override,
+      breadcrumbs: { ...tr_TR.breadcrumbs, ...override.breadcrumbs },
+    };
+
+    render(
+      <LocaleProvider locale={tr_TR}>
+        <LocaleProvider locale={override}>
+          <ExpectLocaleComponent expectedValue={expectedValue} />
+        </LocaleProvider>
+        <ExpectLocaleComponent expectedValue={tr_TR} />
+      </LocaleProvider>
+    );
+  });
+});

--- a/src/locale/index.tsx
+++ b/src/locale/index.tsx
@@ -32,8 +32,12 @@ export type LocaleProviderProps = {
 
 const LocaleProvider: React.FC<LocaleProviderProps> = (props) => {
   const { locale, children } = props;
+  const parentLocale = React.useContext(LocaleContext) ?? {};
+
   return (
-    <LocaleContext.Provider value={extend({}, en_US, locale)}>{children}</LocaleContext.Provider>
+    <LocaleContext.Provider value={extend({}, en_US, parentLocale, locale)}>
+      {children}
+    </LocaleContext.Provider>
   );
 };
 


### PR DESCRIPTION

#### Description

Locale provider loses all other values when you override the values in a nested fashion. Instead this creates a new pattern of inheritance where the parent values are inherited into the child. There are some risks that this will introduce copy difference in places where the default values were used. However, this may also improve copy where there were two locale  providers: one parent proving all translations, and a child overriding a selection of values. Now the translations should not be lost. 

Here isa sample of the functionality: https://codesandbox.io/s/green-grass-1pxsz0?file=/src/App.js

#### Scope
Major: Breaking change
