### PR TITLE
Update sortable.tsx

### DIFF
--- a/documentation-site/examples/table-semantic/sortable.tsx
+++ b/documentation-site/examples/table-semantic/sortable.tsx
@@ -32,7 +32,7 @@ export default function Example() {
   ]);
 
   const sortedData = useMemo(() => {
-    return data.slice().sort((a: any, b: any) => {
+    return data.slice().sort((a: Row, b: Row) => {
       const left = sortAsc ? a : b;
       const right = sortAsc ? b : a;
       const leftValue = String(left[sortColumn]);


### PR DESCRIPTION
make types more specific on semantic-table sorting example

#### Description

* `any` types were inaccurate
* They made the docs less clear because it wasn't as obvious that "a" and "b" were **rows**

#### Scope

Patch: Bug Fix
