### PR TITLE
fix(types): fix definition of optional TS theme properties

### DIFF
--- a/src/themes/types.ts
+++ b/src/themes/types.ts
@@ -110,18 +110,18 @@ export type CoreSemanticColorTokens = {
   contentInverseTertiary: string;
   // Border
   borderOpaque: string;
-  borderTransparent: string | undefined | null;
+  borderTransparent?: string;
   borderSelected: string;
   borderInverseOpaque: string;
-  borderInverseTransparent: string | undefined | null;
+  borderInverseTransparent?: string;
   borderInverseSelected: string;
 };
 export type CoreExtensionSemanticColorTokens = {
   // Backgrounds
   backgroundStateDisabled: string;
-  backgroundOverlayDark: string | undefined | null;
-  backgroundOverlayLight: string | undefined | null;
-  backgroundOverlayArt: string | undefined | null;
+  backgroundOverlayDark?: string;
+  backgroundOverlayLight?: string;
+  backgroundOverlayArt?: string;
   backgroundAccent: string;
   backgroundNegative: string;
   backgroundWarning: string;


### PR DESCRIPTION
#### Description

A number of optional theme properties is currently not defined correctly in TypeScript and don't match [flow types](https://github.com/uber/baseweb/blob/master/src/themes/types.js.flow#L119-L130). Furthermore, they cause a very annoying issue of not being compatible with `styletron` and `csstype` because of `null`.

![image](https://user-images.githubusercontent.com/65633/193635582-692d2ac8-d279-4f27-9559-d2777457345a.png)

It's possible to workaround this with `?? undefined`, however making this change across large code base is not ideal (and shouldn't be necessary IMO)

![image](https://user-images.githubusercontent.com/65633/193635992-535abd5e-6ad8-4d5a-b365-f517bfbdf250.png)

 
#### Scope

Patch: Bug Fix

