### PR TITLE
fix: setting leading and trailing content with color from theme

### DIFF
--- a/documentation-site/components/yard/config/tile.ts
+++ b/documentation-site/components/yard/config/tile.ts
@@ -48,7 +48,7 @@ const TileConfig: TConfig = {
     },
     leadingContent: {
       type: PropTypes.ReactNode,
-      value: '() => <Search size={36} color="white" />',
+      value: '() => <Search size={36} />',
       description: 'Determines the leading content to render in the tile',
       imports: {
         'baseui/icon/search': { named: ['Search'] },
@@ -56,7 +56,7 @@ const TileConfig: TConfig = {
     },
     trailingContent: {
       type: PropTypes.ReactNode,
-      value: '() => <ChevronRight size={36} color="white" />',
+      value: '() => <ChevronRight size={36} />',
       description: 'Determines the trailing content to render in the tile',
       imports: {
         'baseui/icon/chevron-right': { named: ['ChevronRight'] },

--- a/documentation-site/examples/tile/action.tsx
+++ b/documentation-site/examples/tile/action.tsx
@@ -6,7 +6,7 @@ export default function Example() {
   return (
     <Tile
       tileKind={TILE_KIND.action}
-      leadingContent={() => <Calendar size={36} color="white" />}
+      leadingContent={() => <Calendar size={36} />}
       label="Book now"
       color
       onClick={() => alert('booking appointment')}

--- a/documentation-site/examples/tile/alignment.tsx
+++ b/documentation-site/examples/tile/alignment.tsx
@@ -6,7 +6,7 @@ export default function Example() {
   return (
     <Tile
       tileKind={TILE_KIND.action}
-      leadingContent={() => <Upload color="white" size={48} />}
+      leadingContent={() => <Upload size={48} />}
       label="Mixed"
       headerAlignment={ALIGNMENT.center}
       bodyAlignment={ALIGNMENT.right}

--- a/src/datepicker/calendar.tsx
+++ b/src/datepicker/calendar.tsx
@@ -706,8 +706,9 @@ export default class Calendar<T = Date> extends React.Component<
           <Root
             $density={this.props.density}
             data-baseweb="calendar"
-            role="application"
+            role="dialog"
             aria-roledescription="date picker"
+            id={this.props.id}
             // @ts-ignore
             ref={(root) => {
               if (root && root instanceof HTMLElement && !this.state.rootElement) {

--- a/src/datepicker/styled-components.ts
+++ b/src/datepicker/styled-components.ts
@@ -675,3 +675,22 @@ export const StyledWeekdayHeader = styled<'div', SharedStyleProps>('div', (props
   };
 });
 StyledWeekdayHeader.displayName = 'StyledWeekdayHeader';
+
+export const StyledInputContainer = styled<
+  'div',
+  {
+    $separateRangeInputs: boolean;
+  } & SharedStyleProps
+>('div', (props) => {
+  const { $theme, $separateRangeInputs } = props;
+
+  return {
+    width: '100%',
+    ...($separateRangeInputs ? { display: 'flex', justifyContent: 'center' } : {}),
+    backgroundColor: $theme.colors.backgroundPrimary,
+    outline: 'none',
+    paddingInlineStart: 'unset',
+  };
+});
+
+StyledInputContainer.displayName = 'StyledInputContainer';

--- a/src/datepicker/types.ts
+++ b/src/datepicker/types.ts
@@ -68,7 +68,7 @@ export type DatepickerOverrides = {
   PrimaryButton?: Override;
   SecondaryButton?: Override;
   CalendarSelect?: Override;
-  Combobox?: Override;
+  InputContainer?: Override;
 };
 
 export type DayProps<T = Date> = {
@@ -221,6 +221,8 @@ export type CalendarProps<T = Date> = {
     label: React.ReactNode;
     onClick: () => unknown;
   };
+  // id for the calendar container
+  id?: string;
 };
 
 export type HeaderProps<T = Date> = CalendarProps<T> & {

--- a/src/list/styled-components.ts
+++ b/src/list/styled-components.ts
@@ -196,7 +196,7 @@ export const StyledHeadingMainHeading = styled<'p', StyledHeadingHeadingProps>(
   'p',
   ({ $maxLines = 1, $theme }) => {
     return {
-      ...$theme.typography.HeadingSmall,
+      ...$theme.typography.HeadingXSmall,
       color: $theme.colors.contentPrimary,
       marginTop: 0,
       marginBottom: 0,
@@ -215,8 +215,8 @@ export const StyledHeadingSubHeading = styled<'p', StyledHeadingHeadingProps>(
   'p',
   ({ $maxLines = 1, $theme }) => {
     return {
-      ...$theme.typography.ParagraphLarge,
-      color: $theme.colors.contentPrimary,
+      ...$theme.typography.ParagraphMedium,
+      color: $theme.colors.contentSecondary,
       marginTop: 0,
       marginBottom: 0,
       marginRight: $theme.sizing.scale600,
@@ -247,7 +247,8 @@ export const StyledHeadingEndEnhancerContainer = styled<
 StyledHeadingEndEnhancerContainer.displayName = 'StyledHeadingEndEnhancerContainer';
 
 export const StyledHeadingEndEnhancerDescriptionContainer = styled('p', ({ $theme }) => ({
-  ...$theme.typography.ParagraphMedium,
+  ...$theme.typography.ParagraphSmall,
+  color: $theme.colors.contentSecondary,
   marginTop: 0,
   marginBottom: 0,
   display: 'flex',

--- a/src/mobile-header/styled-components.ts
+++ b/src/mobile-header/styled-components.ts
@@ -48,12 +48,13 @@ export const StyledTitle = styled<'div', { $expanded: boolean }>(
   ({ $theme, $expanded = false }) => ({
     alignSelf: 'center',
     justifyContent: 'flex-start',
-    ...($expanded ? $theme.typography.DisplayXSmall : $theme.typography.LabelLarge),
+    ...($expanded ? $theme.typography.HeadingLarge : $theme.typography.LabelLarge),
     ...($expanded
       ? {
           gridColumn: '1 / 4',
           gridRow: 2,
           paddingLeft: $theme.sizing.scale600,
+          paddingBottom: $theme.sizing.scale100,
         }
       : {}),
     // truncate long titles

--- a/src/progress-steps/constants.ts
+++ b/src/progress-steps/constants.ts
@@ -1,0 +1,10 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+export const ORIENTATION = {
+  horizontal: 'horizontal',
+  vertical: 'vertical',
+} as const;

--- a/src/progress-steps/index.ts
+++ b/src/progress-steps/index.ts
@@ -9,4 +9,5 @@ export { default as ProgressSteps } from './progress-steps';
 export { default as Step } from './step';
 export { default as NumberedStep } from './numbered-step';
 export * from './styled-components';
+export * from './constants';
 export * from './types';

--- a/src/progress-steps/numbered-step.tsx
+++ b/src/progress-steps/numbered-step.tsx
@@ -18,12 +18,14 @@ import {
 import Check from '../icon/check';
 
 import type { NumberedStepProps } from './types';
+import { ORIENTATION } from './constants';
 
 function NumberedStep({
   overrides = {},
   isCompleted,
   isActive,
   isLast,
+  orientation = ORIENTATION.vertical,
   title,
   step,
   alwaysShowDescription,
@@ -43,28 +45,37 @@ function NumberedStep({
   const sharedProps = {
     $isCompleted: isCompleted,
     $isActive: isActive,
+    $orientation: orientation,
   };
 
   return (
-    <Root {...sharedProps} {...rootProps}>
-      <Icon {...sharedProps} {...iconProps}>
-        {!isCompleted && <span>{step}</span>}
+    <>
+      <Root {...sharedProps} {...rootProps}>
+        <Icon {...sharedProps} {...iconProps}>
+          {!isCompleted && <span>{step}</span>}
 
-        {isCompleted && <CheckIcon size={28} {...checkIconProps} />}
-      </Icon>
+          {isCompleted && <CheckIcon size={28} {...checkIconProps} />}
+        </Icon>
 
-      {!isLast && <Tail {...sharedProps} {...tailProps} />}
+        {!isLast && orientation === ORIENTATION.vertical && (
+          <Tail {...sharedProps} {...tailProps} />
+        )}
 
-      <Content {...sharedProps} {...contentProps}>
-        <Title {...sharedProps} {...titleProps}>
-          {title}
-        </Title>
+        <Content {...sharedProps} {...contentProps}>
+          <Title {...sharedProps} {...titleProps}>
+            {title}
+          </Title>
 
-        <Description {...descriptionProps}>
-          {(isActive || alwaysShowDescription) && children}
-        </Description>
-      </Content>
-    </Root>
+          <Description {...descriptionProps}>
+            {(isActive || alwaysShowDescription) && children}
+          </Description>
+        </Content>
+      </Root>
+
+      {!isLast && orientation === ORIENTATION.horizontal && (
+        <Tail {...sharedProps} {...tailProps} aria-hidden="true" />
+      )}
+    </>
   );
 }
 

--- a/src/progress-steps/progress-steps.tsx
+++ b/src/progress-steps/progress-steps.tsx
@@ -9,11 +9,13 @@ import * as React from 'react';
 import { getOverrides } from '../helpers/overrides';
 import { StyledProgressSteps } from './styled-components';
 import type { ProgressStepsProps, StepProps } from './types';
+import { ORIENTATION } from './constants';
 
 function ProgressSteps({
   overrides = {},
   current,
   alwaysShowDescription = false,
+  orientation = ORIENTATION.vertical,
   children,
 }: ProgressStepsProps) {
   const [Root, rootProps] = getOverrides(overrides.Root, StyledProgressSteps);
@@ -36,6 +38,7 @@ function ProgressSteps({
           ? alwaysShowDescription
           : child.props.alwaysShowDescription,
       step: index + 1,
+      orientation,
       overrides: {
         ...overrides,
         Root: overrides.StepRoot,
@@ -45,7 +48,7 @@ function ProgressSteps({
   });
 
   return (
-    <Root data-baseweb="progress-steps" {...rootProps}>
+    <Root data-baseweb="progress-steps" $orientation={orientation} {...rootProps}>
       {modifiedChildren}
     </Root>
   );

--- a/src/progress-steps/step.tsx
+++ b/src/progress-steps/step.tsx
@@ -19,12 +19,14 @@ import {
 } from './styled-components';
 
 import type { StepProps } from './types';
+import { ORIENTATION } from './constants';
 
 function Step({
   overrides = {},
   isCompleted,
   isActive,
   isLast,
+  orientation = ORIENTATION.vertical,
   title,
   alwaysShowDescription,
   children,
@@ -47,28 +49,37 @@ function Step({
   const sharedProps = {
     $isCompleted: isCompleted,
     $isActive: isActive,
+    $orientation: orientation,
   };
 
   return (
-    <Root {...sharedProps} {...rootProps}>
-      <IconContainer {...sharedProps} {...iconContainerProps}>
-        <Icon {...sharedProps} {...iconProps}>
-          {isActive && <InnerIcon {...innerIconProps} />}
-        </Icon>
-      </IconContainer>
+    <>
+      <Root {...sharedProps} {...rootProps}>
+        <IconContainer {...sharedProps} {...iconContainerProps}>
+          <Icon {...sharedProps} {...iconProps}>
+            {isActive && <InnerIcon {...innerIconProps} />}
+          </Icon>
+        </IconContainer>
 
-      {!isLast && <Tail {...sharedProps} {...tailProps} />}
+        {!isLast && orientation === ORIENTATION.vertical && (
+          <Tail {...sharedProps} {...tailProps} />
+        )}
 
-      <Content {...sharedProps} {...contentProps}>
-        <Title {...sharedProps} {...titleProps}>
-          {title}
-        </Title>
+        <Content {...sharedProps} {...contentProps}>
+          <Title {...sharedProps} {...titleProps}>
+            {title}
+          </Title>
 
-        <Description {...descriptionProps}>
-          {(isActive || alwaysShowDescription) && children}
-        </Description>
-      </Content>
-    </Root>
+          <Description {...descriptionProps}>
+            {(isActive || alwaysShowDescription) && children}
+          </Description>
+        </Content>
+      </Root>
+
+      {!isLast && orientation === ORIENTATION.horizontal && (
+        <Tail {...sharedProps} {...tailProps} aria-hidden="true" />
+      )}
+    </>
   );
 }
 

--- a/src/progress-steps/styled-components.ts
+++ b/src/progress-steps/styled-components.ts
@@ -6,11 +6,20 @@ LICENSE file in the root directory of this source tree.
 */
 
 import { styled } from '../styles';
+import { ORIENTATION } from './constants';
 import type { StyleProps } from './types';
 
-export const StyledProgressSteps = styled('ol', ({ $theme }) => {
-  return {
+export const StyledProgressSteps = styled<'ol', StyleProps>('ol', ({ $theme, $orientation }) => {
+  const horizontalStyles = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    width: '100%',
+  };
+  const verticalStyles = {
     display: 'inline-block',
+  };
+  return {
+    ...($orientation === ORIENTATION.horizontal ? horizontalStyles : verticalStyles),
     marginBottom: 0,
     marginTop: 0,
     paddingTop: $theme.sizing.scale300,
@@ -23,11 +32,18 @@ export const StyledProgressSteps = styled('ol', ({ $theme }) => {
 StyledProgressSteps.displayName = 'StyledProgressSteps';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const StyledStep = styled<'li', StyleProps>('li', ({ $theme }) => {
+export const StyledStep = styled<'li', StyleProps>('li', ({ $orientation }) => {
+  const horizontalStyles = {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+  } as const;
+
   return {
     listStyleType: 'none',
     position: 'relative',
     overflow: 'visible',
+    ...($orientation === ORIENTATION.horizontal ? horizontalStyles : {}),
   };
 });
 
@@ -35,34 +51,41 @@ StyledStep.displayName = 'StyledStep';
 
 export const StyledIconContainer = styled<'div', StyleProps>(
   'div',
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  ({ $theme, $isActive, $isCompleted, $disabled }) => {
-    let currentColor = $theme.colors.backgroundPrimary;
-    let size = $theme.sizing.scale500;
-    let marginLeft = '26px';
-    let marginRight = '26px';
-    let font = $theme.typography.LabelMedium;
-    let titlePad = $theme.sizing.scale800;
+  ({ $theme, $isActive, $orientation }) => {
+    const size = $isActive ? $theme.sizing.scale700 : $theme.sizing.scale500;
+    const font = $theme.typography.LabelMedium;
 
-    if ($isActive) {
-      size = $theme.sizing.scale700;
-      marginLeft = $theme.sizing.scale750;
-      marginRight = $theme.sizing.scale750;
-    }
+    const getOrientationStyles = (orientation) => {
+      if (orientation === ORIENTATION.horizontal) {
+        return {
+          marginLeft: '50px',
+          height: '20px',
+          width: '20px',
+        };
+      }
 
-    const marginTop = `calc(${titlePad} + (${font.lineHeight} - ${size}) / 2)`;
-    if ($theme.direction === 'rtl') {
-      [marginLeft, marginRight] = [marginRight, marginLeft];
-    }
+      let marginLeft = $isActive ? $theme.sizing.scale750 : '26px';
+      let marginRight = $isActive ? $theme.sizing.scale750 : '26px';
+      const titlePad = $theme.sizing.scale800;
+      const marginTop = `calc(${titlePad} + (${font.lineHeight} - ${size}) / 2)`;
+      if ($theme.direction === 'rtl') {
+        [marginLeft, marginRight] = [marginRight, marginLeft];
+      }
+      return {
+        float: $theme.direction === 'rtl' ? 'right' : 'left',
+        marginRight,
+        marginLeft,
+        marginTop,
+
+        width: size,
+        height: size,
+        lineHeight: size,
+      };
+    };
 
     return {
-      marginRight,
-      marginLeft,
-      marginTop,
-      width: size,
-      height: size,
-      lineHeight: size,
-      backgroundColor: currentColor,
+      ...getOrientationStyles($orientation),
+      backgroundColor: $theme.colors.backgroundPrimary,
       float: $theme.direction === 'rtl' ? 'right' : 'left',
       textAlign: 'center',
       display: 'flex',
@@ -76,7 +99,7 @@ StyledIconContainer.displayName = 'StyledIconContainer';
 
 export const StyledIcon = styled<'div', StyleProps>(
   'div',
-  ({ $theme, $isActive, $isCompleted }) => {
+  ({ $theme, $isActive, $isCompleted, $orientation }) => {
     let currentColor = $theme.colors.contentTertiary;
     let size = $theme.sizing.scale300;
 
@@ -90,6 +113,10 @@ export const StyledIcon = styled<'div', StyleProps>(
       size = $theme.sizing.scale600;
     }
 
+    const verticalStyles = {
+      float: $theme.direction === 'rtl' ? 'right' : 'left',
+    } as const;
+
     return {
       width: size,
       height: size,
@@ -99,11 +126,11 @@ export const StyledIcon = styled<'div', StyleProps>(
       borderBottomRightRadius: size,
       borderBottomLeftRadius: size,
       backgroundColor: currentColor,
-      float: $theme.direction === 'rtl' ? 'right' : 'left',
       textAlign: 'center',
       display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',
+      ...($orientation === ORIENTATION.horizontal ? {} : verticalStyles),
     };
   }
 );
@@ -126,18 +153,28 @@ export const StyledInnerIcon = styled<'div', StyleProps>('div', ({ $theme }) => 
 
 StyledInnerIcon.displayName = 'StyledInnerIcon';
 
-export const StyledContent = styled<'div', StyleProps>('div', ({ $theme }) => {
+export const StyledContent = styled<'div', StyleProps>('div', ({ $theme, $orientation }) => {
+  if ($orientation === ORIENTATION.horizontal) {
+    return {
+      marginTop: '8px',
+      width: '120px',
+      flex: 'display',
+      flexDirection: 'column',
+      justifyContent: 'start',
+    } as const;
+  }
+
   const marginDir: string = $theme.direction === 'rtl' ? 'marginRight' : 'marginLeft';
   return {
     [marginDir]: $theme.sizing.scale1600,
-  };
+  } as const;
 });
 
 StyledContent.displayName = 'StyledContent';
 
 export const StyledContentTitle = styled<'div', StyleProps>(
   'div',
-  ({ $theme, $isActive, $isCompleted }) => {
+  ({ $theme, $isActive, $isCompleted, $orientation }) => {
     let color = $theme.colors.contentTertiary;
     if ($isCompleted) {
       color = $theme.colors.contentPrimary;
@@ -146,11 +183,18 @@ export const StyledContentTitle = styled<'div', StyleProps>(
     }
     let font = $theme.typography.LabelMedium;
 
+    const horizontalStyles = {
+      textAlign: 'center' as const,
+    };
+    const verticalStyles = {
+      paddingTop: $theme.sizing.scale800,
+      paddingBottom: $theme.sizing.scale800,
+    };
+
     return {
       ...font,
       color,
-      paddingTop: $theme.sizing.scale800,
-      paddingBottom: $theme.sizing.scale800,
+      ...($orientation === ORIENTATION.horizontal ? horizontalStyles : verticalStyles),
     };
   }
 );
@@ -159,32 +203,42 @@ StyledContentTitle.displayName = 'StyledContentTitle';
 
 export const StyledContentTail = styled<'div', StyleProps>(
   'div',
-  ({ $theme, $isCompleted, $isActive }) => {
-    let currentColor = $theme.colors.borderOpaque;
-    let size = $theme.sizing.scale500;
-    let font = $theme.typography.LabelMedium;
-    let titlePad = $theme.sizing.scale800;
+  ({ $theme, $isCompleted, $isActive, $orientation }) => {
+    const getOrientationStyles = (orientation) => {
+      const dir: string = $theme.direction === 'rtl' ? 'right' : 'left';
 
-    if ($isActive) {
-      size = $theme.sizing.scale700;
-    }
+      // horizontal styles
+      if (orientation === ORIENTATION.horizontal) {
+        return {
+          position: 'relative',
+          top: '9px',
+          marginLeft: '-48px',
+          marginRight: '-48px',
+          height: $theme.sizing.scale0,
+          width: '100%',
+        } as const;
+      }
 
-    if ($isCompleted) {
-      currentColor = $theme.colors.borderSelected;
-    }
+      // vertical styles
+      let size = $isActive ? $theme.sizing.scale700 : $theme.sizing.scale500;
+      let font = $theme.typography.LabelMedium;
+      let titlePad = $theme.sizing.scale800;
 
-    const dir: string = $theme.direction === 'rtl' ? 'right' : 'left';
+      return {
+        position: 'absolute',
+        marginTop: `calc(${titlePad} + (${font.lineHeight} + ${size}) / 2)`,
+        [dir]: '31px',
+        top: 0,
+        height: `calc(100% + ${$theme.sizing.scale500})`,
+        marginBottom: 0,
+        width: $theme.sizing.scale0,
+        display: 'inline-block',
+      } as const;
+    };
 
     return {
-      position: 'absolute',
-      [dir]: '31px',
-      top: 0,
-      height: `calc(100% + ${$theme.sizing.scale500})`,
-      marginBottom: 0,
-      width: $theme.sizing.scale0,
-      marginTop: `calc(${titlePad} + (${font.lineHeight} + ${size}) / 2)`,
-      display: 'inline-block',
-      backgroundColor: currentColor,
+      ...getOrientationStyles($orientation),
+      backgroundColor: $isCompleted ? $theme.colors.borderSelected : $theme.colors.borderOpaque,
     };
   }
 );
@@ -199,11 +253,18 @@ export const StyledContentDescription = styled<'div', StyleProps>('div', ({ $the
 
 StyledContentDescription.displayName = 'StyledContentDescription';
 
-export const StyledNumberStep = styled<'li', StyleProps>('li', () => {
+export const StyledNumberStep = styled<'li', StyleProps>('li', ({ $orientation }) => {
+  const horizontalStyles = {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+  } as const;
+
   return {
     listStyleType: 'none',
     position: 'relative',
     overflow: 'visible',
+    ...($orientation === ORIENTATION.horizontal ? horizontalStyles : {}),
   };
 });
 
@@ -211,15 +272,11 @@ StyledNumberStep.displayName = 'StyledNumberStep';
 
 export const StyledNumberIcon = styled<'div', StyleProps>(
   'div',
-  ({ $theme, $isActive, $isCompleted }) => {
+  ({ $theme, $isActive, $isCompleted, $orientation }) => {
     let backgroundColor = $theme.colors.backgroundTertiary;
     let color = $theme.colors.contentPrimary;
-    let size = $theme.sizing.scale950;
-    let font = $theme.typography.ParagraphMedium;
-    let marginLeft = $theme.sizing.scale550;
-    let marginRight = $theme.sizing.scale550;
-    let titlePad = $theme.sizing.scale800;
-    let titleFont = $theme.typography.LabelMedium;
+    const size = $theme.sizing.scale950;
+    const font = $theme.typography.ParagraphMedium;
 
     if ($isCompleted) {
       color = $theme.colors.progressStepsCompletedText;
@@ -229,12 +286,25 @@ export const StyledNumberIcon = styled<'div', StyleProps>(
       backgroundColor = $theme.colors.progressStepsActiveFill;
     }
 
-    const marginTop = `calc(${titlePad} + (${titleFont.lineHeight} - ${size}) / 2)`;
+    const getOrientationStyles = (orientation) => {
+      if (orientation === ORIENTATION.horizontal) {
+        return {
+          marginLeft: '42px',
+        };
+      } else {
+        let titlePad = $theme.sizing.scale800;
+        let titleFont = $theme.typography.LabelMedium;
+
+        return {
+          marginLeft: $theme.sizing.scale550,
+          marginRight: $theme.sizing.scale550,
+          marginTop: `calc(${titlePad} + (${titleFont.lineHeight} - ${size}) / 2)`,
+        };
+      }
+    };
 
     return {
-      marginLeft,
-      marginRight,
-      marginTop,
+      ...getOrientationStyles($orientation),
       width: size,
       height: size,
       borderTopLeftRadius: size,
@@ -257,28 +327,47 @@ StyledNumberIcon.displayName = 'StyledNumberIcon';
 
 export const StyledNumberContentTail = styled<'div', StyleProps>(
   'div',
-  ({ $theme, $isCompleted }) => {
-    let currentColor = $theme.colors.backgroundTertiary;
-    let size = $theme.sizing.scale950;
-    let titleFont = $theme.typography.LabelMedium;
-    let titlePad = $theme.sizing.scale800;
+  ({ $theme, $isCompleted, $orientation }) => {
+    const getOrientationStyles = (orientation) => {
+      const dir: string = $theme.direction === 'rtl' ? 'right' : 'left';
 
-    if ($isCompleted) {
-      currentColor = $theme.colors.contentPrimary;
-    }
-    const marginTop = `calc(${titlePad} + ${size} + (${titleFont.lineHeight} - ${size}) / 2)`;
-    const dir: string = $theme.direction === 'rtl' ? 'right' : 'left';
+      // horizontal styles
+      if (orientation === ORIENTATION.horizontal) {
+        return {
+          position: 'relative',
+          top: '17px',
+          marginLeft: '-42px',
+          marginRight: '-42px',
+          height: $theme.sizing.scale0,
+          width: '100%',
+        } as const;
+      }
+
+      // vertical styles
+      const size = $theme.sizing.scale950;
+      const titleFont = $theme.typography.LabelMedium;
+      const titlePad = $theme.sizing.scale800;
+      const marginTop = `calc(${titlePad} + ${size} + (${titleFont.lineHeight} - ${size}) / 2)`;
+
+      return {
+        position: 'absolute',
+        [dir]: '31px',
+        top: 0,
+        height: `calc(100% - ${$theme.sizing.scale500})`,
+        paddingBottom: 0,
+        marginTop,
+        width: $theme.sizing.scale0,
+        display: 'inline-block',
+      } as const;
+    };
+
     return {
-      position: 'absolute',
-      [dir]: '31px',
-      top: 0,
-      height: `calc(100% - ${$theme.sizing.scale500})`,
-      paddingBottom: 0,
-      marginTop,
-      width: $theme.sizing.scale0,
-      backgroundColor: currentColor,
-      display: 'inline-block',
+      ...getOrientationStyles($orientation),
+      backgroundColor: $isCompleted
+        ? $theme.colors.contentPrimary
+        : $theme.colors.backgroundTertiary,
     };
   }
 );
+
 StyledNumberContentTail.displayName = 'StyledNumberContentTail';

--- a/src/progress-steps/types.ts
+++ b/src/progress-steps/types.ts
@@ -7,6 +7,9 @@ LICENSE file in the root directory of this source tree.
 
 import type { ReactNode } from 'react';
 import type { Override } from '../helpers/overrides';
+import type { ORIENTATION } from './constants';
+
+export type Orientation = keyof typeof ORIENTATION;
 
 export type ProgressStepsOverrides = {
   Root?: Override;
@@ -27,6 +30,7 @@ export type ProgressStepsProps = {
   current?: number;
   /** when true, the description of a step will continue to be displayed even after the step is completed. */
   alwaysShowDescription?: boolean;
+  orientation?: Orientation;
 };
 
 export type StepOverrides = {
@@ -53,6 +57,7 @@ export type StepProps = {
   alwaysShowDescription?: boolean;
   overrides?: StepOverrides;
   children?: ReactNode;
+  orientation?: Orientation;
 };
 
 export type NumberedStepOverrides = {
@@ -81,10 +86,12 @@ export type NumberedStepProps = {
   children?: ReactNode;
   /** The number displayed as the step number */
   step?: ReactNode;
+  orientation?: Orientation;
 };
 
 export type StyleProps = {
   $isActive?: boolean;
   $isCompleted?: boolean;
   $disabled?: boolean;
+  $orientation?: Orientation;
 };

--- a/src/tile/__tests__/tile.test.tsx
+++ b/src/tile/__tests__/tile.test.tsx
@@ -6,12 +6,12 @@ LICENSE file in the root directory of this source tree.
 */
 
 import * as React from 'react';
-import { render, fireEvent, getByText } from '@testing-library/react';
+import { render, fireEvent, getByText, screen } from '@testing-library/react';
 import { ArrowRight } from '../../icon';
-
 import { Tile, TILE_KIND, StyledParagraph } from '..';
+import '@testing-library/jest-dom/extend-expect';
 
-describe('Tile Ciomponent', () => {
+describe('Tile Component', () => {
   it('basic render', () => {
     const { container } = render(
       <Tile tileKind={TILE_KIND.action} label="Label">
@@ -19,8 +19,8 @@ describe('Tile Ciomponent', () => {
       </Tile>
     );
 
-    getByText(container, 'Label');
-    getByText(container, 'Paragraph');
+    expect(getByText(container, 'Label')).toBeInTheDocument();
+    expect(getByText(container, 'Paragraph')).toBeInTheDocument();
   });
 
   it('renders leading content', () => {
@@ -30,7 +30,7 @@ describe('Tile Ciomponent', () => {
       </Tile>
     );
 
-    getByText(container, 'Arrow Right');
+    expect(getByText(container, 'Arrow Right')).toBeInTheDocument();
   });
 
   it('renders trailing content', () => {
@@ -40,7 +40,7 @@ describe('Tile Ciomponent', () => {
       </Tile>
     );
 
-    getByText(container, 'Arrow Right');
+    expect(getByText(container, 'Arrow Right')).toBeInTheDocument();
   });
 
   it('renders with style overrides', () => {
@@ -71,5 +71,29 @@ describe('Tile Ciomponent', () => {
     const button = container.querySelector('button');
     if (button) fireEvent.click(button);
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders children appropriately', () => {
+    const { container } = render(
+      <Tile tileKind={TILE_KIND.action} label="Label">
+        Paragraph
+      </Tile>
+    );
+
+    expect(getByText(container, 'Paragraph')).toBeInTheDocument();
+  });
+
+  it('should render a Label that is not a string', () => {
+    const LabelComponent = () => {
+      return (
+        <div>
+          <p>Not a string</p>
+        </div>
+      );
+    };
+    const { container } = render(<Tile tileKind={TILE_KIND.action} label={LabelComponent} />);
+
+    expect(getByText(container, 'Not a string')).toBeInTheDocument();
+    screen.debug();
   });
 });

--- a/src/tile/styled-components.ts
+++ b/src/tile/styled-components.ts
@@ -59,14 +59,23 @@ export const StyledHeaderContainer = styled<
   marginBottom: '16px',
 }));
 
-export const StyledLeadingContentContainer = styled('div', ({ $theme }) => ({
-  marginRight: $theme.sizing.scale300,
-  ':last-child': {
-    marginRight: '0px',
-  },
-}));
+export const StyledLeadingContentContainer = styled<'div', { $disabled: boolean }>(
+  'div',
+  ({ $theme, $disabled }) => ({
+    marginRight: $theme.sizing.scale300,
+    color: $disabled ? $theme.colors.contentStateDisabled : $theme.colors.contentPrimary,
+    ':last-child': {
+      marginRight: '0px',
+    },
+  })
+);
 
-export const StyledTrailingContentContainer = styled('div', () => ({}));
+export const StyledTrailingContentContainer = styled<'div', { $disabled: boolean }>(
+  'div',
+  ({ $theme, $disabled }) => ({
+    color: $disabled ? $theme.colors.contentStateDisabled : $theme.colors.contentPrimary,
+  })
+);
 
 export const StyledBodyContainer = styled<'div', { $alignment?: keyof typeof ALIGNMENT }>(
   'div',

--- a/src/tile/tile.tsx
+++ b/src/tile/tile.tsx
@@ -70,7 +70,8 @@ const Tile = React.forwardRef(
         </LabelContainer>
       );
     } else if (label) {
-      Label = label;
+      const LabelComponent = label;
+      Label = <LabelComponent />;
     }
 
     const renderTopContainer = shouldRenderHeaderContainer(leadingContent, trailingContent);

--- a/src/tile/tile.tsx
+++ b/src/tile/tile.tsx
@@ -94,12 +94,12 @@ const Tile = React.forwardRef(
             $alignment={headerAlignment}
           >
             {LeadingContent && (
-              <LeadingContentContainer {...leadingContentContainerProps}>
+              <LeadingContentContainer {...leadingContentContainerProps} $disabled={disabled}>
                 <LeadingContent />
               </LeadingContentContainer>
             )}
             {TrailingContent && (
-              <TrailingContentContainer {...trailingContentContainerProps}>
+              <TrailingContentContainer {...trailingContentContainerProps} $disabled={disabled}>
                 <TrailingContent />
               </TrailingContentContainer>
             )}


### PR DESCRIPTION
#### Description

- setting color for leadingContent and trailingContent in styled component using theme
- removing color declaration for Tile in documentation-site tile config and tile examples

https://github.com/uber/baseweb/assets/48413510/8519e10c-c77e-416b-a37d-d6278e09eac5

#### Scope
Patch: Bug Fix




