### PR TITLE
Avoid duplicate parent.type lookup in dev-globals Babel plugin

### DIFF
--- a/publish/transform-cup-globals.js
+++ b/publish/transform-cup-globals.js
@@ -1,10 +1,8 @@
 /*
 Copyright (c) Uber Technologies, Inc.
-
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
-
 /* eslint-env node */
 
 module.exports = (babel) => {
@@ -13,10 +11,10 @@ module.exports = (babel) => {
   const buildAst = babel.template(`
   typeof document !== 'undefined'
 `);
-
   const buildAst2 = babel.template(`
   typeof document === 'undefined'
 `);
+
   const targetMap = {
     __NODE__: buildAst2({}),
     __BROWSER__: buildAst({}),
@@ -35,10 +33,8 @@ module.exports = (babel) => {
         if (name !== '__DEV__' && name !== '__NODE__' && name !== '__BROWSER__') {
           return;
         }
-        if (path.parent.type === 'MemberExpression') {
-          return;
-        }
-        if (path.parent.type === 'ClassMethod') {
+        const parentType = path.parent.type;
+        if (parentType === 'MemberExpression' || parentType === 'ClassMethod') {
           return;
         }
         if (path.isPure()) {


### PR DESCRIPTION
Fixes #1, Fixes #2

#### Description

Reads `path.parent.type` once into a local `parentType` variable in the
`Identifier` visitor, instead of accessing it twice via two separate
`path.parent.type === '...'` checks. Same nodes are skipped as before
(`MemberExpression` and `ClassMethod` parents); no behavioral change.

#### Scope
Patch: Bug Fix
