### PR TITLE
fix(types): make SkeletonProps.rows optional to match the docs

### DIFF
--- a/src/skeleton/skeleton.js.flow
+++ b/src/skeleton/skeleton.js.flow
@@ -36,7 +36,7 @@ class Skeleton extends React.Component<SkeletonPropsT> {
               <Row
                 $animation={this.props.animation}
                 key={index}
-                $isLastRow={index === this.props.rows - 1}
+                $isLastRow={index === (typeof this.props.rows !== 'undefined' ? this.props.rows : 0) - 1}
                 {...rowProps}
               ></Row>
             ))}

--- a/src/skeleton/types.js.flow
+++ b/src/skeleton/types.js.flow
@@ -16,7 +16,7 @@ export type OverridesT = {
 export type SkeletonPropsT = {
   overrides?: OverridesT,
   /** Defines the number of row element in a skeleton */
-  rows: number,
+  rows?: number,
   /** Defines if the skeleton has an animation default is false*/
   animation: boolean,
   /** Defines the height of the skeleton container*/

--- a/src/skeleton/types.ts
+++ b/src/skeleton/types.ts
@@ -14,7 +14,7 @@ export type SkeletonOverrides = {
 export type SkeletonProps = {
   overrides?: SkeletonOverrides;
   /** Defines the number of row element in a skeleton */
-  rows: number;
+  rows?: number;
   /** Defines if the skeleton has an animation default is false*/
   animation: boolean;
   /** Defines the height of the skeleton container*/


### PR DESCRIPTION
#### Description

According to the [docs](https://baseweb.design/components/skeleton/) `SkeletonProps.rows` is optional, however it's not so according to the [typings](https://github.com/uber/baseweb/blob/master/src/skeleton/types.ts#L14). This PR makes `SkeletonProps.rows` optional.

#### Scope

Patch: Bug Fix
