### PR TITLE
fix(select): update default maxDropdownHeight to 40vh

### DIFF
--- a/src/select/default-props.ts
+++ b/src/select/default-props.ts
@@ -29,7 +29,7 @@ const defaultProps = {
   ignoreCase: true,
   isLoading: false,
   labelKey: 'label',
-  maxDropdownHeight: '900px',
+  maxDropdownHeight: '40vh',
   multi: false,
   onBlur: () => {},
   onBlurResetsInput: true,


### PR DESCRIPTION
Previous value was 900px, which is quite large when the browser is not desktop sized

#### Scope
Patch: Bug Fix