### PR TITLE
fix(ts-errors): fix TS errors that prevent build from succeeding

### DIFF
--- a/src/page-control/page-control.tsx
+++ b/src/page-control/page-control.tsx
@@ -76,7 +76,7 @@ const PageControl = ({
     return SIZE.small;
   }
 
-  // @ts-expect-error useId does not exist in React 17
+  // @ts-expect-error todo(fix once web-code is fully on React 18) TS2339: Property 'useId' does not exist on type 'typeof React'.
   const name = React.useId();
 
   return (

--- a/src/page-control/page-control.tsx
+++ b/src/page-control/page-control.tsx
@@ -76,6 +76,7 @@ const PageControl = ({
     return SIZE.small;
   }
 
+  // @ts-expect-error useId does not exist in React 17
   const name = React.useId();
 
   return (

--- a/src/phone-input/country-select-dropdown.tsx
+++ b/src/phone-input/country-select-dropdown.tsx
@@ -92,11 +92,9 @@ function CountrySelectDropdown(
   );
   return (
     <Container ref={forwardedRef} $height={maxDropdownHeight} {...containerProps}>
-      {/* @ts-expect-error todo(fix once web-code is fully on React 18) TS2786: 'AutoSizer' cannot be used as a JSX component */}
       <AutoSizer>
         {({ height, width }) => {
           return (
-            // @ts-expect-error todo(fix once web-code is fully on React 18) TS2786: 'List' cannot be used as a JSX component
             <List
               role="listbox"
               height={height}


### PR DESCRIPTION
#### Description
It looks like the CodeSandbox build is currently failing because of 3 TS errors.

2 of them are fixed in this PR, the other one I'm not sure how to fix it (I suppressed it to make the build succeed).
The third error is about `src/page-control/page-control.tsx` using `React.useId()`. `baseweb` requires React 17, however the `useId()` hook has been introduced in React 18.

Note: this only fixes CodeSandbox build. Vercel builds are still failing. I don't have access to the logs so I'm not sure why.

#### Scope
Patch: Bug Fix