### PR TITLE
fix(types): use React.PropsWithChildren with HeaderNavigationProps

### DIFF
--- a/src/header-navigation/types.js.flow
+++ b/src/header-navigation/types.js.flow
@@ -5,6 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
+import * as React from 'react';
 import type { OverrideT } from '../helpers/overrides.js';
 
 export type OverridesT = {
@@ -13,4 +14,5 @@ export type OverridesT = {
 
 export type PropsT = {
   overrides: OverridesT,
+  children?: React.Node,
 };

--- a/src/header-navigation/types.ts
+++ b/src/header-navigation/types.ts
@@ -10,6 +10,6 @@ export type HeaderNavigationOverrides = {
   Root?: Override;
 };
 
-export type HeaderNavigationProps = {
+export type HeaderNavigationProps = React.PropsWithChildren<{
   overrides: HeaderNavigationOverrides;
-};
+}>;


### PR DESCRIPTION
#### Description

`HeaderNavigation.children` is currently missing when paired with `@types/react@18`. This PR fixes addresses that.

#### Scope
Patch: Bug Fix

