### PR TITLE
fix(textarea): do not apply children

### DIFF
--- a/src/input/base-input.tsx
+++ b/src/input/base-input.tsx
@@ -285,8 +285,6 @@ class BaseInput<T extends HTMLInputElement | HTMLTextAreaElement> extends React.
 
   render() {
     const {
-      value,
-      type,
       overrides: {
         InputContainer: InputContainerOverride,
         Input: InputOverride,
@@ -356,9 +354,7 @@ class BaseInput<T extends HTMLInputElement | HTMLTextAreaElement> extends React.
           rows={this.props.type === CUSTOM_INPUT_TYPE.textarea ? this.props.rows : null}
           {...sharedProps}
           {...inputProps}
-        >
-          {type === CUSTOM_INPUT_TYPE.textarea ? value : null}
-        </Input>
+        />
         {this.renderClear()}
         {this.renderMaskToggle()}
         <After {...sharedProps} {...afterProps} />


### PR DESCRIPTION
#### Description

I'm not quite sure why textarea children prop was applied, but it seems to be breaking SSR in react 18. This commit removes it and relies on textarea value prop

#### Scope
Patch: Bug Fix

