### PR TITLE
fix(table-semantic): remove padding-right from sortable columns

### DIFF
--- a/src/table-semantic/styled-components.js.flow
+++ b/src/table-semantic/styled-components.js.flow
@@ -81,7 +81,7 @@ type StyledTableHeadCellPropsT = {
 
 export const StyledTableHeadCell = styled<StyledTableHeadCellPropsT>(
   'th',
-  ({ $theme, $size, $divider, $isNumeric }) => {
+  ({ $theme, $size, $divider }) => {
     const borderDir: string = $theme.direction === 'rtl' ? 'Left' : 'Right';
     const borderVertical = $divider === DIVIDER.grid || $divider === DIVIDER.vertical;
     const padding = sizeToCellPadding($theme, $size);
@@ -96,7 +96,7 @@ export const StyledTableHeadCell = styled<StyledTableHeadCellPropsT>(
       paddingLeft: padding,
       backgroundColor: $theme.colors.tableHeadBackgroundColor,
       color: $theme.colors.contentPrimary,
-      textAlign: $theme.direction === 'rtl' || $isNumeric ? 'right' : 'left',
+      textAlign: $theme.direction === 'rtl' ? 'right' : 'left',
       verticalAlign: 'top',
       whiteSpace: 'nowrap',
       zIndex: 1,
@@ -128,7 +128,6 @@ export const StyledTableHeadCellSortable = withStyle<
 >(StyledTableHeadCell, ({ $theme, $isFocusVisible }) => {
   return {
     cursor: 'pointer',
-    paddingRight: $theme.sizing.scale1000,
     outline: 'none',
     ':focus': {
       outline: $isFocusVisible ? `3px solid ${$theme.colors.accent}` : 'none',
@@ -148,6 +147,7 @@ export const StyledSortIconContainer = styled<{}>('span', ({ $theme }) => {
     top: '50%',
     right: $theme.sizing.scale500,
     transform: 'translateY(-50%)',
+    backgroundColor: 'inherit',
   };
 });
 
@@ -221,7 +221,7 @@ export const StyledTableBodyCell = styled<StyledTableBodyCellPropsT>(
     return {
       ...$theme.typography.font200,
       paddingTop: padding,
-      paddingRight: !$isSortable ? padding : $theme.sizing.scale1000,
+      paddingRight: padding,
       paddingBottom: padding,
       paddingLeft: padding,
       color: $theme.colors.contentPrimary,

--- a/src/table-semantic/styled-components.ts
+++ b/src/table-semantic/styled-components.ts
@@ -93,7 +93,7 @@ type StyledTableHeadCellProps = {
 
 export const StyledTableHeadCell = styled<'th', StyledTableHeadCellProps>(
   'th',
-  ({ $theme, $size, $divider, $isNumeric }) => {
+  ({ $theme, $size, $divider }) => {
     const borderDir: string = $theme.direction === 'rtl' ? 'Left' : 'Right';
     const borderVertical = $divider === DIVIDER.grid || $divider === DIVIDER.vertical;
     const padding = sizeToCellPadding($theme, $size);
@@ -108,7 +108,7 @@ export const StyledTableHeadCell = styled<'th', StyledTableHeadCellProps>(
       paddingLeft: padding,
       backgroundColor: $theme.colors.tableHeadBackgroundColor,
       color: $theme.colors.contentPrimary,
-      textAlign: $theme.direction === 'rtl' || $isNumeric ? 'right' : 'left',
+      textAlign: $theme.direction === 'rtl' ? 'right' : 'left',
       whiteSpace: 'nowrap',
       zIndex: 1,
 
@@ -140,7 +140,6 @@ export const StyledTableHeadCellSortable = withStyle<
 >(StyledTableHeadCell, ({ $theme, $isFocusVisible }) => {
   return {
     cursor: 'pointer',
-    paddingRight: $theme.sizing.scale1000,
     outline: 'none',
     ':focus': {
       outline: $isFocusVisible ? `3px solid ${$theme.colors.accent}` : 'none',
@@ -162,6 +161,7 @@ export const StyledSortIconContainer = styled('span', ({ $theme }) => {
     top: '50%',
     right: $theme.sizing.scale500,
     transform: 'translateY(-50%)',
+    backgroundColor: 'inherit',
   };
 });
 
@@ -249,7 +249,7 @@ export const StyledTableBodyCell = styled<'td', StyledTableBodyCellProps>(
     return {
       ...$theme.typography.font200,
       paddingTop: padding,
-      paddingRight: !$isSortable ? padding : $theme.sizing.scale1000,
+      paddingRight: padding,
       paddingBottom: padding,
       paddingLeft: padding,
       color: $theme.colors.contentPrimary,


### PR DESCRIPTION
- Remove padding-right from sortable columns to match documentation: https://base.uber.com/6d2425e9f/p/901301-data-table/t/4633ea
- Avoid right-aligning text for numeric columns to match documentation.
- Add `background: inherit` to sort icon so it appears in front of text to match documentation.

This should help us with data-dense tables, where we have many columns that need to fit on a page.
