### PR TITLE
fix: removing color prop from leadingContent and trailingContent

### DIFF
--- a/documentation-site/components/yard/config/tile.ts
+++ b/documentation-site/components/yard/config/tile.ts
@@ -48,7 +48,7 @@ const TileConfig: TConfig = {
     },
     leadingContent: {
       type: PropTypes.ReactNode,
-      value: '() => <Search size={36} color="white" />',
+      value: '() => <Search size={36} />',
       description: 'Determines the leading content to render in the tile',
       imports: {
         'baseui/icon/search': { named: ['Search'] },
@@ -56,7 +56,7 @@ const TileConfig: TConfig = {
     },
     trailingContent: {
       type: PropTypes.ReactNode,
-      value: '() => <ChevronRight size={36} color="white" />',
+      value: '() => <ChevronRight size={36} />',
       description: 'Determines the trailing content to render in the tile',
       imports: {
         'baseui/icon/chevron-right': { named: ['ChevronRight'] },

--- a/documentation-site/examples/tile/action.tsx
+++ b/documentation-site/examples/tile/action.tsx
@@ -6,7 +6,7 @@ export default function Example() {
   return (
     <Tile
       tileKind={TILE_KIND.action}
-      leadingContent={() => <Calendar size={36} color="white" />}
+      leadingContent={() => <Calendar size={36} />}
       label="Book now"
       color
       onClick={() => alert('booking appointment')}

--- a/documentation-site/examples/tile/alignment.tsx
+++ b/documentation-site/examples/tile/alignment.tsx
@@ -6,7 +6,7 @@ export default function Example() {
   return (
     <Tile
       tileKind={TILE_KIND.action}
-      leadingContent={() => <Upload color="white" size={48} />}
+      leadingContent={() => <Upload size={48} />}
       label="Mixed"
       headerAlignment={ALIGNMENT.center}
       bodyAlignment={ALIGNMENT.right}


### PR DESCRIPTION
#### Description

- removing setting color for leadingContent and trailingContent for Tile examples

 https://github.com/uber/baseweb/assets/48413510/30e0d8e7-32c5-40f5-ac55-fde816068d34

#### Scope
Patch: Bug Fix




