### PR TITLE
fix(types): fix CardProps to match docs

### DIFF
--- a/src/card/types.js.flow
+++ b/src/card/types.js.flow
@@ -41,7 +41,7 @@ export type CardsPropsT = {
   /** Content to be rendered within the Card body. */
   +children?: Node,
   /** Function that takes Card props and returns a boolean that represents if a thumbnail will be rendered. */
-  +hasThumbnail: ({ +thumbnail?: string }) => boolean,
+  +hasThumbnail?: ({ +thumbnail?: string }) => boolean,
   /** Image to be positioned at the top of the Card. Can be a string representing the img src or an object with img attrs */
   +headerImage?: string | ImagePropsT,
   +overrides: CardComponentsT,

--- a/src/card/types.ts
+++ b/src/card/types.ts
@@ -40,7 +40,7 @@ export type CardProps = {
   /** Content to be rendered within the Card body. */
   readonly children?: ReactNode;
   /** Function that takes Card props and returns a boolean that represents if a thumbnail will be rendered. */
-  readonly hasThumbnail: (a: { readonly thumbnail?: string }) => boolean;
+  readonly hasThumbnail?: (a: { readonly thumbnail?: string }) => boolean;
   /** Image to be positioned at the top of the Card. Can be a string representing the img src or an object with img attrs */
   readonly headerImage?: string | ImageProps;
   readonly overrides: CardOverrides;


### PR DESCRIPTION
#### Description

Makes `CardProps.hasThumbnail` optional as per [docs](https://baseweb.design/components/card/) and [implementation](https://github.com/uber/baseweb/blob/master/src/card/card.tsx#L97) 

#### Scope
Patch: Bug Fix

