### PR TITLE
fix: styled-bar should only require props it uses

### DIFF
--- a/src/progress-bar/styled-components.tsx
+++ b/src/progress-bar/styled-components.tsx
@@ -42,7 +42,13 @@ export const StyledBarContainer = styled<'div', StyleProps>('div', (props) => {
 
 StyledBarContainer.displayName = 'StyledBarContainer';
 
-export const StyledBar = styled<'div', StyleProps>('div', (props) => {
+export const StyledBar = styled<
+  'div',
+  {
+    $size: Size;
+    $steps?: number;
+  }
+>('div', (props) => {
   const { $theme, $size, $steps } = props;
   const { colors, sizing, borders } = $theme;
   const borderRadius = borders.useRoundedCorners ? sizing.scale0 : 0;


### PR DESCRIPTION
#### Description

Not all members of ```StyleProps``` is required. Regression from v11. 

#### Scope
Patch: Bug Fix

