### PR TITLE
[WIP] [baseui] Have Datepicker honor FormControl's caption/error

### DIFF
--- a/src/datepicker/__tests__/datepicker-form-control.scenario.tsx
+++ b/src/datepicker/__tests__/datepicker-form-control.scenario.tsx
@@ -1,0 +1,28 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+import * as React from 'react';
+
+import { Datepicker } from '..';
+import { FormControl } from '../../form-control';
+
+export function Scenario() {
+  const [value, setValue] = React.useState(new Date());
+  return (
+    <div>
+      <FormControl label="Datepicker with FormControl" caption="This is a caption">
+        <Datepicker value={value} onChange={({ date }) => setValue(date)} />
+      </FormControl>
+      <FormControl
+        label="Datepicker with FormControl with error"
+        caption="This is a caption"
+        error="This is an error"
+      >
+        <Datepicker value={value} onChange={({ date }) => setValue(date)} />
+      </FormControl>
+    </div>
+  );
+}

--- a/src/datepicker/__tests__/datepicker.stories.tsx
+++ b/src/datepicker/__tests__/datepicker.stories.tsx
@@ -23,6 +23,7 @@ import { Scenario as DatepickerRangeLockedBehavior } from './datepicker-range-lo
 import { Scenario as DatepickerRangeExcludeDates } from './datepicker-range-exclude-dates.scenario';
 import { Scenario as DatepickerDefault } from './datepicker.scenario';
 import { Scenario as DatepickerTimeScenario } from './datepicker-time.scenario';
+import { Scenario as DatepickerFormControlScenario } from './datepicker-form-control.scenario';
 import { Scenario as DatepickersColorStates } from './datepickers-color-states.scenario';
 import { Scenario as DatepickersComposedRange } from './datepickers-composed-range.scenario';
 import { Scenario as DatepickersComposedSingle } from './datepickers-composed-single.scenario';
@@ -51,6 +52,7 @@ export const RangeLockedBehavior = () => <DatepickerRangeLockedBehavior />;
 export const RangeExcludeDates = () => <DatepickerRangeExcludeDates />;
 export const Datepicker = () => <DatepickerDefault />;
 export const DatepickerTime = () => <DatepickerTimeScenario />;
+export const DatepickerFormControl = () => <DatepickerFormControlScenario />;
 export const OnChangeFlow = () => <DatepickerOnChangeFlow />;
 export const StatefulColorStates = () => <DatepickersColorStates />;
 export const StatefulComposedRange = () => <DatepickersComposedRange />;

--- a/src/datepicker/datepicker.tsx
+++ b/src/datepicker/datepicker.tsx
@@ -580,9 +580,11 @@ export default class Datepicker<T = Date> extends React.Component<
                 clipPath: 'inset(100%)',
               }}
             >
-              {getInterpolatedString(locale.datepicker.screenReaderMessageInput, {
-                formatString: formatString,
-              })}
+              {this.props.formControlCaptionText +
+                ' - ' +
+                getInterpolatedString(locale.datepicker.screenReaderMessageInput, {
+                  formatString: formatString,
+                })}
             </p>
             <p
               aria-live="assertive"

--- a/src/datepicker/types.ts
+++ b/src/datepicker/types.ts
@@ -191,7 +191,7 @@ export type CalendarProps<T = Date> = {
   /** Event handler that is called when a selection is made using the quick select menu. */
   onQuickSelectChange?: (option?: QuickSelectOption<T>) => unknown;
   /** Sets the orientation of the calendar when multiple months are displayed */
-  orientation?: (typeof ORIENTATION)[keyof typeof ORIENTATION];
+  orientation?: typeof ORIENTATION[keyof typeof ORIENTATION];
   overrides?: DatepickerOverrides;
   /** Defines if dates outside of the range of the current month are displayed. */
   peekNextMonth?: boolean;
@@ -257,6 +257,7 @@ export type DatepickerProps<T = Date> = {
   startDateLabel?: string;
   endDateLabel?: string;
   value?: T | undefined | null | Array<T | undefined | null>;
+  formControlCaptionText?: string;
 } & CalendarProps<T>;
 
 export type SharedStyleProps = {
@@ -290,7 +291,7 @@ export type SharedStyleProps = {
 };
 
 export type StateChangeType =
-  | (typeof STATE_CHANGE_TYPE)[keyof typeof STATE_CHANGE_TYPE]
+  | typeof STATE_CHANGE_TYPE[keyof typeof STATE_CHANGE_TYPE]
   | undefined
   | null;
 
@@ -340,9 +341,9 @@ export type StatefulDatepickerProps<Props, T = Date> = Omit<
   'children'
 >;
 
-export type InputRole = (typeof INPUT_ROLE)[keyof typeof INPUT_ROLE] | undefined | null;
+export type InputRole = typeof INPUT_ROLE[keyof typeof INPUT_ROLE] | undefined | null;
 
 export type RangedCalendarBehavior =
-  | (typeof RANGED_CALENDAR_BEHAVIOR)[keyof typeof RANGED_CALENDAR_BEHAVIOR]
+  | typeof RANGED_CALENDAR_BEHAVIOR[keyof typeof RANGED_CALENDAR_BEHAVIOR]
   | undefined
   | null;

--- a/src/form-control/form-control.tsx
+++ b/src/form-control/form-control.tsx
@@ -189,6 +189,7 @@ export default class FormControl extends React.Component<FormControlProps, FormC
                       : sharedProps.$positive === false
                       ? undefined
                       : sharedProps.$positive,
+                  formControlCaptionText: hint,
                 });
               })}
               {(!!caption || !!error || positive) && (


### PR DESCRIPTION
This is by having the FormControl pass down `formControlCaptionText` and having the Datepicker merge that text with it's own hidden aria-describedby

Before:

![Screenshot 2023-03-30 at 6 26 12 PM](https://user-images.githubusercontent.com/1808588/228977411-1b18ffd5-ff08-4414-a1c0-92dcb5177f1f.png)
![Screenshot 2023-03-30 at 6 26 22 PM](https://user-images.githubusercontent.com/1808588/228977439-4820c2e5-9306-4d66-bab4-36d676001089.png)

After:

![Screenshot 2023-03-30 at 6 24 25 PM](https://user-images.githubusercontent.com/1808588/228977473-2903bef1-4780-4c25-80ea-9d984995ff68.png)
![Screenshot 2023-03-30 at 6 24 39 PM](https://user-images.githubusercontent.com/1808588/228977488-11a0c2e1-feb6-4055-9ab8-d2ed61d2e219.png)

