### PR TITLE
fix(input): always mask password input when toggle is overridden to null

### DIFF
--- a/src/input/__tests__/input-password-mask-toggle-button-override.scenario.tsx
+++ b/src/input/__tests__/input-password-mask-toggle-button-override.scenario.tsx
@@ -1,0 +1,36 @@
+/*
+Copyright (c) Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+/* global window */
+
+import React from 'react';
+import { StatefulInput } from '..';
+
+export function Scenario() {
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        // @ts-expect-error
+        window.__e2e__formSubmitted__ = true;
+        return false;
+      }}
+    >
+      <StatefulInput
+        type="password"
+        initialState={{ value: '1234' }}
+        overrides={{
+          Input: {
+            props: {
+              'data-e2e': 'input',
+            },
+          },
+          MaskToggleButton: () => null,
+        }}
+      />
+    </form>
+  );
+}

--- a/src/input/base-input.tsx
+++ b/src/input/base-input.tsx
@@ -165,11 +165,14 @@ class BaseInput<T extends HTMLInputElement | HTMLTextAreaElement> extends React.
   };
 
   getInputType() {
+    const maskToggleDisabled = this.props.overrides.MaskToggleButton === NullComponent;
+
     // If the type prop is equal to "password" we allow the user to toggle between
     // masked and non masked text. Internally, we toggle between type "password"
-    // and "text".
+    // and "text". If MaskToggleButton is not provided, this indicates an opt-out
+    // of this behavior and the input will always be of type "password".
     if (this.props.type === 'password') {
-      return this.state.isMasked ? 'password' : 'text';
+      return (this.state.isMasked || maskToggleDisabled) ? 'password' : 'text';
     } else {
       return this.props.type;
     }


### PR DESCRIPTION
#### Description

Enables the use case when input value is shown when active but masked when unfocused. Docs [mention](https://baseweb.design/components/input/#input-for-passwords) that overriding `MaskToggleButton` to `null` opts out of mask-toggling behavior but the internal `isMasked` state conflicts with the `type` prop changing from `text` to `password` (or vice-versa).

Current (requires toggle to enable this behavior):

https://github.com/uber/baseweb/assets/3171252/abf02b78-af93-48d6-8c96-bc4be152772c

With this change:

https://github.com/uber/baseweb/assets/3171252/8e07d8a9-5a4d-4f63-9c7b-8f749be584b1

Let me know if I should implement this `onFocus`/`onBlur` behavior here instead, I figured it was too specific for baseweb but could be useful elsewhere.

#### Scope

Patch: Bug Fix