### PR TITLE
Updating import paths to avoid multi level nesting of paths

### DIFF
--- a/documentation-site/examples/icon/list.tsx
+++ b/documentation-site/examples/icon/list.tsx
@@ -3,12 +3,7 @@ import {useStyletron} from 'baseui';
 import * as Icons from 'baseui/icon/icon-exports';
 
 function makeImportStatement(key: string) {
-  const path = key
-    .split(/(?=[A-Z])/)
-    .map((word) => word.toLowerCase())
-    .join('-');
-
-  return `import ${key} from 'baseui/icon/${path}'`;
+  return `import { ${key} } from 'baseui/icon'`;
 }
 
 function Row(props: any) {


### PR DESCRIPTION
`Fixes #1` <!-- remove the (`) quotes to link the issues -->
Updated import path in base web docs to support the linter rule warning for not allowing multi level nesting of paths.

#### Description
Updated import path in base web docs to support the linter rule warning for not allowing multi level nesting of paths. This way by default users would be able use the correct way of using icons through baseweb.
<!-- Describe your changes below in as much detail as possible -->

#### Scope
<!-- Pick one:
Patch: Bug Fix
Minor: New Feature
Major: Breaking change
-->
