### PR TITLE
fix(types): fix StatefulPopoverProps to match docs

### DIFF
--- a/src/popover/popover.js.flow
+++ b/src/popover/popover.js.flow
@@ -115,7 +115,7 @@ class PopoverInner extends React.Component<PopoverPropsT, PopoverPrivateStateT> 
       isAnimating: false,
       arrowOffset: { left: 0, top: 0 },
       popoverOffset: { left: 0, top: 0 },
-      placement: props.placement,
+      placement: props.placement || PLACEMENT.auto,
       isMounted: false,
       isLayerMounted: false,
       autoFocusAfterPositioning: false,
@@ -328,7 +328,7 @@ class PopoverInner extends React.Component<PopoverPropsT, PopoverPrivateStateT> 
 
   getSharedProps(): $Diff<SharedStylePropsArgT, { children?: React.Node }> {
     const { isOpen, showArrow, popoverMargin = POPOVER_MARGIN } = this.props;
-    const { isAnimating, arrowOffset, popoverOffset, placement } = this.state;
+    const { isAnimating, arrowOffset, popoverOffset, placement = PLACEMENT.auto } = this.state;
     return {
       $showArrow: !!showArrow,
       $arrowOffset: arrowOffset,

--- a/src/popover/types.js.flow
+++ b/src/popover/types.js.flow
@@ -86,7 +86,7 @@ export type BasePopoverPropsT = {
   onMouseLeaveDelay?: number,
   overrides?: OverridesT,
   /** How to position the popover relative to the target. */
-  placement: TetherPlacementT,
+  placement?: TetherPlacementT,
   /** Popper options override
    * https://github.com/popperjs/popper.js/blob/v1.x/docs/_includes/popper-documentation.md
    */
@@ -101,7 +101,7 @@ export type BasePopoverPropsT = {
   /** Whether or not to show the arrow pointing from the popover to the trigger. */
   showArrow?: boolean,
   /** Whether to toggle the popover when trigger is clicked or hovered. */
-  triggerType: TriggerTypeT,
+  triggerType?: TriggerTypeT,
   /** Margin of the popover */
   popoverMargin?: number,
 };
@@ -131,9 +131,9 @@ export type StatefulPopoverPropsT = BasePopoverPropsT & {
   /** Content to render within the popover when it's shown. */
   content: React.Node | StatefulContentRenderPropT,
   /** Whether to hide the popover when the user clicks anywhere outside the trigger/popover. */
-  dismissOnClickOutside: boolean,
+  dismissOnClickOutside?: boolean,
   /** Whether to hide the popover when the user presses the escape key. */
-  dismissOnEsc: boolean,
+  dismissOnEsc?: boolean,
   /** Initial state populated into the component */
   initialState?: StateT,
   /** Event handler when popover is hidden. */

--- a/src/popover/types.ts
+++ b/src/popover/types.ts
@@ -81,7 +81,7 @@ export type BasePopoverProps = {
   onMouseLeaveDelay?: number;
   overrides?: PopoverOverrides;
   /** How to position the popover relative to the target. */
-  placement: TetherPlacement;
+  placement?: TetherPlacement;
   /** Popper options override
    * https://github.com/popperjs/popper.js/blob/v1.x/docs/_includes/popper-documentation.md
    */
@@ -96,7 +96,7 @@ export type BasePopoverProps = {
   /** Whether or not to show the arrow pointing from the popover to the trigger. */
   showArrow?: boolean;
   /** Whether to toggle the popover when trigger is clicked or hovered. */
-  triggerType: TriggerType;
+  triggerType?: TriggerType;
   /** Margin of the popover */
   popoverMargin?: number;
 };
@@ -126,9 +126,9 @@ export type StatefulPopoverProps = BasePopoverProps & {
   /** Content to render within the popover when it's shown. */
   content: React.ReactNode | StatefulContentRenderProp;
   /** Whether to hide the popover when the user clicks anywhere outside the trigger/popover. */
-  dismissOnClickOutside: boolean;
+  dismissOnClickOutside?: boolean;
   /** Whether to hide the popover when the user presses the escape key. */
-  dismissOnEsc: boolean;
+  dismissOnEsc?: boolean;
   /** Initial state populated into the component */
   initialState?: State;
   /** Event handler when popover is hidden. */


### PR DESCRIPTION
#### Description

Makes the following fields optional to match the [docs](https://baseweb.design/components/popover/):

* `StatefulPopoverProps.triggerType`
* `StatefulPopoverProps.dismissOnClickOutside`
* `StatefulPopoverProps.placement`
* `StatefulPopoverProps.dismissOnEsc` 

#### Scope
Patch: Bug Fix
