### PR TITLE
fix: datepicker focus outline shouldnt be cut off

### DIFF
--- a/src/datepicker/styled-components.js.flow
+++ b/src/datepicker/styled-components.js.flow
@@ -463,6 +463,7 @@ export const StyledDay = styled<SharedStylePropsT>('div', (props) => {
     // a z-index used on its' children doesn't
     // interfere with anything outside the component
     transform: 'scale(1)',
+    ...($isFocusVisible ? { zIndex: 1 } : {}),
     ...getDayStyles(code, props.$theme),
     // :after pseudo element defines the selected
     // or highlighted day's circle styles

--- a/src/datepicker/styled-components.ts
+++ b/src/datepicker/styled-components.ts
@@ -502,6 +502,7 @@ export const StyledDay = styled<'div', SharedStyleProps>('div', (props) => {
     // a z-index used on its' children doesn't
     // interfere with anything outside the component
     transform: 'scale(1)',
+    ...($isFocusVisible ? { zIndex: 1 } : {}),
     ...getDayStyles(code, props.$theme),
     // :after pseudo element defines the selected
     // or highlighted day's circle styles


### PR DESCRIPTION
Fixes datepicker’s day focus outline cut off issue.

#### Description

Currently, day's focus outline is partly covered by the following day’s cell. The images and the recording explain this better. This fix makes the datepicker look a little more polished.

#### Before

<img src="https://user-images.githubusercontent.com/17082436/191592862-1b8b464b-af10-4d12-a635-78ad3820a316.png"  width="500" />

<img src="https://user-images.githubusercontent.com/17082436/191592868-03a72b8a-69f9-4f3c-ae07-cdb952b704fe.png"  width="500" />


#### After

<img src="https://user-images.githubusercontent.com/17082436/191592912-fa212966-8af2-4753-95a7-38b92cf414e0.png"  width="500" />

<img src="https://user-images.githubusercontent.com/17082436/191592915-e06b6542-1e1c-4646-b4cf-347767d6db8a.png"  width="500" />

https://user-images.githubusercontent.com/17082436/191592924-67021dce-bdb8-4948-b5d1-c592fc22c402.mp4




#### Scope

Patch: Bug Fix

