### PR TITLE
Patched/Fixed CVE-2021-23358

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18345,9 +18345,9 @@ underscore.string@3.0.3:
   integrity sha1-Rhe4waJQz25QZPu7Nj0PqWzxRVI=
 
 underscore@^1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
-  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
+  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
 unfetch@^3.1.0:
   version "3.1.2"


### PR DESCRIPTION
`Fixes #1`

#### Description
The uber used `underscore` from 1.13.0-0 and before 1.13.0-2, from 1.3.2 and before 1.12.1 are vulnerable to Arbitrary Code Execution via the template function, particularly when a variable property is passed as an argument as it is not sanitized.


<!-- Describe your changes below in as much detail as possible -->

#### Scope
Patch: Bug Fix
`>= 1.3.2, < 1.12.1`


CVE-2021-23358
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`
