### PR TITLE
fix(popover): handle click within anchor children

### DIFF
--- a/src/popover/popover.tsx
+++ b/src/popover/popover.tsx
@@ -237,7 +237,7 @@ class PopoverInner extends React.Component<PopoverProps, PopoverPrivateState> {
     if (!popper || popper === target || (target instanceof Node && popper.contains(target))) {
       return;
     }
-    if (!anchor || anchor === target || (target instanceof Node && popper.contains(target))) {
+    if (!anchor || anchor === target || (target instanceof Node && anchor.contains(target))) {
       return;
     }
     if (this.props.onClickOutside) {


### PR DESCRIPTION
#### Description

import * as React from "react";
import { StatefulPopover } from "baseui/popover";

export default () => {
  return (
    <StatefulPopover
      content={() => (
        <div>popover content</div>
      )}
      returnFocus
      autoFocus
    >
      <span><span>Click me</span></span>
    </StatefulPopover>
  );
}

If you continuously click on “Click me”, the popover content will just flicker.

Patch: Bug Fix

