### PR TITLE
Dont leak theme properties between themes

### DIFF
--- a/src/themes/dark-theme/create-dark-theme.js.flow
+++ b/src/themes/dark-theme/create-dark-theme.js.flow
@@ -58,5 +58,5 @@ export default function createDarkTheme(
     },
   };
 
-  return deepMerge(theme, overrides);
+  return deepMerge({}, theme, overrides);
 }

--- a/src/themes/dark-theme/create-dark-theme.ts
+++ b/src/themes/dark-theme/create-dark-theme.ts
@@ -56,5 +56,5 @@ export default function createDarkTheme(
     },
   };
 
-  return deepMerge(theme, overrides);
+  return deepMerge({}, theme, overrides);
 }

--- a/src/themes/light-theme/create-light-theme.js.flow
+++ b/src/themes/light-theme/create-light-theme.js.flow
@@ -58,5 +58,5 @@ export default function createLightTheme(
     },
   };
 
-  return deepMerge(theme, overrides);
+  return deepMerge({}, theme, overrides);
 }

--- a/src/themes/light-theme/create-light-theme.ts
+++ b/src/themes/light-theme/create-light-theme.ts
@@ -56,5 +56,5 @@ export default function createLightTheme(
     },
   };
 
-  return deepMerge(theme, overrides);
+  return deepMerge({}, theme, overrides);
 }

--- a/src/themes/move-theme/dark-theme-with-move.js.flow
+++ b/src/themes/move-theme/dark-theme-with-move.js.flow
@@ -22,5 +22,5 @@ export const DarkThemeMove: ThemeT = deepMerge({}, DarkTheme, {
   // in `moveTypography`. For it we'll get the typography value built
   // with a custom font using `getTypography` helper and extend the result
   // value with the customized set of fonts that reference a secondary font
-  typography: deepMerge(getTypography(moveFontTokens), moveTypography),
+  typography: deepMerge({}, getTypography(moveFontTokens), moveTypography),
 });

--- a/src/themes/move-theme/dark-theme-with-move.ts
+++ b/src/themes/move-theme/dark-theme-with-move.ts
@@ -20,5 +20,5 @@ export const DarkThemeMove: Theme = deepMerge({}, DarkTheme, {
   // in `moveTypography`. For it we'll get the typography value built
   // with a custom font using `getTypography` helper and extend the result
   // value with the customized set of fonts that reference a secondary font
-  typography: deepMerge(getTypography(moveFontTokens), moveTypography),
+  typography: deepMerge({}, getTypography(moveFontTokens), moveTypography),
 });

--- a/src/themes/move-theme/light-theme-with-move.js.flow
+++ b/src/themes/move-theme/light-theme-with-move.js.flow
@@ -22,5 +22,5 @@ export const LightThemeMove: ThemeT = deepMerge({}, LightTheme, {
   // in `moveTypography`. For it we'll get the typography value built
   // with a custom font using `getTypography` helper and extend the result
   // value with the customized set of fonts that reference a secondary font
-  typography: deepMerge(getTypography(moveFontTokens), moveTypography),
+  typography: deepMerge({}, getTypography(moveFontTokens), moveTypography),
 });

--- a/src/themes/move-theme/light-theme-with-move.ts
+++ b/src/themes/move-theme/light-theme-with-move.ts
@@ -20,5 +20,5 @@ export const LightThemeMove: Theme = deepMerge({}, LightTheme, {
   // in `moveTypography`. For it we'll get the typography value built
   // with a custom font using `getTypography` helper and extend the result
   // value with the customized set of fonts that reference a secondary font
-  typography: deepMerge(getTypography(moveFontTokens), moveTypography),
+  typography: deepMerge({}, getTypography(moveFontTokens), moveTypography),
 });


### PR DESCRIPTION
#### Description

I found this really strange bug where certain properties defined in one theme would leak into the other (eg. any typography property). I eventually narrowed down the problem to the `createTheme` functions mutating shared state.

The fix is pretty straightforward, instead of mutating the shared state, the create functions now deep merge into an empty object. (this same pattern is already used in most other calls to `deepMerge`).

#### Scope
Patch: Bug Fix (although this is also a potentially breaking change if apps are designed to rely on this leak)