### PR TITLE
Update react docs link to new documentation space

### DIFF
--- a/documentation-site/components/yard/knob.tsx
+++ b/documentation-site/components/yard/knob.tsx
@@ -90,7 +90,7 @@ const Knob: React.SFC<{
         <Spacing>
           <Label tooltip={getTooltip(description, type, name)}>{name}</Label>
           <StyledLink
-            href="https://reactjs.org/docs/refs-and-the-dom.html"
+            href="https://react.dev/learn/referencing-values-with-refs#refs-and-the-dom"
             target="_blank"
             $style={{
               fontSize: '14px',


### PR DESCRIPTION
Update react docs link to the new documentation space as the old one is being deprecated now.

#### Description

Update react docs link to the new documentation space as the old one is being deprecated now.


#### Scope
Patch: Bug Fix
