### PR TITLE
chore(types): upgrade @types/react to version 18, fix type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,9 +106,9 @@
     "@types/lodash": "^4.14.141",
     "@types/node": "^12.6.8",
     "@types/prettier": "^1.18.0",
-    "@types/react": "^17.0.2",
-    "@types/react-dom": "^17.0.2",
-    "@types/react-is": "^17.0.2",
+    "@types/react": "^18.0.21",
+    "@types/react-dom": "^18.0.6",
+    "@types/react-is": "^17.0.3",
     "@types/react-virtualized": "^9.21.3",
     "@types/react-window": "^1.8.1",
     "@types/testing-library__jest-dom": "^5.14.5",
@@ -233,7 +233,7 @@
     "styletron-react": ">=6.1.0 < 7"
   },
   "resolutions": {
-    "@types/react": "^17.0.2",
+    "@types/react": "^18.0.21",
     "@types/jest/jest-diff": "^25.1.0",
     "@types/jest/pretty-format": "^25.1.0"
   },

--- a/src/helpers/react-helpers.tsx
+++ b/src/helpers/react-helpers.tsx
@@ -9,7 +9,7 @@ import { isFragment } from 'react-is';
 
 export const flattenFragments = (
   children?: React.ReactNode,
-  ChildWrapper?: React.ComponentType<{}>,
+  ChildWrapper?: React.ComponentType<{ children: React.ReactNode }>,
   depth = 0
 ): React.ReactNode[] =>
   // @ts-expect-error

--- a/src/layer/layer.tsx
+++ b/src/layer/layer.tsx
@@ -28,6 +28,7 @@ class LayerComponent extends React.Component<LayerComponentProps, LayerState> {
   static contextType: typeof LayersContext = LayersContext;
 
   state = { container: null };
+  declare context: React.ContextType<typeof LayersContext>;
 
   componentDidMount() {
     this.context.addEscapeHandler(this.onEscape);

--- a/src/layer/layer.tsx
+++ b/src/layer/layer.tsx
@@ -28,7 +28,8 @@ class LayerComponent extends React.Component<LayerComponentProps, LayerState> {
   static contextType: typeof LayersContext = LayersContext;
 
   state = { container: null };
-  declare context: React.ContextType<typeof LayersContext>;
+  // todo: update babel config to use declare keyword instead
+  context: React.ContextType<typeof LayersContext> = undefined;
 
   componentDidMount() {
     this.context.addEscapeHandler(this.onEscape);

--- a/src/layer/layers-manager.tsx
+++ b/src/layer/layers-manager.tsx
@@ -127,13 +127,13 @@ export default class LayersManager extends React.Component<LayersManagerProps, L
     });
   };
 
-  onAddKeyDownHandler = (keyDownHandler: () => unknown) => {
+  onAddKeyDownHandler = (keyDownHandler: (event: KeyboardEvent) => unknown) => {
     this.setState((prev) => {
       return { keyDownHandlers: [...prev.keyDownHandlers, keyDownHandler] };
     });
   };
 
-  onRemoveKeyDownHandler = (keyDownHandler: () => unknown) => {
+  onRemoveKeyDownHandler = (keyDownHandler: (event: KeyboardEvent) => unknown) => {
     this.setState((prev) => {
       return {
         keyDownHandlers: prev.keyDownHandlers.filter((handler) => handler !== keyDownHandler),
@@ -141,13 +141,13 @@ export default class LayersManager extends React.Component<LayersManagerProps, L
     });
   };
 
-  onAddKeyUpHandler = (keyUpHandler: () => unknown) => {
+  onAddKeyUpHandler = (keyUpHandler: (event: KeyboardEvent) => unknown) => {
     this.setState((prev) => {
       return { keyUpHandlers: [...prev.keyUpHandlers, keyUpHandler] };
     });
   };
 
-  onRemoveKeyUpHandler = (keyUpHandler: () => unknown) => {
+  onRemoveKeyUpHandler = (keyUpHandler: (event: KeyboardEvent) => unknown) => {
     this.setState((prev) => {
       return {
         keyUpHandlers: prev.keyUpHandlers.filter((handler) => handler !== keyUpHandler),
@@ -155,13 +155,13 @@ export default class LayersManager extends React.Component<LayersManagerProps, L
     });
   };
 
-  onAddKeyPressHandler = (keyPressHandler: () => unknown) => {
+  onAddKeyPressHandler = (keyPressHandler: (event: KeyboardEvent) => unknown) => {
     this.setState((prev) => {
       return { keyPressHandlers: [...prev.keyPressHandlers, keyPressHandler] };
     });
   };
 
-  onRemoveKeyPressHandler = (keyPressHandler: () => unknown) => {
+  onRemoveKeyPressHandler = (keyPressHandler: (event: KeyboardEvent) => unknown) => {
     this.setState((prev) => {
       return {
         keyPressHandlers: prev.keyPressHandlers.filter((handler) => handler !== keyPressHandler),

--- a/src/layer/types.ts
+++ b/src/layer/types.ts
@@ -30,16 +30,16 @@ export type LayersManagerState = {
 export type LayersContextProps = {
   host?: HTMLElement | null;
   zIndex?: number;
-  addEscapeHandler: (a: () => unknown) => void;
-  removeEscapeHandler: (a: () => unknown) => void;
-  addKeyDownHandler: (a: () => unknown) => void;
-  removeKeyDownHandler: (a: () => unknown) => void;
-  addKeyUpHandler: (a: () => unknown) => void;
-  removeKeyUpHandler: (a: () => unknown) => void;
-  addKeyPressHandler: (a: () => unknown) => void;
-  removeKeyPressHandler: (a: () => unknown) => void;
-  addDocClickHandler: (a: () => unknown) => void;
-  removeDocClickHandler: (a: () => unknown) => void;
+  addEscapeHandler: (handler: () => unknown) => void;
+  removeEscapeHandler: (handler: () => unknown) => void;
+  addKeyDownHandler: (handler: (event: KeyboardEvent) => unknown) => void;
+  removeKeyDownHandler: (handler: (event: KeyboardEvent) => unknown) => void;
+  addKeyUpHandler: (handler: (event: KeyboardEvent) => unknown) => void;
+  removeKeyUpHandler: (handler: (event: KeyboardEvent) => unknown) => void;
+  addKeyPressHandler: (handler: (event: KeyboardEvent) => unknown) => void;
+  removeKeyPressHandler: (handler: (event: KeyboardEvent) => unknown) => void;
+  addDocClickHandler: (handler: (event: MouseEvent) => unknown) => void;
+  removeDocClickHandler: (handler: (event: MouseEvent) => unknown) => void;
 };
 
 /** Layer */

--- a/src/menu/maybe-child-menu.tsx
+++ b/src/menu/maybe-child-menu.tsx
@@ -23,6 +23,7 @@ type Props = {
   overrides?: {
     ChildMenuPopover?: Override;
   };
+  children: React.ReactNode;
 };
 
 const MaybeChildMenu: React.FC<Props> = (props): React.ReactElement => {

--- a/src/styles/theme-provider.tsx
+++ b/src/styles/theme-provider.tsx
@@ -11,7 +11,7 @@ import type { Theme } from './types';
 
 export const ThemeContext: React.Context<Theme> = React.createContext(LightTheme);
 
-export type ThemeProviderProps = { theme: Theme };
+export type ThemeProviderProps = { theme: Theme; children: React.ReactNode };
 const ThemeProvider: React.FC<ThemeProviderProps> = (props) => {
   const { theme, children } = props;
   return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>;

--- a/src/tabs-motion/types.ts
+++ b/src/tabs-motion/types.ts
@@ -57,7 +57,7 @@ export type TabsProps = {
   overrides?: TabsOverrides;
   renderAll?: boolean;
   uid?: string;
-  endEnhancer?: React.ReactNode;
+  endEnhancer?: React.ReactNode | React.ComponentType;
 };
 
 export type StatefulTabsProps = {

--- a/src/tabs/stateful-tabs.tsx
+++ b/src/tabs/stateful-tabs.tsx
@@ -37,11 +37,7 @@ export default class StatefulTabs extends React.Component<StatefulTabsProps, Sta
     if (initialState && initialState.activeKey) {
       return initialState.activeKey;
     } else {
-      return React.Children.map(
-        children,
-        // @ts-expect-error todo(flow->ts) child might be not a ReactElement, theoretically including null
-        (child, index) => child.key || String(index)
-      )[0];
+      return React.Children.map(children, (child, index) => child.key || String(index))[0];
     }
   }
 

--- a/src/toast/toaster.tsx
+++ b/src/toast/toaster.tsx
@@ -169,7 +169,7 @@ export class ToasterContainer extends React.Component<
       >
         {({ dismiss }) => {
           this.dismissHandlers[key] = dismiss;
-          return children;
+          return children as React.ReactNode;
         }}
       </Toast>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3729,16 +3729,23 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
-"@types/react-dom@<18.0.0", "@types/react-dom@^17.0.2":
+"@types/react-dom@<18.0.0":
   version "17.0.17"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
   integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
   dependencies:
     "@types/react" "^17"
 
-"@types/react-is@^17.0.2":
+"@types/react-dom@^18.0.6":
+  version "18.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
+  integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-is@^17.0.3":
   version "17.0.3"
-  resolved "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
   integrity sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==
   dependencies:
     "@types/react" "*"
@@ -3765,10 +3772,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17", "@types/react@^17.0.2":
-  version "17.0.47"
-  resolved "https://registry.npmjs.org/@types/react/-/react-17.0.47.tgz#4ee71aaf4c5a9e290e03aa4d0d313c5d666b3b78"
-  integrity sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==
+"@types/react@*", "@types/react@^17", "@types/react@^18.0.21":
+  version "18.0.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.21.tgz#b8209e9626bb00a34c76f55482697edd2b43cc67"
+  integrity sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
#### Description

updating react type dependencies to version 18, which is a bit more strict comparing to previous version,
adding fixes for new type errors found

<!-- Describe your changes below in as much detail as possible -->

#### Scope
Patch: Type Fix
