### PR TITLE
`CardOverrides` doesn't have `Wrapper`

### DIFF
--- a/documentation-site/components/yard/config/card.ts
+++ b/documentation-site/components/yard/config/card.ts
@@ -67,7 +67,6 @@ const CardConfig: TConfig = {
           'Root',
           'Thumbnail',
           'Title',
-          'Wrapper',
         ],
         sharedProps: {},
       },


### PR DESCRIPTION
There is no `Wrapper` key in `Card` component's overrides.

#### Description

`Wrapper` key is not present in `CardOverrides` (`baseui/card/types.d.ts`).

#### Scope
Patch: Bug Fix
