### PR TITLE
Add concurrency to PR check workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: pr-check-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and Type Check


### PR DESCRIPTION
Fixes #1, Fixes #2

#### Description

Adds a `concurrency` group to the PR Check workflow so that pushing multiple
commits to the same PR in quick succession cancels any still-running check
for that PR instead of letting every run finish independently. This avoids
burning CI minutes on stale runs whose results are superseded by the latest
push. No changes to the build/type-check steps themselves.

#### Scope
Patch: Bug Fix