### PR TITLE
File uploader beta label hint example

### DIFF
--- a/documentation-site/examples/file-uploader-beta/label-hint.tsx
+++ b/documentation-site/examples/file-uploader-beta/label-hint.tsx
@@ -6,10 +6,8 @@ export default function Example() {
   return (
     <FileUploaderBeta
       fileRows={fileRows}
-      hint={
-        "Try uploading a file to see the item preview. Image files will show a thumbnail."
-      }
-      itemPreview
+      hint={"Test hint"}
+      label={"Test label"}
       setFileRows={setFileRows}
     />
   );

--- a/documentation-site/pages/components/file-uploader-beta.mdx
+++ b/documentation-site/pages/components/file-uploader-beta.mdx
@@ -4,6 +4,7 @@ import Exports from "../../components/exports";
 
 import FileUploaderBetaBasic from "examples/file-uploader-beta/basic.tsx";
 import FileUploaderBetaItemPreview from "examples/file-uploader-beta/item-preview.tsx";
+import FileUploaderBetaLabelHint from "examples/file-uploader-beta/label-hint.tsx";
 import FileUploaderBetaUploadRestrictions from "examples/file-uploader-beta/upload-restrictions.tsx";
 
 import * as FileUploaderBetaExports from "baseui/file-uploader-beta";
@@ -48,6 +49,10 @@ To learn more, read the corresponding [OWASP article on file uploads](https://ww
 
 <Example title="Item preview" path="file-uploader-beta/item-preview.tsx">
   <FileUploaderBetaItemPreview />
+</Example>
+
+<Example title="Label and hint" path="file-uploader-beta/label-hint.tsx">
+  <FileUploaderBetaLabelHint />
 </Example>
 
 <Example


### PR DESCRIPTION
#### Description
<!-- Describe your changes below in as much detail as possible -->
- Add label hint example
- Remove `processFileOnDrop` from item preview example for brevity
<img width="650" alt="Screenshot 2024-06-28 at 10 22 12 AM" src="https://github.com/uber/baseweb/assets/33812570/72875229-675a-4600-9692-231a03e412e2">


#### Scope
<!-- Pick one:
Patch: Bug Fix
Minor: New Feature
Major: Breaking change
-->
Minor: New Feature