### PR TITLE
passed getId nested to update nested id nodes

### DIFF
--- a/src/tree-view/utils.ts
+++ b/src/tree-view/utils.ts
@@ -177,7 +177,7 @@ export const toggleIsExpanded = (
       newNode.isExpanded = !newNode.isExpanded;
     }
     if (newNode.children && newNode.children.length) {
-      newNode.children = toggleIsExpanded(newNode.children, toggledNode);
+      newNode.children = toggleIsExpanded(newNode.children, toggledNode, getId);
     }
     return newNode;
   });


### PR DESCRIPTION
#### Description
Previously the `getId` function was not passed causing not to work in children for custom ids.

#### Scope
Patch: Bug Fix
