### PR TITLE
fix(file-uploader): remove unused tsc expect error directive

### DIFF
--- a/src/file-uploader/file-uploader.tsx
+++ b/src/file-uploader/file-uploader.tsx
@@ -73,7 +73,6 @@ function FileUploader(props: FileUploaderProps) {
   const afterFileDrop = !!(props.progressAmount || props.progressMessage || props.errorMessage);
 
   return (
-    // @ts-expect-error todo(flow->ts): dropzone api
     <Dropzone {...props} disabled={props.disabled || afterFileDrop}>
       {(renderProps) => {
         const { getRootProps, getInputProps, open, ...styleProps } = renderProps;


### PR DESCRIPTION
Fixes tsc issue: `Unused '@ts-expect-error' directive`.

Unable to pass `yarn tsc` because this is failing.

<img width="788" alt="image" src="https://user-images.githubusercontent.com/221746/195241652-dcd60eee-eaf2-4cc4-85b4-0551cd628cdd.png">
