### PR TITLE
fix(types): fix HeaderNavigation to allow children

### DIFF
--- a/src/header-navigation/types.js.flow
+++ b/src/header-navigation/types.js.flow
@@ -5,12 +5,13 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
+import type { PropsWithChildren } from 'react';
 import type { OverrideT } from '../helpers/overrides.js';
 
 export type OverridesT = {
   Root?: OverrideT,
 };
 
-export type PropsT = {
+export type PropsT = PropsWithChildren<{
   overrides: OverridesT,
-};
+}>;

--- a/src/header-navigation/types.ts
+++ b/src/header-navigation/types.ts
@@ -4,12 +4,13 @@ Copyright (c) Uber Technologies, Inc.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
+import type { PropsWithChildren } from 'react';
 import type { Override } from '../helpers/overrides';
 
 export type HeaderNavigationOverrides = {
   Root?: Override;
 };
 
-export type HeaderNavigationProps = {
+export type HeaderNavigationProps = PropsWithChildren<{
   overrides: HeaderNavigationOverrides;
-};
+}>;


### PR DESCRIPTION
#### Description

`HeaderNavigation.children` is currently missing when paired with `@types/react@18`. This PR fixes addresses that.

#### Scope
Patch: Bug Fix
