### PR TITLE
fix: popover should only appear if the trigger event is focus-visible

### DIFF
--- a/src/popover/stateful-container.ts
+++ b/src/popover/stateful-container.ts
@@ -19,6 +19,7 @@ import type {
   StateChangeType,
   StateReducer,
 } from './types';
+import { isFocusVisible } from '../utils/focusVisible';
 
 const defaultStateReducer: StateReducer = (type, nextState) => nextState;
 
@@ -77,7 +78,9 @@ class StatefulContainer extends React.Component<StatefulPopoverContainerProps, S
     if (this.props.onFocus) {
       this.props.onFocus(e);
     }
-    this.open();
+    if (isFocusVisible(e)) {
+      this.open();
+    }
   };
 
   onMouseEnter = (e: React.MouseEvent) => {


### PR DESCRIPTION
Fixes Popover focus issue. Popover should only appear if the last event was focus-visible

#### Description
Right now `onFocus()` of popover container doesn't check if the triggering event is focus-visible and hence calls `this.open()` on every focus event. However this results in unexpected behaviour. One example as shown in the video below is of a button with tooltip, which opens a Modal on click. Here when the modal is closed using backdrop click or close button click the tooltip re-appears. Which should not happen.
 
### Before
https://user-images.githubusercontent.com/32041242/187265255-5878b594-fe7b-42d2-9faa-54903ac643e7.mov

Ideally the tooltip should not appear on any click event that closes the modal and returns focus to the button. Only when keyboard event closes modal and button gets focus-visible then only the tooltip should appear. The suggested fix provides this expected behaviour.

### After

https://user-images.githubusercontent.com/32041242/187265535-d3b1403c-2116-44be-a2a2-cc5174e9855c.mov


<!-- Describe your changes below in as much detail as possible -->

#### Scope
Patch: Bug Fix
<!-- Pick one:
Patch: Bug Fix
Minor: New Feature
Major: Breaking change
-->
