### PR TITLE
Update button background in dark mode to match design spec

### DIFF
--- a/src/themes/dark-theme/color-component-tokens.js.flow
+++ b/src/themes/dark-theme/color-component-tokens.js.flow
@@ -26,7 +26,7 @@ export default (themePrimitives: ColorTokensT = colorTokens): ComponentColorToke
   bannerActionHighWarning: themePrimitives.warning600,
 
   // Buttons
-  buttonPrimaryFill: themePrimitives.primary,
+  buttonPrimaryFill: themePrimitives.primaryA,
   buttonPrimaryText: themePrimitives.black,
   buttonPrimaryHover: themePrimitives.primary100,
   buttonPrimaryActive: themePrimitives.primary200,

--- a/src/themes/dark-theme/color-component-tokens.ts
+++ b/src/themes/dark-theme/color-component-tokens.ts
@@ -25,8 +25,7 @@ export default (themePrimitives: ColorTokens = colorTokens): ComponentColorToken
   bannerActionHighWarning: themePrimitives.warning600,
 
   // Buttons
-  buttonPrimaryFill: themePrimitives.primary,
-
+  buttonPrimaryFill: themePrimitives.primaryA,
   buttonPrimaryText: themePrimitives.black,
   buttonPrimaryHover: themePrimitives.primary100,
   buttonPrimaryActive: themePrimitives.primary200,


### PR DESCRIPTION
`Update the buttonPrimaryFill color token dark mode mapping to match design spec` <!-- remove the (`) quotes to link the issues -->

#### Description

Currently all Primary buttons have a component specific color token that maps them to white in a dark mode theme. This change replaces the mapping to the correct color token to match the design spec (`primaryA`)

Note: Long term, we should remap all component color tokens to map to semantic ones (`backgroundInversePrimary`) over the primitives.

Before: 
<img width="422" alt="Screenshot 2022-10-03 at 15 17 40" src="https://user-images.githubusercontent.com/47660004/193696273-b681fd8f-2592-43d0-adff-4231e6872e64.png">

After:
<img width="426" alt="Screenshot 2022-10-03 at 15 21 09" src="https://user-images.githubusercontent.com/47660004/193696331-5a16c937-764b-4a26-a3fb-ea364d98911d.png">

<!-- Describe your changes below in as much detail as possible -->

#### Scope
<!-- Pick one:
Patch: Bug Fix
Minor: New Feature
Major: Breaking change
-->
Bugfix
