### PR TITLE
fix(types): fix TreeLabelInteractable to allow children

### DIFF
--- a/src/tree-view/tree-label-interactable.js.flow
+++ b/src/tree-view/tree-label-interactable.js.flow
@@ -12,6 +12,8 @@ import type { OverrideT } from '../helpers/overrides.js';
 
 const TreeLabelInteractable: React$ComponentType<{
   overrides?: { LabelInteractable: OverrideT },
+  /** Content to be rendered in the TreeLabelInteractable. */
+  children?: React$Node,
 }> = ({ overrides = {}, ...props }) => {
   const LabelInteractable = getOverride(overrides.LabelInteractable) || StyledLabelInteractable;
   return (

--- a/src/tree-view/tree-label-interactable.tsx
+++ b/src/tree-view/tree-label-interactable.tsx
@@ -9,13 +9,15 @@ import { StyledLabelInteractable } from './styled-components';
 import { getOverride } from '../helpers/overrides';
 import type { Override } from '../helpers/overrides';
 
-import type { ComponentType } from 'react';
+import type { ComponentType, PropsWithChildren } from 'react';
 
-const TreeLabelInteractable: ComponentType<{
-  overrides?: {
-    LabelInteractable: Override;
-  };
-}> = ({ overrides = {}, ...props }) => {
+const TreeLabelInteractable: PropsWithChildren<
+  ComponentType<{
+    overrides?: {
+      LabelInteractable: Override;
+    };
+  }>
+> = ({ overrides = {}, ...props }) => {
   const LabelInteractable = getOverride(overrides.LabelInteractable) || StyledLabelInteractable;
   return (
     // $FlowExpectedError[cannot-spread-inexact]


### PR DESCRIPTION
#### Description

`TreeLabelInteractable.children` is currently missing when paired with `@types/react@18`. This PR fixes addresses that.

#### Scope
Patch: Bug Fix
